### PR TITLE
ci: fix main workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    paths:
+      - '.github/workflows/cpp.yml'
 jobs:
   default:
     runs-on: ubuntu-latest
@@ -21,4 +24,3 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - run: make
-    - run: make install

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,7 @@ on:
       - main
   pull_request:
     paths:
-      - '.github/workflows/cpp.yml'
+      - '.github/workflows/main.yaml'
 jobs:
   default:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ PYTHON := python3
 
 default:
 	make deps
+	make install
 	make test
 	make lint
 	make build


### PR DESCRIPTION
#60 updated the pull request workflow but also needed to update the main workflow, which was not triggered on the PR. This PR fixes that and modifies that workflow to run when the workflow file is touched, which should trigger it on this PR.

That said, I'm not sure why we need a separate workflow to run on main from the one we run on PRs. 