### PR TITLE
feat: pull the Connect server's version (lazily)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ build==1.0.3
 coverage==7.4.0
 mypy==1.8.0
 pytest==7.4.4
+responses>=0.25
 ruff==0.1.14
 setuptools==69.0.3
 setuptools-scm==8.0.4

--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -38,6 +38,15 @@ class Client:
         # Store the Session object.
         self.session = session
 
+        # Place to cache the server settings
+        self.server_settings = None
+
+    @property
+    def connect_version(self):
+        if self.server_settings is None:
+            self.server_settings = self.get("server_settings").json()
+        return self.server_settings["version"]
+
     def __del__(self):
         """
         Close the session when the Client instance is deleted.

--- a/src/posit/connect/client_test.py
+++ b/src/posit/connect/client_test.py
@@ -1,5 +1,8 @@
-from unittest.mock import MagicMock, patch
 import pytest
+import responses
+
+from unittest.mock import MagicMock, patch
+
 
 from .client import Client
 
@@ -67,6 +70,20 @@ class TestClient:
         with Client(api_key=api_key, url=url) as client:
             assert isinstance(client, Client)
         MockSession.return_value.close.assert_called_once()
+
+    @responses.activate
+    def test_connect_version(self):
+        api_key = "foobar"
+        url = "http://foo.bar/__api__"
+        client = Client(api_key=api_key, url=url)
+
+        # The actual server_settings response has a lot more attributes, but we
+        # don't need to include them all here because we don't use them
+        responses.get(
+            "http://foo.bar/__api__/server_settings",
+            json={"version": "2024.01.0"},
+        )
+        assert client.connect_version == "2024.01.0"
 
     def test_request(self, MockSession):
         api_key = "foobar"


### PR DESCRIPTION
Just a quick PR to add a little feature we will need, but also to demonstrate how to use `responses` to stand in for the Connect API. Very straightforward to add a feature that makes an API request and then set up a test that uses a simulated response.