### PR TITLE
chore: Factor some mock responses to JSON files and read them in with a helper

### DIFF
--- a/src/posit/connect/paginator.py
+++ b/src/posit/connect/paginator.py
@@ -33,7 +33,6 @@ class Paginator:
         result = []
         while self.total is None or self.seen < self.total:
             result += self.get_next_page()
-            self.page_number += 1
         return result
 
     def get_next_page(self) -> List[dict]:
@@ -46,4 +45,5 @@ class Paginator:
             self.total = response["total"]
         results = response["results"]
         self.seen += len(results)
+        self.page_number += 1
         return results

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -41,7 +41,6 @@ class Users:
         self, filter: Callable[[User], bool] = lambda _: True, page_size=_MAX_PAGE_SIZE
     ) -> User | None:
         pager = Paginator(self.session, self.url, page_size=page_size)
-        result = pager.get_next_page()
         while pager.total is None or pager.seen < pager.total:
             result = pager.get_next_page()
             for u in result:

--- a/tests/posit/connect/__api__/v1/user.json
+++ b/tests/posit/connect/__api__/v1/user.json
@@ -1,0 +1,13 @@
+{
+    "email": "carlos@connect.example",
+    "username": "carlos12",
+    "first_name": "Carlos",
+    "last_name": "User",
+    "user_role": "publisher",
+    "created_time": "2019-09-09T15:24:32Z",
+    "updated_time": "2022-03-02T20:25:06Z",
+    "active_time": "2020-05-11T16:58:45Z",
+    "confirmed": true,
+    "locked": true,
+    "guid": "20a79ce3-6e87-4522-9faf-be24228800a4"
+}

--- a/tests/posit/connect/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json
+++ b/tests/posit/connect/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json
@@ -1,0 +1,13 @@
+{
+    "email": "carlos@connect.example",
+    "username": "carlos12",
+    "first_name": "Carlos",
+    "last_name": "User",
+    "user_role": "publisher",
+    "created_time": "2019-09-09T15:24:32Z",
+    "updated_time": "2022-03-02T20:25:06Z",
+    "active_time": "2020-05-11T16:58:45Z",
+    "confirmed": true,
+    "locked": false,
+    "guid": "20a79ce3-6e87-4522-9faf-be24228800a4"
+}

--- a/tests/posit/connect/__api__/v1/users?page_number=1&page_size=2.json
+++ b/tests/posit/connect/__api__/v1/users?page_number=1&page_size=2.json
@@ -1,0 +1,32 @@
+{
+    "results": [
+        {
+            "email": "alice@connect.example",
+            "username": "al",
+            "first_name": "Alice",
+            "last_name": "User",
+            "user_role": "publisher",
+            "created_time": "2017-08-08T15:24:32Z",
+            "updated_time": "2023-03-02T20:25:06Z",
+            "active_time": "2018-05-09T16:58:45Z",
+            "confirmed": true,
+            "locked": false,
+            "guid": "a01792e3-2e67-402e-99af-be04a48da074"
+        },
+        {
+            "email": "bob@connect.example",
+            "username": "robert",
+            "first_name": "Bob",
+            "last_name": "Loblaw",
+            "user_role": "publisher",
+            "created_time": "2023-01-06T19:47:29Z",
+            "updated_time": "2023-05-05T19:08:45Z",
+            "active_time": "2023-05-05T20:29:11Z",
+            "confirmed": true,
+            "locked": false,
+            "guid": "87c12c08-11cd-4de1-8da3-12a7579c4998"
+        }
+    ],
+    "current_page": 1,
+    "total": 3
+}

--- a/tests/posit/connect/__api__/v1/users?page_number=2&page_size=2.json
+++ b/tests/posit/connect/__api__/v1/users?page_number=2&page_size=2.json
@@ -1,0 +1,19 @@
+{
+    "results": [
+        {
+            "email": "carlos@connect.example",
+            "username": "carlos12",
+            "first_name": "Carlos",
+            "last_name": "User",
+            "user_role": "publisher",
+            "created_time": "2019-09-09T15:24:32Z",
+            "updated_time": "2022-03-02T20:25:06Z",
+            "active_time": "2020-05-11T16:58:45Z",
+            "confirmed": true,
+            "locked": false,
+            "guid": "20a79ce3-6e87-4522-9faf-be24228800a4"
+        }
+    ],
+    "current_page": 2,
+    "total": 3
+}

--- a/tests/posit/connect/api.py
+++ b/tests/posit/connect/api.py
@@ -1,0 +1,10 @@
+import json
+
+from pathlib import Path
+
+
+def load_mock(path):
+    """
+    Read a JSON object from `path`
+    """
+    return json.loads((Path(__file__).parent / "__api__" / path).read_text())

--- a/tests/posit/connect/api.py
+++ b/tests/posit/connect/api.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 
 
-def load_mock(path):
+def load_mock(path: str) -> dict:
     """
     Read a JSON object from `path`
     """

--- a/tests/posit/connect/test_client.py
+++ b/tests/posit/connect/test_client.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from posit.connect import Client
 
-from .api import load_mock
+from .api import load_mock  # type: ignore
 
 
 @pytest.fixture

--- a/tests/posit/connect/test_client.py
+++ b/tests/posit/connect/test_client.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, patch
 
 from posit.connect import Client
 
+from .api import load_mock
+
 
 @pytest.fixture
 def MockAuth():
@@ -78,19 +80,7 @@ class TestClient:
     def test_me_request(self):
         responses.get(
             "https://connect.example/__api__/v1/user",
-            json={
-                "email": "carlos@connect.example",
-                "username": "carlos12",
-                "first_name": "Carlos",
-                "last_name": "User",
-                "user_role": "publisher",
-                "created_time": "2019-09-09T15:24:32Z",
-                "updated_time": "2022-03-02T20:25:06Z",
-                "active_time": "2020-05-11T16:58:45Z",
-                "confirmed": True,
-                "locked": False,
-                "guid": "20a79ce3-6e87-4522-9faf-be24228800a4",
-            },
+            json=load_mock("v1/user.json"),
         )
 
         con = Client(api_key="12345", url="https://connect.example/")

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -6,7 +6,7 @@ from requests import HTTPError
 
 from posit.connect.client import Client
 
-from .api import load_mock
+from .api import load_mock  # type: ignore
 
 
 class TestUsers:

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -1,5 +1,8 @@
 import pandas as pd
+import pytest
 import responses
+
+from requests import HTTPError
 
 from posit.connect.client import Client
 
@@ -8,7 +11,7 @@ from .api import load_mock
 
 class TestUsers:
     @responses.activate
-    def test_get_users(self):
+    def test_users_find(self):
         responses.get(
             "https://connect.example/__api__/v1/users",
             match=[
@@ -50,16 +53,67 @@ class TestUsers:
         ]
         assert df["username"].to_list() == ["al", "robert", "carlos12"]
 
-        # Test find_one()
-        bob = con.users.find_one(lambda u: u["first_name"] == "Bob", page_size=2)
-        # Can't isinstance(bob, User) bc inherits TypedDict (cf. #23)
-        assert bob["username"] == "robert"
+    @responses.activate
+    def test_users_find_one(self):
+        responses.get(
+            "https://connect.example/__api__/v1/users",
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"page_size": 2, "page_number": 1}
+                )
+            ],
+            json=load_mock("v1/users?page_number=1&page_size=2.json"),
+        )
+        responses.get(
+            "https://connect.example/__api__/v1/users",
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"page_size": 2, "page_number": 2}
+                )
+            ],
+            json=load_mock("v1/users?page_number=2&page_size=2.json"),
+        )
 
-        # Test where find_one() doesn't find any
+        con = Client(api_key="12345", url="https://connect.example/")
+        c = con.users.find_one(lambda u: u["first_name"] == "Carlos", page_size=2)
+        # Can't isinstance(c, User) bc inherits TypedDict (cf. #23)
+        assert c["username"] == "carlos12"
+
+        # Now test that if not found, it returns None
         assert (
             con.users.find_one(lambda u: u["first_name"] == "Ringo", page_size=2)
             is None
         )
+
+    @responses.activate
+    def test_users_find_one_only_gets_necessary_pages(self):
+        responses.get(
+            "https://connect.example/__api__/v1/users",
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"page_size": 2, "page_number": 1}
+                )
+            ],
+            json=load_mock("v1/users?page_number=1&page_size=2.json"),
+        )
+        # Make page 2 return an error so we can prove that we're quitting
+        # when we find the user
+        responses.get(
+            "https://connect.example/__api__/v1/users",
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"page_size": 2, "page_number": 2}
+                )
+            ],
+            status=500,
+        )
+
+        con = Client(api_key="12345", url="https://connect.example/")
+        bob = con.users.find_one(lambda u: u["first_name"] == "Bob", page_size=2)
+        assert bob["username"] == "robert"
+        # This errors because we have to go past the first page
+        with pytest.raises(HTTPError, match="500 Server Error"):
+            con.users.find_one(lambda u: u["first_name"] == "Carlos", page_size=2)
 
     @responses.activate
     def test_users_get(self):

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -3,6 +3,8 @@ import responses
 
 from posit.connect.client import Client
 
+from .api import load_mock
+
 
 class TestUsers:
     @responses.activate
@@ -14,38 +16,7 @@ class TestUsers:
                     {"page_size": 2, "page_number": 1}
                 )
             ],
-            json={
-                "results": [
-                    {
-                        "email": "alice@connect.example",
-                        "username": "al",
-                        "first_name": "Alice",
-                        "last_name": "User",
-                        "user_role": "publisher",
-                        "created_time": "2017-08-08T15:24:32Z",
-                        "updated_time": "2023-03-02T20:25:06Z",
-                        "active_time": "2018-05-09T16:58:45Z",
-                        "confirmed": True,
-                        "locked": False,
-                        "guid": "a01792e3-2e67-402e-99af-be04a48da074",
-                    },
-                    {
-                        "email": "bob@connect.example",
-                        "username": "robert",
-                        "first_name": "Bob",
-                        "last_name": "Loblaw",
-                        "user_role": "publisher",
-                        "created_time": "2023-01-06T19:47:29Z",
-                        "updated_time": "2023-05-05T19:08:45Z",
-                        "active_time": "2023-05-05T20:29:11Z",
-                        "confirmed": True,
-                        "locked": False,
-                        "guid": "87c12c08-11cd-4de1-8da3-12a7579c4998",
-                    },
-                ],
-                "current_page": 1,
-                "total": 3,
-            },
+            json=load_mock("v1/users?page_number=1&page_size=2.json"),
         )
         responses.get(
             "https://connect.example/__api__/v1/users",
@@ -54,25 +25,7 @@ class TestUsers:
                     {"page_size": 2, "page_number": 2}
                 )
             ],
-            json={
-                "results": [
-                    {
-                        "email": "carlos@connect.example",
-                        "username": "carlos12",
-                        "first_name": "Carlos",
-                        "last_name": "User",
-                        "user_role": "publisher",
-                        "created_time": "2019-09-09T15:24:32Z",
-                        "updated_time": "2022-03-02T20:25:06Z",
-                        "active_time": "2020-05-11T16:58:45Z",
-                        "confirmed": True,
-                        "locked": False,
-                        "guid": "20a79ce3-6e87-4522-9faf-be24228800a4",
-                    },
-                ],
-                "current_page": 2,
-                "total": 3,
-            },
+            json=load_mock("v1/users?page_number=2&page_size=2.json"),
         )
 
         con = Client(api_key="12345", url="https://connect.example/")
@@ -112,19 +65,7 @@ class TestUsers:
     def test_users_get(self):
         responses.get(
             "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",
-            json={
-                "email": "carlos@connect.example",
-                "username": "carlos12",
-                "first_name": "Carlos",
-                "last_name": "User",
-                "user_role": "publisher",
-                "created_time": "2019-09-09T15:24:32Z",
-                "updated_time": "2022-03-02T20:25:06Z",
-                "active_time": "2020-05-11T16:58:45Z",
-                "confirmed": True,
-                "locked": False,
-                "guid": "20a79ce3-6e87-4522-9faf-be24228800a4",
-            },
+            json=load_mock("v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
         )
 
         con = Client(api_key="12345", url="https://connect.example/")


### PR DESCRIPTION
The goals here are to make the test files more readable by separating out the JSON API responses to separate files, and also to make it more natural to reuse the responses in multiple tests. I've just done this for the users mocks right now so you can review what it looks like before I go further.

It may be easier to review the commits individually. The first commit is the refactor and setup for that. In the second commit, I used it to separate out the users tests so that it was easier to test more corners of the find_one behavior, and in the process, I found and fixed a bug in its implementation. 