### PR TITLE
refactor: moves session and url to resource attributes

### DIFF
--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -23,6 +23,7 @@ jobs:
             fix
             perf
             style
+            refactor
             test
       - uses: marocchino/sticky-pull-request-comment@v2
         if: always() && (steps.lint.outputs.error_message != null)

--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -50,7 +50,7 @@ class Client:
     def me(self) -> User:
         url = urls.append_path(self.config.url, "v1/user")
         response = self.session.get(url)
-        return User(**response.json())
+        return User(self.session, url, **response.json())
 
     @property
     def oauth(self) -> OAuthIntegration:

--- a/src/posit/connect/resources.py
+++ b/src/posit/connect/resources.py
@@ -1,13 +1,22 @@
 import warnings
 
 from abc import ABC, abstractmethod
-from typing import Generic, List, Optional, TypeVar
+from typing import Any, Generic, List, Optional, TypeVar
+
+import requests
 
 
 T = TypeVar("T")
 
 
 class Resource(ABC, dict):
+    def __init__(self, session: requests.Session, url: str, **kwargs):
+        super().__init__(**kwargs)
+        self.session: requests.Session
+        super().__setattr__("session", session)
+        self.url: str
+        super().__setattr__("url", url)
+
     def __getitem__(self, key):
         warnings.warn(
             f"__getitem__ for '{key}' does not support backwards compatibility. Consider using field based access instead: 'instance.{key}'",
@@ -28,6 +37,9 @@ class Resource(ABC, dict):
             FutureWarning,
         )
         return super().__delitem__(key)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        raise AttributeError("cannot set attributes: use update() instead")
 
 
 class Resources(ABC, Generic[T]):

--- a/tests/posit/connect/test_resources.py
+++ b/tests/posit/connect/test_resources.py
@@ -1,9 +1,15 @@
+from unittest.mock import Mock
 import pytest
 import warnings
 
 from typing import Any, List, Optional
 
+from requests.sessions import Session as Session
+
 from posit.connect.resources import Resource, Resources
+
+session = Mock()
+url = Mock()
 
 
 class FakeResource(Resource):
@@ -13,12 +19,20 @@ class FakeResource(Resource):
 
 
 class TestResource:
+    def test_init(self):
+        k = "foo"
+        v = "bar"
+        d = dict({k: v})
+        r = FakeResource(session, url, **d)
+        assert r.session == session
+        assert r.url == url
+
     def test__getitem__(self):
         warnings.filterwarnings("ignore", category=FutureWarning)
         k = "foo"
         v = "bar"
         d = dict({k: v})
-        r = FakeResource(d)
+        r = FakeResource(session, url, **d)
         assert r.__getitem__(k) == d.__getitem__(k)
         assert r[k] == d[k]
 
@@ -27,7 +41,8 @@ class TestResource:
         k = "foo"
         v1 = "bar"
         v2 = "baz"
-        r = FakeResource({k: v1})
+        d = dict({k: v1})
+        r = FakeResource(session, url, **d)
         assert r[k] == v1
         r[k] = v2
         assert r[k] == v2
@@ -36,7 +51,8 @@ class TestResource:
         warnings.filterwarnings("ignore", category=FutureWarning)
         k = "foo"
         v = "bar"
-        r = FakeResource({k: v})
+        d = dict({k: v})
+        r = FakeResource(session, url, **d)
         assert k in r
         assert r[k] == v
         del r[k]
@@ -46,7 +62,7 @@ class TestResource:
         k = "foo"
         v = "bar"
         d = dict({k: v})
-        r = FakeResource(d)
+        r = FakeResource(session, url, **d)
         assert r.foo == v
 
 

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -19,77 +19,77 @@ class TestUser:
         user = User(session, url)
         assert hasattr(user, "guid")
         assert user.guid is None
-        user = User(session, url, **{"guid": "test_guid"})
+        user = User(session, url, guid="test_guid")
         assert user.guid == "test_guid"
 
     def test_email(self):
         user = User(session, url)
         assert hasattr(user, "email")
         assert user.email is None
-        user = User(session, url, **{"email": "test@example.com"})
+        user = User(session, url, email="test@example.com")
         assert user.email == "test@example.com"
 
     def test_username(self):
         user = User(session, url)
         assert hasattr(user, "username")
         assert user.username is None
-        user = User(session, url, **{"username": "test_user"})
+        user = User(session, url, username="test_user")
         assert user.username == "test_user"
 
     def test_first_name(self):
         user = User(session, url)
         assert hasattr(user, "first_name")
         assert user.first_name is None
-        user = User(session, url, **{"first_name": "John"})
+        user = User(session, url, first_name="John")
         assert user.first_name == "John"
 
     def test_last_name(self):
         user = User(session, url)
         assert hasattr(user, "last_name")
         assert user.last_name is None
-        user = User(session, url, **{"last_name": "Doe"})
+        user = User(session, url, last_name="Doe")
         assert user.last_name == "Doe"
 
     def test_user_role(self):
         user = User(session, url)
         assert hasattr(user, "user_role")
         assert user.user_role is None
-        user = User(session, url, **{"user_role": "admin"})
+        user = User(session, url, user_role="admin")
         assert user.user_role == "admin"
 
     def test_created_time(self):
         user = User(session, url)
         assert hasattr(user, "created_time")
         assert user.created_time is None
-        user = User(session, url, **{"created_time": "2022-01-01T00:00:00"})
+        user = User(session, url, created_time="2022-01-01T00:00:00")
         assert user.created_time == "2022-01-01T00:00:00"
 
     def test_updated_time(self):
         user = User(session, url)
         assert hasattr(user, "updated_time")
         assert user.updated_time is None
-        user = User(session, url, **{"updated_time": "2022-01-01T00:00:00"})
+        user = User(session, url, updated_time="2022-01-01T00:00:00")
         assert user.updated_time == "2022-01-01T00:00:00"
 
     def test_active_time(self):
         user = User(session, url)
         assert hasattr(user, "active_time")
         assert user.active_time is None
-        user = User(session, url, **{"active_time": "2022-01-01T00:00:00"})
+        user = User(session, url, active_time="2022-01-01T00:00:00")
         assert user.active_time == "2022-01-01T00:00:00"
 
     def test_confirmed(self):
         user = User(session, url)
         assert hasattr(user, "confirmed")
         assert user.confirmed is None
-        user = User(session, url, **{"confirmed": True})
+        user = User(session, url, confirmed=True)
         assert user.confirmed is True
 
     def test_locked(self):
         user = User(session, url)
         assert hasattr(user, "locked")
         assert user.locked is None
-        user = User(session, url, **{"locked": False})
+        user = User(session, url, locked=False)
         assert user.locked is False
 
 

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -1,3 +1,4 @@
+from unittest.mock import Mock
 import pandas as pd
 import pytest
 import responses
@@ -9,83 +10,86 @@ from posit.connect.users import User
 
 from .api import load_mock  # type: ignore
 
+session = Mock()
+url = Mock()
+
 
 class TestUser:
     def test_guid(self):
-        user = User()
+        user = User(session, url)
         assert hasattr(user, "guid")
         assert user.guid is None
-        user = User({"guid": "test_guid"})
+        user = User(session, url, **{"guid": "test_guid"})
         assert user.guid == "test_guid"
 
     def test_email(self):
-        user = User()
+        user = User(session, url)
         assert hasattr(user, "email")
         assert user.email is None
-        user = User({"email": "test@example.com"})
+        user = User(session, url, **{"email": "test@example.com"})
         assert user.email == "test@example.com"
 
     def test_username(self):
-        user = User()
+        user = User(session, url)
         assert hasattr(user, "username")
         assert user.username is None
-        user = User({"username": "test_user"})
+        user = User(session, url, **{"username": "test_user"})
         assert user.username == "test_user"
 
     def test_first_name(self):
-        user = User()
+        user = User(session, url)
         assert hasattr(user, "first_name")
         assert user.first_name is None
-        user = User({"first_name": "John"})
+        user = User(session, url, **{"first_name": "John"})
         assert user.first_name == "John"
 
     def test_last_name(self):
-        user = User()
+        user = User(session, url)
         assert hasattr(user, "last_name")
         assert user.last_name is None
-        user = User({"last_name": "Doe"})
+        user = User(session, url, **{"last_name": "Doe"})
         assert user.last_name == "Doe"
 
     def test_user_role(self):
-        user = User()
+        user = User(session, url)
         assert hasattr(user, "user_role")
         assert user.user_role is None
-        user = User({"user_role": "admin"})
+        user = User(session, url, **{"user_role": "admin"})
         assert user.user_role == "admin"
 
     def test_created_time(self):
-        user = User()
+        user = User(session, url)
         assert hasattr(user, "created_time")
         assert user.created_time is None
-        user = User({"created_time": "2022-01-01T00:00:00"})
+        user = User(session, url, **{"created_time": "2022-01-01T00:00:00"})
         assert user.created_time == "2022-01-01T00:00:00"
 
     def test_updated_time(self):
-        user = User()
+        user = User(session, url)
         assert hasattr(user, "updated_time")
         assert user.updated_time is None
-        user = User({"updated_time": "2022-01-01T00:00:00"})
+        user = User(session, url, **{"updated_time": "2022-01-01T00:00:00"})
         assert user.updated_time == "2022-01-01T00:00:00"
 
     def test_active_time(self):
-        user = User()
+        user = User(session, url)
         assert hasattr(user, "active_time")
         assert user.active_time is None
-        user = User({"active_time": "2022-01-01T00:00:00"})
+        user = User(session, url, **{"active_time": "2022-01-01T00:00:00"})
         assert user.active_time == "2022-01-01T00:00:00"
 
     def test_confirmed(self):
-        user = User()
+        user = User(session, url)
         assert hasattr(user, "confirmed")
         assert user.confirmed is None
-        user = User({"confirmed": True})
+        user = User(session, url, **{"confirmed": True})
         assert user.confirmed is True
 
     def test_locked(self):
-        user = User()
+        user = User(session, url)
         assert hasattr(user, "locked")
         assert user.locked is None
-        user = User({"locked": False})
+        user = User(session, url, **{"locked": False})
         assert user.locked is False
 
 
@@ -117,7 +121,7 @@ class TestUsers:
 
         df = pd.DataFrame(all_users)
         assert isinstance(df, pd.DataFrame)
-        assert df.shape == (3, 13)
+        assert df.shape == (3, 11)
         assert df.columns.to_list() == [
             "email",
             "username",
@@ -130,8 +134,6 @@ class TestUsers:
             "confirmed",
             "locked",
             "guid",
-            "session",
-            "url",
         ]
         assert df["username"].to_list() == ["al", "robert", "carlos12"]
 
@@ -263,6 +265,6 @@ class TestUsers:
 
         with pytest.raises(
             AttributeError,
-            match=r"Cannot set attributes: use update\(\) instead",
+            match=r"cannot set attributes: use update\(\) instead",
         ):
             carlos.first_name = "Carlitos"

--- a/tinkering.py
+++ b/tinkering.py
@@ -1,11 +1,7 @@
 from posit.connect import Client
 
 with Client() as client:
-    print(client.get("v1/users"))
-    print(client.users.get("f55ca95d-ce52-43ed-b31b-48dc4a07fe13"))
-
-    users = client.users
-    users = users.find(lambda user: user["first_name"].startswith("T"))
-    users = users.find(lambda user: user["last_name"].startswith("S"))
-    user = users.find_one(lambda user: user["user_role"] == "administrator")
-    print(user)
+    client.get("v1/users")
+    client.users.get("f55ca95d-ce52-43ed-b31b-48dc4a07fe13")
+    client.users.find(lambda user: user.first_name.startswith("T"))
+    client.users.find_one(lambda user: user.first_name.startswith("T"))


### PR DESCRIPTION
This change moves the `url` and `session` items from the underlying hash table used by `dict` to instance attributes. 

Subsequently, these columns no longer appear as columns when converting from a `list[Resource]` to a pandas DataFrame.

The `__setattr__` override behavior is also moved to the base `Resource` class.

Resolves #102 
