### PR TITLE
fix: allow chaining paths with urls.append_path

### DIFF
--- a/src/posit/connect/config.py
+++ b/src/posit/connect/config.py
@@ -48,5 +48,5 @@ class Config:
         self, api_key: Optional[str] = None, url: Optional[str] = None
     ) -> None:
         self.api_key = api_key or _get_api_key()
-        self.url = urls.fix(url or _get_url())
+        self.url = urls.server_to_api_url(url or _get_url())
         urls.validate(self.url)

--- a/src/posit/connect/config.py
+++ b/src/posit/connect/config.py
@@ -1,5 +1,8 @@
 import os
+
 from typing import Optional
+
+from . import urls
 
 
 def _get_api_key() -> str:
@@ -45,4 +48,5 @@ class Config:
         self, api_key: Optional[str] = None, url: Optional[str] = None
     ) -> None:
         self.api_key = api_key or _get_api_key()
-        self.url = url or _get_url()
+        self.url = urls.fix(url or _get_url())
+        urls.validate(self.url)

--- a/src/posit/connect/config_test.py
+++ b/src/posit/connect/config_test.py
@@ -41,7 +41,7 @@ def test_get_url_miss():
 
 def test_init():
     api_key = "foobar"
-    url = "http://foo.bar"
+    url = "http://foo.bar/__api__"
     config = Config(api_key=api_key, url=url)
     assert config.api_key == api_key
     assert config.url == url

--- a/src/posit/connect/urls.py
+++ b/src/posit/connect/urls.py
@@ -5,7 +5,7 @@ import posixpath
 from urllib.parse import urlsplit, urlunsplit
 
 
-def fix(url: str) -> str:
+def server_to_api_url(url: str) -> str:
     """
     Fixes the given URL by appending '__api__' if it doesn't already end with it.
 
@@ -15,6 +15,7 @@ def fix(url: str) -> str:
     Returns:
         str: The fixed URL.
     """
+    url = url.rstrip("/")
     if not url.endswith("__api__"):
         return append_path(url, "__api__")
     return url
@@ -31,7 +32,7 @@ def validate(url: str) -> None:
         bool: True if the URL is valid, False otherwise.
 
     Raises:
-        ValueError: If the URL is missing a scheme, is not absolute, or does not end with '/__api__'.
+        ValueError: If the URL is missing a scheme or is not absolute.
     """
     split = urlsplit(url, allow_fragments=False)
     if not split.scheme:
@@ -42,11 +43,6 @@ def validate(url: str) -> None:
     if not split.netloc:
         raise ValueError(
             f"url must be absolute (e.g., http://example.com/__api__): {url}"
-        )
-
-    if not (split.path and split.path.endswith("/__api__")):
-        raise ValueError(
-            f"url must end with path __api__ (e.g., http://example.com/__api__): {url}"
         )
 
 

--- a/src/posit/connect/urls.py
+++ b/src/posit/connect/urls.py
@@ -5,23 +5,33 @@ import posixpath
 from urllib.parse import urlsplit, urlunsplit
 
 
-def append_path(url: str, path: str) -> str:
+def fix(url: str) -> str:
     """
-    Appends a path to the end of a URL.
+    Fixes the given URL by appending '__api__' if it doesn't already end with it.
 
     Args:
-        url (str): The URL to append the path to.
-        path (str): The path to append to the URL.
+        url (str): The URL to fix.
 
     Returns:
-        str: The modified URL with the appended path.
+        str: The fixed URL.
+    """
+    if not url.endswith("__api__"):
+        return append_path(url, "__api__")
+    return url
+
+
+def validate(url: str) -> None:
+    """
+    Check if the given URL is valid.
+
+    Args:
+        url (str): The URL to be validated.
+
+    Returns:
+        bool: True if the URL is valid, False otherwise.
 
     Raises:
-        ValueError: If the URL does not specify a scheme, is not absolute, or does not end with "/__api__".
-
-    Example:
-        >>> append_path("http://example.com", "api")
-        'http://example.com/__api__/api'
+        ValueError: If the URL is missing a scheme, is not absolute, or does not end with '/__api__'.
     """
     split = urlsplit(url, allow_fragments=False)
     if not split.scheme:
@@ -39,7 +49,23 @@ def append_path(url: str, path: str) -> str:
             f"url must end with path __api__ (e.g., http://example.com/__api__): {url}"
         )
 
-    joined_path = posixpath.join(split.path, path.lstrip("/"))
 
+def append_path(url: str, path: str) -> str:
+    """
+    Appends a path to a URL.
+
+    Args:
+        url (str): The original URL.
+        path (str): The path to append.
+
+    Returns:
+        str: The modified URL with the appended path.
+    """
+    # See https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlsplit
+    split = urlsplit(url, allow_fragments=False)
+    # Removes leading '/' from path to avoid double slashes.
+    path = path.lstrip("/")
+    # Prepend the path with the existing URL path.
+    path = posixpath.join(split.path, path)
     # See https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlunsplit
-    return urlunsplit((split.scheme, split.netloc, joined_path, split.query, None))
+    return urlunsplit((split.scheme, split.netloc, path, split.query, None))

--- a/src/posit/connect/urls_test.py
+++ b/src/posit/connect/urls_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .urls import append_path, fix, validate
+from .urls import append_path, server_to_api_url, validate
 
 
 def test_append_path():
@@ -12,15 +12,16 @@ def test_append_path_with_leading_slash():
 
 
 def test_fix_with_correct_url():
-    assert fix("http://foo.bar/__api__") == "http://foo.bar/__api__"
+    assert server_to_api_url("http://foo.bar/__api__") == "http://foo.bar/__api__"
+    assert server_to_api_url("http://foo.bar/__api__/") == "http://foo.bar/__api__"
 
 
 def test_fix_without_path():
-    assert fix("http://foo.bar") == "http://foo.bar/__api__"
+    assert server_to_api_url("http://foo.bar") == "http://foo.bar/__api__"
 
 
 def test_fix_with_proxy_path():
-    assert fix("http://foo.bar/baz") == "http://foo.bar/baz/__api__"
+    assert server_to_api_url("http://foo.bar/baz") == "http://foo.bar/baz/__api__"
 
 
 def test_validate_without_scheme():
@@ -32,12 +33,3 @@ def test_validate_without_netloc():
     with pytest.raises(ValueError):
         validate("http:///__api__")
 
-
-def test_validate_without_path():
-    with pytest.raises(ValueError):
-        validate("http://foo.bar")
-
-
-def test_validate_without_correct_path():
-    with pytest.raises(ValueError):
-        validate("http://foo.bar/baz")

--- a/src/posit/connect/urls_test.py
+++ b/src/posit/connect/urls_test.py
@@ -1,28 +1,43 @@
 import pytest
 
-from .urls import append_path
+from .urls import append_path, fix, validate
 
 
-def test_fix_without_scheme():
-    with pytest.raises(ValueError):
-        append_path("foo.bar/__api__", "baz")
+def test_append_path():
+    assert append_path("http://foo.bar/__api__", "baz") == "http://foo.bar/__api__/baz"
 
 
-def test_fix_without_netloc():
-    with pytest.raises(ValueError):
-        append_path("http:///__api__", "baz")
+def test_append_path_with_leading_slash():
+    assert append_path("http://foo.bar/__api__", "/baz") == "http://foo.bar/__api__/baz"
+
+
+def test_fix_with_correct_url():
+    assert fix("http://foo.bar/__api__") == "http://foo.bar/__api__"
 
 
 def test_fix_without_path():
+    assert fix("http://foo.bar") == "http://foo.bar/__api__"
+
+
+def test_fix_with_proxy_path():
+    assert fix("http://foo.bar/baz") == "http://foo.bar/baz/__api__"
+
+
+def test_validate_without_scheme():
     with pytest.raises(ValueError):
-        append_path("http://foo.bar", "baz")
+        validate("foo.bar/__api__")
 
 
-def test_fix_without_correct_path():
+def test_validate_without_netloc():
     with pytest.raises(ValueError):
-        append_path("http://foo.bar/baz", "qux")
+        validate("http:///__api__")
 
 
-def test_fix_with_no_errors():
-    url = append_path("http://foo.bar/baz/__api__", "qux")
-    assert url == "http://foo.bar/baz/__api__/qux"
+def test_validate_without_path():
+    with pytest.raises(ValueError):
+        validate("http://foo.bar")
+
+
+def test_validate_without_correct_path():
+    with pytest.raises(ValueError):
+        validate("http://foo.bar/baz")

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -52,6 +52,7 @@ class Users(CachedUsers, Resources[User]):
             )
 
         super().__init__(config.url)
+        self.url = urls.append_path(config.url, "v1/users")
         self.config = config
         self.session = session
         self.page_size = page_size
@@ -67,10 +68,8 @@ class Users(CachedUsers, Resources[User]):
         page_number = int(index / self.page_size) + 1
         # Define query parameters for pagination.
         params = {"page_number": page_number, "page_size": self.page_size}
-        # Create the URL for the endpoint.
-        url = urls.append_path(self.config.url, "v1/users")
         # Send a GET request to the endpoint with the specified parameters.
-        response = self.session.get(url, params=params)
+        response = self.session.get(self.url, params=params)
         # Convert response to dict
         json: dict = dict(response.json())
         # Parse the JSON response and extract the results.
@@ -82,6 +81,6 @@ class Users(CachedUsers, Resources[User]):
         return (users, exhausted)
 
     def get(self, id: str) -> User:
-        url = urls.append_path(self.config.url, f"v1/users/{id}")
+        url = urls.append_path(self.url, id)
         response = self.session.get(url)
         return User(**response.json())


### PR DESCRIPTION
This change moves base URL validation to the Config initialization sequence, which allows `append_path` to be called on URLs that are not base URLs.