### PR TITLE
feat: switch User and Content to inherit dict, add update method for User

### DIFF
--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -13,175 +13,175 @@ from .resources import Resources
 class ContentItem(dict):
     @property
     def guid(self) -> str:
-        return self.get("guid")
+        return self.get("guid")  # type: ignore
 
     @property
     def name(self) -> str:
-        return self.get("name")
+        return self.get("name")  # type: ignore
 
     @property
     def title(self) -> Optional[str]:
-        return self.get("title")
+        return self.get("title")  # type: ignore
 
     @property
     def description(self) -> str:
-        return self.get("description")
+        return self.get("description")  # type: ignore
 
     @property
     def access_type(self) -> str:
-        return self.get("access_type")
+        return self.get("access_type")  # type: ignore
 
     @property
     def connection_timeout(self) -> Optional[int]:
-        return self.get("connection_timeout")
+        return self.get("connection_timeout")  # type: ignore
 
     @property
     def read_timeout(self) -> Optional[int]:
-        return self.get("read_timeout")
+        return self.get("read_timeout")  # type: ignore
 
     @property
     def init_timeout(self) -> Optional[int]:
-        return self.get("init_timeout")
+        return self.get("init_timeout")  # type: ignore
 
     @property
     def idle_timeout(self) -> Optional[int]:
-        return self.get("idle_timeout")
+        return self.get("idle_timeout")  # type: ignore
 
     @property
     def max_processes(self) -> Optional[int]:
-        return self.get("max_processes")
+        return self.get("max_processes")  # type: ignore
 
     @property
     def min_processes(self) -> Optional[int]:
-        return self.get("min_processes")
+        return self.get("min_processes")  # type: ignore
 
     @property
     def max_conns_per_process(self) -> Optional[int]:
-        return self.get("max_conns_per_process")
+        return self.get("max_conns_per_process")  # type: ignore
 
     @property
     def load_factor(self) -> Optional[float]:
-        return self.get("load_factor")
+        return self.get("load_factor")  # type: ignore
 
     @property
     def cpu_request(self) -> Optional[float]:
-        return self.get("cpu_request")
+        return self.get("cpu_request")  # type: ignore
 
     @property
     def cpu_limit(self) -> Optional[float]:
-        return self.get("cpu_limit")
+        return self.get("cpu_limit")  # type: ignore
 
     @property
     def memory_request(self) -> Optional[int]:
-        return self.get("memory_request")
+        return self.get("memory_request")  # type: ignore
 
     @property
     def memory_limit(self) -> Optional[int]:
-        return self.get("memory_limit")
+        return self.get("memory_limit")  # type: ignore
 
     @property
     def amd_gpu_limit(self) -> Optional[int]:
-        return self.get("amd_gpu_limit")
+        return self.get("amd_gpu_limit")  # type: ignore
 
     @property
     def nvidia_gpu_limit(self) -> Optional[int]:
-        return self.get("nvidia_gpu_limit")
+        return self.get("nvidia_gpu_limit")  # type: ignore
 
     @property
     def created_time(self) -> str:
-        return self.get("created_time")
+        return self.get("created_time")  # type: ignore
 
     @property
     def last_deployed_time(self) -> str:
-        return self.get("last_deployed_time")
+        return self.get("last_deployed_time")  # type: ignore
 
     @property
     def bundle_id(self) -> Optional[str]:
-        return self.get("bundle_id")
+        return self.get("bundle_id")  # type: ignore
 
     @property
     def app_mode(self) -> str:
-        return self.get("app_mode")
+        return self.get("app_mode")  # type: ignore
 
     @property
     def content_category(self) -> Optional[str]:
-        return self.get("content_category")
+        return self.get("content_category")  # type: ignore
 
     @property
     def parameterized(self) -> bool:
-        return self.get("parameterized")
+        return self.get("parameterized")  # type: ignore
 
     @property
     def cluster_name(self) -> Optional[str]:
-        return self.get("cluster_name")
+        return self.get("cluster_name")  # type: ignore
 
     @property
     def image_name(self) -> Optional[str]:
-        return self.get("image_name")
+        return self.get("image_name")  # type: ignore
 
     @property
     def default_image_name(self) -> Optional[str]:
-        return self.get("default_image_name")
+        return self.get("default_image_name")  # type: ignore
 
     @property
     def default_r_environment_management(self) -> Optional[bool]:
-        return self.get("default_r_environment_management")
+        return self.get("default_r_environment_management")  # type: ignore
 
     @property
     def default_py_environment_management(self) -> Optional[bool]:
-        return self.get("default_py_environment_management")
+        return self.get("default_py_environment_management")  # type: ignore
 
     @property
     def service_account_name(self) -> Optional[str]:
-        return self.get("service_account_name")
+        return self.get("service_account_name")  # type: ignore
 
     @property
     def r_version(self) -> Optional[str]:
-        return self.get("r_version")
+        return self.get("r_version")  # type: ignore
 
     @property
     def r_environment_management(self) -> Optional[bool]:
-        return self.get("r_environment_management")
+        return self.get("r_environment_management")  # type: ignore
 
     @property
     def py_version(self) -> Optional[str]:
-        return self.get("py_version")
+        return self.get("py_version")  # type: ignore
 
     @property
     def py_environment_management(self) -> Optional[bool]:
-        return self.get("py_environment_management")
+        return self.get("py_environment_management")  # type: ignore
 
     @property
     def quarto_version(self) -> Optional[str]:
-        return self.get("quarto_version")
+        return self.get("quarto_version")  # type: ignore
 
     @property
     def run_as(self) -> Optional[str]:
-        return self.get("run_as")
+        return self.get("run_as")  # type: ignore
 
     @property
     def run_as_current_user(self) -> bool:
-        return self.get("run_as_current_user")
+        return self.get("run_as_current_user")  # type: ignore
 
     @property
     def owner_guid(self) -> str:
-        return self.get("owner_guid")
+        return self.get("owner_guid")  # type: ignore
 
     @property
     def content_url(self) -> str:
-        return self.get("content_url")
+        return self.get("content_url")  # type: ignore
 
     @property
     def dashboard_url(self) -> str:
-        return self.get("dashboard_url")
+        return self.get("dashboard_url")  # type: ignore
 
     @property
     def app_role(self) -> str:
-        return self.get("app_role")
+        return self.get("app_role")  # type: ignore
 
     @property
     def id(self) -> str:
-        return self.get("id")
+        return self.get("id")  # type: ignore
 
     def __setattr__(self, name: str, value: Any) -> None:
         raise AttributeError("Cannot set attributes: use update() instead")

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, List, Optional
+from typing import Any, Callable, List, Optional
 
 from requests import Session
 

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -11,45 +11,180 @@ from .resources import Resources
 
 
 class ContentItem(dict):
-
-    def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
-        # TODO: self.url, self.config, self.session
-
-    def update(self):
-        pass
+    @property
+    def guid(self) -> str:
+        return self.get("guid")
 
     @property
     def name(self) -> str:
-        return self["name"]
+        return self.get("name")
 
     @property
-    def id(self) -> str:
-        return self["id"]
-
-    @property
-    def title(self) -> str:
-        return self["title"]
+    def title(self) -> Optional[str]:
+        return self.get("title")
 
     @property
     def description(self) -> str:
-        return self["description"]
-
-    @property
-    def created_time(self) -> str:
-        return self["created_time"]
-
-    @property
-    def guid(self) -> str:
-        return self["guid"]
+        return self.get("description")
 
     @property
     def access_type(self) -> str:
-        return self["access_type"]
+        return self.get("access_type")
 
     @property
     def connection_timeout(self) -> Optional[int]:
-        return self["connection_timeout"]
+        return self.get("connection_timeout")
+
+    @property
+    def read_timeout(self) -> Optional[int]:
+        return self.get("read_timeout")
+
+    @property
+    def init_timeout(self) -> Optional[int]:
+        return self.get("init_timeout")
+
+    @property
+    def idle_timeout(self) -> Optional[int]:
+        return self.get("idle_timeout")
+
+    @property
+    def max_processes(self) -> Optional[int]:
+        return self.get("max_processes")
+
+    @property
+    def min_processes(self) -> Optional[int]:
+        return self.get("min_processes")
+
+    @property
+    def max_conns_per_process(self) -> Optional[int]:
+        return self.get("max_conns_per_process")
+
+    @property
+    def load_factor(self) -> Optional[float]:
+        return self.get("load_factor")
+
+    @property
+    def cpu_request(self) -> Optional[float]:
+        return self.get("cpu_request")
+
+    @property
+    def cpu_limit(self) -> Optional[float]:
+        return self.get("cpu_limit")
+
+    @property
+    def memory_request(self) -> Optional[int]:
+        return self.get("memory_request")
+
+    @property
+    def memory_limit(self) -> Optional[int]:
+        return self.get("memory_limit")
+
+    @property
+    def amd_gpu_limit(self) -> Optional[int]:
+        return self.get("amd_gpu_limit")
+
+    @property
+    def nvidia_gpu_limit(self) -> Optional[int]:
+        return self.get("nvidia_gpu_limit")
+
+    @property
+    def created_time(self) -> str:
+        return self.get("created_time")
+
+    @property
+    def last_deployed_time(self) -> str:
+        return self.get("last_deployed_time")
+
+    @property
+    def bundle_id(self) -> Optional[str]:
+        return self.get("bundle_id")
+
+    @property
+    def app_mode(self) -> str:
+        return self.get("app_mode")
+
+    @property
+    def content_category(self) -> Optional[str]:
+        return self.get("content_category")
+
+    @property
+    def parameterized(self) -> bool:
+        return self.get("parameterized")
+
+    @property
+    def cluster_name(self) -> Optional[str]:
+        return self.get("cluster_name")
+
+    @property
+    def image_name(self) -> Optional[str]:
+        return self.get("image_name")
+
+    @property
+    def default_image_name(self) -> Optional[str]:
+        return self.get("default_image_name")
+
+    @property
+    def default_r_environment_management(self) -> Optional[bool]:
+        return self.get("default_r_environment_management")
+
+    @property
+    def default_py_environment_management(self) -> Optional[bool]:
+        return self.get("default_py_environment_management")
+
+    @property
+    def service_account_name(self) -> Optional[str]:
+        return self.get("service_account_name")
+
+    @property
+    def r_version(self) -> Optional[str]:
+        return self.get("r_version")
+
+    @property
+    def r_environment_management(self) -> Optional[bool]:
+        return self.get("r_environment_management")
+
+    @property
+    def py_version(self) -> Optional[str]:
+        return self.get("py_version")
+
+    @property
+    def py_environment_management(self) -> Optional[bool]:
+        return self.get("py_environment_management")
+
+    @property
+    def quarto_version(self) -> Optional[str]:
+        return self.get("quarto_version")
+
+    @property
+    def run_as(self) -> Optional[str]:
+        return self.get("run_as")
+
+    @property
+    def run_as_current_user(self) -> bool:
+        return self.get("run_as_current_user")
+
+    @property
+    def owner_guid(self) -> str:
+        return self.get("owner_guid")
+
+    @property
+    def content_url(self) -> str:
+        return self.get("content_url")
+
+    @property
+    def dashboard_url(self) -> str:
+        return self.get("dashboard_url")
+
+    @property
+    def app_role(self) -> str:
+        return self.get("app_role")
+
+    @property
+    def id(self) -> str:
+        return self.get("id")
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        raise AttributeError("Cannot set attributes: use update() instead")
 
 
 class Content(Resources[ContentItem]):

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, List, TypedDict
+from typing import Callable, List, Optional
 
 from requests import Session
 
@@ -10,9 +10,46 @@ from .config import Config
 from .resources import Resources
 
 
-class ContentItem(TypedDict, total=False):
-    # TODO: specify types
-    pass
+class ContentItem(dict):
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        # TODO: self.url, self.config, self.session
+
+    def update(self):
+        pass
+
+    @property
+    def name(self) -> str:
+        return self["name"]
+
+    @property
+    def id(self) -> str:
+        return self["id"]
+
+    @property
+    def title(self) -> str:
+        return self["title"]
+
+    @property
+    def description(self) -> str:
+        return self["description"]
+
+    @property
+    def created_time(self) -> str:
+        return self["created_time"]
+
+    @property
+    def guid(self) -> str:
+        return self["guid"]
+
+    @property
+    def access_type(self) -> str:
+        return self["access_type"]
+
+    @property
+    def connection_timeout(self) -> Optional[int]:
+        return self["connection_timeout"]
 
 
 class Content(Resources[ContentItem]):

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Callable, List
+from typing import Any, Callable, List, Optional
 
 from requests import Session
 
@@ -15,54 +15,86 @@ class User(dict):
 
     @property
     def guid(self) -> str:
-        return self["guid"]
+        return self.get("guid")
 
     @property
     def email(self) -> str:
-        return self["email"]
+        return self.get("email")
 
     @property
     def username(self) -> str:
-        return self["username"]
+        return self.get("username")
 
     @property
     def first_name(self) -> str:
-        return self["first_name"]
+        return self.get("first_name")
 
     @property
     def last_name(self) -> str:
-        return self["last_name"]
+        return self.get("last_name")
 
     @property
     def user_role(self) -> str:
-        return self["user_role"]
+        return self.get("user_role")
 
     @property
     def created_time(self) -> str:
-        return self["created_time"]
+        return self.get("created_time")
 
     @property
     def updated_time(self) -> str:
-        return self["updated_time"]
+        return self.get("updated_time")
 
     @property
     def active_time(self) -> str:
-        return self["active_time"]
+        return self.get("active_time")
 
     @property
     def confirmed(self) -> bool:
-        return self["confirmed"]
+        return self.get("confirmed")
 
     @property
     def locked(self) -> bool:
-        return self["locked"]
+        return self.get("locked")
 
     def __setattr__(self, name: str, value: Any) -> None:
         raise AttributeError("Cannot set attributes: use update() instead.")
 
-    def update(self, **kwargs):
-        self["session"].patch(self["url"], json=kwargs)
-        super().update(kwargs)
+    def _update(self, body):
+        self.get("session").patch(self.get("url"), json=body)
+        # If the request is successful, update the local object
+        # TODO: that patch request returns a payload on success,
+        # so we could update the local object with that payload
+        # (includes updated_time)
+        super().update(body)
+
+    def update(
+        self,
+        # Not all properties are settable, so we enumerate them here
+        # (also for type-hinting purposes)
+        email: Optional[str] = None,
+        username: Optional[str] = None,
+        first_name: Optional[str] = None,
+        last_name: Optional[str] = None,
+        user_role: Optional[str] = None,
+        # TODO: in the API, this goes via POST /v1/users/{guid}/lock
+        # accept it here and make that request? Or add a .lock() method?
+        # locked: Optional[bool] = None,
+    ) -> None:
+        kwargs = {}
+        if email is not None:
+            kwargs["email"] = email
+        if username is not None:
+            kwargs["username"] = username
+        if first_name is not None:
+            kwargs["first_name"] = first_name
+        if last_name is not None:
+            kwargs["last_name"] = last_name
+        if user_role is not None:
+            kwargs["user_role"] = user_role
+        # if locked is not None:
+        #     kwargs["locked"] = locked
+        self._update(kwargs)
 
 
 class Users(Resources[User]):

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
-
-from datetime import datetime
-from typing import Callable, List, TypedDict
+from typing import Any, Callable, List
 
 from requests import Session
 
@@ -40,15 +38,15 @@ class User(dict):
         return self["user_role"]
 
     @property
-    def created_time(self) -> datetime:
+    def created_time(self) -> str:
         return self["created_time"]
 
     @property
-    def updated_time(self) -> datetime:
+    def updated_time(self) -> str:
         return self["updated_time"]
 
     @property
-    def active_time(self) -> datetime:
+    def active_time(self) -> str:
         return self["active_time"]
 
     @property
@@ -58,6 +56,9 @@ class User(dict):
     @property
     def locked(self) -> bool:
         return self["locked"]
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        raise AttributeError("Cannot set attributes: use update() instead.")
 
     def update(self, **kwargs):
         self["session"].patch(self["url"], json=kwargs)

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -63,10 +63,10 @@ class User(dict):
     def _update(self, body):
         self.get("session").patch(self.get("url"), json=body)
         # If the request is successful, update the local object
-        # TODO: that patch request returns a payload on success,
-        # so we could update the local object with that payload
-        # (includes updated_time)
         super().update(body)
+        # TODO(#99): that patch request returns a payload on success,
+        # so we should instead update the local object with that payload
+        # (includes updated_time)
 
     def update(  # type: ignore
         self,
@@ -77,7 +77,7 @@ class User(dict):
         first_name: Optional[str] = None,
         last_name: Optional[str] = None,
         user_role: Optional[str] = None,
-        # TODO: in the API, this goes via POST /v1/users/{guid}/lock
+        # TODO(#100): in the API, this goes via POST /v1/users/{guid}/lock
         # accept it here and make that request? Or add a .lock() method?
         # locked: Optional[bool] = None,
     ) -> None:

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -15,47 +15,47 @@ class User(dict):
 
     @property
     def guid(self) -> str:
-        return self.get("guid")
+        return self.get("guid")  # type: ignore
 
     @property
     def email(self) -> str:
-        return self.get("email")
+        return self.get("email")  # type: ignore
 
     @property
     def username(self) -> str:
-        return self.get("username")
+        return self.get("username")  # type: ignore
 
     @property
     def first_name(self) -> str:
-        return self.get("first_name")
+        return self.get("first_name")  # type: ignore
 
     @property
     def last_name(self) -> str:
-        return self.get("last_name")
+        return self.get("last_name")  # type: ignore
 
     @property
     def user_role(self) -> str:
-        return self.get("user_role")
+        return self.get("user_role")  # type: ignore
 
     @property
     def created_time(self) -> str:
-        return self.get("created_time")
+        return self.get("created_time")  # type: ignore
 
     @property
     def updated_time(self) -> str:
-        return self.get("updated_time")
+        return self.get("updated_time")  # type: ignore
 
     @property
     def active_time(self) -> str:
-        return self.get("active_time")
+        return self.get("active_time")  # type: ignore
 
     @property
     def confirmed(self) -> bool:
-        return self.get("confirmed")
+        return self.get("confirmed")  # type: ignore
 
     @property
     def locked(self) -> bool:
-        return self.get("locked")
+        return self.get("locked")  # type: ignore
 
     def __setattr__(self, name: str, value: Any) -> None:
         raise AttributeError("Cannot set attributes: use update() instead.")
@@ -68,7 +68,7 @@ class User(dict):
         # (includes updated_time)
         super().update(body)
 
-    def update(
+    def update(  # type: ignore
         self,
         # Not all properties are settable, so we enumerate them here
         # (also for type-hinting purposes)

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -1,6 +1,7 @@
 import responses
 
 from posit.connect.client import Client
+from posit.connect.content import ContentItem
 
 from .api import load_mock  # type: ignore
 
@@ -15,7 +16,7 @@ class TestContents:
         con = Client("12345", "https://connect.example")
         all_content = con.content.find()
         assert len(all_content) == 3
-        assert [c["name"] for c in all_content] == [
+        assert [c.name for c in all_content] == [
             "team-admin-dashboard",
             "Performance-Data-1671216053560",
             "My-Streamlit-app",
@@ -29,11 +30,12 @@ class TestContents:
         )
         con = Client("12345", "https://connect.example")
 
-        one = con.content.find_one(lambda c: c["title"] == "Performance Data")
-        assert one["name"] == "Performance-Data-1671216053560"
+        one = con.content.find_one(lambda c: c.title == "Performance Data")
+        assert isinstance(one, ContentItem)
+        assert one.name == "Performance-Data-1671216053560"
 
         # Test find_one doesn't find any
-        assert con.content.find_one(lambda c: c["title"] == "Does not exist") is None
+        assert con.content.find_one(lambda c: c.title == "Does not exist") is None
 
     @responses.activate
     def test_content_get(self):
@@ -43,4 +45,4 @@ class TestContents:
         )
         con = Client("12345", "https://connect.example")
         get_one = con.content.get("f2f37341-e21d-3d80-c698-a935ad614066")
-        assert get_one["name"] == "Performance-Data-1671216053560"
+        assert get_one.name == "Performance-Data-1671216053560"

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -166,8 +166,10 @@ class TestUsers:
 
         assert patch_request.call_count == 1
         assert carlos.first_name == "Carlitos"
-        # TODO: test setting the other fields
-        # TODO: test invalid field
+        # TODO(#99):
+        # * test setting the other fields
+        # * test invalid field
+        # * error response (e.g. not authorized)
 
     @responses.activate
     def test_user_cant_setattr(self):

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -77,14 +77,13 @@ class TestUsers:
         )
 
         con = Client(api_key="12345", url="https://connect.example/")
-        c = con.users.find_one(lambda u: u["first_name"] == "Carlos", page_size=2)
+        c = con.users.find_one(lambda u: u.first_name == "Carlos", page_size=2)
         # Can't isinstance(c, User) bc inherits TypedDict (cf. #23)
-        assert c["username"] == "carlos12"
+        assert c.username == "carlos12"
 
         # Now test that if not found, it returns None
         assert (
-            con.users.find_one(lambda u: u["first_name"] == "Ringo", page_size=2)
-            is None
+            con.users.find_one(lambda u: u.first_name == "Ringo", page_size=2) is None
         )
 
     @responses.activate
@@ -111,11 +110,11 @@ class TestUsers:
         )
 
         con = Client(api_key="12345", url="https://connect.example/")
-        bob = con.users.find_one(lambda u: u["first_name"] == "Bob", page_size=2)
-        assert bob["username"] == "robert"
+        bob = con.users.find_one(lambda u: u.first_name == "Bob", page_size=2)
+        assert bob.username == "robert"
         # This errors because we have to go past the first page
         with pytest.raises(HTTPError, match="500 Server Error"):
-            con.users.find_one(lambda u: u["first_name"] == "Carlos", page_size=2)
+            con.users.find_one(lambda u: u.first_name == "Carlos", page_size=2)
 
     @responses.activate
     def test_users_get(self):

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -167,3 +167,19 @@ class TestUsers:
 
         assert patch_request.call_count == 1
         assert carlos.first_name == "Carlitos"
+
+    @responses.activate
+    def test_user_cant_setattr(self):
+        responses.get(
+            "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",
+            json=load_mock("v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
+        )
+
+        con = Client(api_key="12345", url="https://connect.example/")
+        carlos = con.users.get("20a79ce3-6e87-4522-9faf-be24228800a4")
+
+        with pytest.raises(
+            AttributeError,
+            match=r"Cannot set attributes: use update\(\) instead",
+        ):
+            carlos.first_name = "Carlitos"

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -37,7 +37,7 @@ class TestUsers:
 
         df = pd.DataFrame(all_users)
         assert isinstance(df, pd.DataFrame)
-        assert df.shape == (3, 11)
+        assert df.shape == (3, 13)
         assert df.columns.to_list() == [
             "email",
             "username",
@@ -50,6 +50,8 @@ class TestUsers:
             "confirmed",
             "locked",
             "guid",
+            "session",
+            "url",
         ]
         assert df["username"].to_list() == ["al", "robert", "carlos12"]
 
@@ -123,7 +125,45 @@ class TestUsers:
         )
 
         con = Client(api_key="12345", url="https://connect.example/")
-        assert (
-            con.users.get("20a79ce3-6e87-4522-9faf-be24228800a4")["username"]
-            == "carlos12"
+        carlos = con.users.get("20a79ce3-6e87-4522-9faf-be24228800a4")
+        assert carlos.username == "carlos12"
+        assert carlos.first_name == "Carlos"
+        assert carlos.created_time == "2019-09-09T15:24:32Z"
+
+    @responses.activate
+    def test_users_get_extra_fields(self):
+        responses.get(
+            "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",
+            json={
+                "guid": "20a79ce3-6e87-4522-9faf-be24228800a4",
+                "username": "carlos12",
+                "some_new_field": "some_new_value",
+            },
         )
+
+        con = Client(api_key="12345", url="https://connect.example/")
+        carlos = con.users.get("20a79ce3-6e87-4522-9faf-be24228800a4")
+        assert carlos.username == "carlos12"
+        assert carlos["some_new_field"] == "some_new_value"
+
+    @responses.activate
+    def test_user_update(self):
+        responses.get(
+            "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",
+            json=load_mock("v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
+        )
+        patch_request = responses.patch(
+            "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",
+            match=[responses.matchers.json_params_matcher({"first_name": "Carlitos"})],
+        )
+
+        con = Client(api_key="12345", url="https://connect.example/")
+        carlos = con.users.get("20a79ce3-6e87-4522-9faf-be24228800a4")
+
+        assert patch_request.call_count == 0
+        assert carlos.first_name == "Carlos"
+
+        carlos.update(first_name="Carlitos")
+
+        assert patch_request.call_count == 1
+        assert carlos.first_name == "Carlitos"

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -166,6 +166,8 @@ class TestUsers:
 
         assert patch_request.call_count == 1
         assert carlos.first_name == "Carlitos"
+        # TODO: test setting the other fields
+        # TODO: test invalid field
 
     @responses.activate
     def test_user_cant_setattr(self):


### PR DESCRIPTION
To help us move the discussion forward. I switched User to inherit from `dict` to see how that works, including adding an update method and wiring that up. I first tried `UserDict` but it messed up the sort order of the columns in the DataFrame version, and googling a bit, it sounded like it wasn't so bad to inherit from `dict` anymore, so I figured I'd try that and see how it went. Summary of what I found so far, as reflected in the test suite:

* ✅  Forwards and backwards compatibility (i.e., what happens if the API returns more or fewer fields than the class definition knows about) all works fine. If new fields appear and you haven't defined `property`s for them, it doesn't break, and you can still get at them via `[`. Missing fields also are fine, at least as long as you don't access them (you'd get a KeyError).
* ✅ `update()` method works. I was worried from that blog post that you wouldn't be able to define a new one, but it was fine. I did not try setattr, and my guess is that we'd want to disable that anyway (but that's a discussion for another time). 
* 🤔 `pd.DataFrame(list of Users)` works fine since it *is* a dict still, but: in adding the `session` and `url` to the object in order to implement `update()`, those now show up in the data frame. AFAIK there's no way to hide them somewhere else, it's just a dict. 
* 🤔 `@property`s work to access the data, but the type hints don't enforce anything. I didn't add in the datetime parsing, just to see what happens, and the methods happily return the unparsed strings. Not strictly a problem, but worth keeping in mind.
* Other consideration related to the last two: we could add an `__init__` method to do things like parse timestamps. As we discussed before, there are tradeoffs to doing this eagerly vs. on demand. Alternatively, if we kept it lazy (my preference), we could add a `to_pandas` function or something that would parse them when you do that conversion, and leave the attribute parsing to the `property` getters.