### PR TITLE
feat!: removes filter parameter from content.find and content.find_one.

### DIFF
--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, List, Optional, overload
+from typing import List, Optional, overload
 
 
 from requests import Session
@@ -285,9 +285,7 @@ class Content(Resources[ContentItem]):
         self.config = config
         self.session = session
 
-    def find(
-        self, filter: Callable[[ContentItem], bool] = lambda _: True
-    ) -> List[ContentItem]:
+    def find(self) -> List[ContentItem]:
         results = self.session.get(self.url).json()
         items = (
             ContentItem(
@@ -297,21 +295,19 @@ class Content(Resources[ContentItem]):
             )
             for result in results
         )
-        return [item for item in items if filter(item)]
+        return [item for item in items]
 
-    def find_one(
-        self, filter: Callable[[ContentItem], bool] = lambda _: True
-    ) -> ContentItem | None:
+    def find_one(self) -> ContentItem | None:
         results = self.session.get(self.url).json()
-        for result in results:
-            item = ContentItem(
+        items = (
+            ContentItem(
                 config=self.config,
                 session=self.session,
                 **result,
             )
-            if filter(item):
-                return item
-        return None
+            for result in results
+        )
+        return next(items, None)
 
     def get(self, id: str) -> ContentItem:
         url = urls.append_path(self.url, id)

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -52,12 +52,9 @@ class TestContents:
         )
         con = Client("12345", "https://connect.example")
 
-        one = con.content.find_one(lambda c: c.title == "Performance Data")
+        one = con.content.find_one()
         assert isinstance(one, ContentItem)
-        assert one.name == "Performance-Data-1671216053560"
-
-        # Test find_one doesn't find any
-        assert con.content.find_one(lambda c: c.title == "Does not exist") is None
+        assert one.name == "team-admin-dashboard"
 
     @responses.activate
     def test_content_get(self):


### PR DESCRIPTION
BREAKING CHANGE: Support for passing a filter as lambda expression to `content.find` and `content.find_one` is removed. Please use client-side filtering instead. Additional filter support is planned for a future release.