### PR TITLE
chore: don't fail the build for having less than 100 percent coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,2 @@
 [report]
-    fail_under = 100
+    fail_under = 80

--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,13 @@ clean:
 	rm -rf .coverage .mypy_cache .pytest_cache .ruff_cache *.egg-info build dist htmlcov
 
 cov:
-	$(PYTHON) -m coverage report --fail-under=80
+	$(PYTHON) -m coverage report
 
 cov-html:
-	$(PYTHON) -m coverage html --fail-under=80
+	$(PYTHON) -m coverage html
 
 cov-xml:
-	$(PYTHON) -m coverage xml --fail-under=80
+	$(PYTHON) -m coverage xml
 
 deps:
 	$(PIP) install -r requirements.txt -r requirements-dev.txt


### PR DESCRIPTION
I chose these numbers arbitrarily, happy to use other numbers, but this seems better than the default of failing the build for having less than 100% line coverage, which `main` already lacks so everything fails.