### PR TITLE
ci: adds action to lint conventional commits.

### DIFF
--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,0 +1,50 @@
+name: Conventional Commits
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+jobs:
+  default:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            style
+            test
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: always() && (steps.lint.outputs.error_message != null)
+        with:
+          header: lint-error
+          message: |
+            Hey there! 👋
+
+            We noticed that the title of your pull request doesn't follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification. To ensure consistency, we kindly ask you to adjust the title accordingly.
+
+            Here are the details:
+
+            ```
+            ${{ steps.lint.outputs.error_message }}
+            ```
+      - if: ${{ steps.lint.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: lint-error
+          delete: true


### PR DESCRIPTION
@nealrichardson and I are using conventional commits to keep the Git changelog clean. This change adds a GitHub action to verify that the pull request title uses the conventional commit syntax in the title. 

Since we are forcing "Squash and merge", developers can continue using whatever commit title they want for individual commits. By default, those commits will be squashed into the commit body.

To test the GitHub action functionality, try fixing the title of this pull request to match the style guide.