### PR TITLE
feat: adds create support for users

### DIFF
--- a/tests/posit/connect/__api__/v1/users/remote.json
+++ b/tests/posit/connect/__api__/v1/users/remote.json
@@ -1,0 +1,20 @@
+{
+    "results": [
+        {
+            "email": "carlos@connect.example",
+            "username": "carlos12",
+            "first_name": "Carlos",
+            "last_name": "User",
+            "user_role": "publisher",
+            "created_time": "2019-09-09T15:24:32Z",
+            "updated_time": "2022-03-02T20:25:06Z",
+            "active_time": "2020-05-11T16:58:45Z",
+            "confirmed": true,
+            "locked": true,
+            "guid": "20a79ce3-6e87-4522-9faf-be24228800a4",
+            "temp_ticket": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        }
+    ],
+    "current_page": 1,
+    "total": 1
+}

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -274,6 +274,58 @@ class TestUsers:
         assert count == 3
 
 
+class TestUsersCreate:
+    @responses.activate
+    def test_with_prefix(self):
+        responses.get(
+            "https://connect.example/__api__/v1/users/remote",
+            json=load_mock("v1/users/remote.json"),
+            match=[
+                responses.matchers.query_param_matcher(
+                    {
+                        "page_number": 1,
+                        "page_size": 500,
+                        "prefix": "carlos@connect.example",
+                    }
+                )
+            ],
+        )
+        responses.put(
+            "https://connect.example/__api__/v1/users",
+            json=load_mock("v1/user.json"),
+            match=[
+                responses.matchers.json_params_matcher(
+                    {
+                        "temp_ticket": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+                    }
+                )
+            ],
+        )
+
+        con = Client(api_key="12345", url="https://connect.example/")
+        user = con.users.create(prefix="carlos@connect.example")
+        assert user.email == "carlos@connect.example"
+
+    @responses.activate
+    def test(self):
+        params = {
+            "email": "carlos@connect.example",
+            "username": "carlos12",
+            "first_name": "Carlos",
+            "last_name": "User",
+        }
+
+        responses.post(
+            "https://connect.example/__api__/v1/users",
+            json=load_mock("v1/user.json"),
+            match=[responses.matchers.json_params_matcher(params)],
+        )
+
+        con = Client(api_key="12345", url="https://connect.example/")
+        user = con.users.create(**params)
+        assert user.email == "carlos@connect.example"
+
+
 class TestUsersFindOne:
     @responses.activate
     def test_default(self):


### PR DESCRIPTION
I'm torn between a few different approaches to solve this problem.

My primary goal is to eliminate the consumer's need to understand which authentication implementation their Connect server is using. 

## Option 1

A simple way to do this (the current implementation) is to key off the provided parameters. If the consumer provides a "prefix", we assume the "remote" flow. Otherwise, do the normal POST flow.

## Option 2

However, I think the better option is to abstract this further and define an interface that provides a better user experience. One that does not require the consumer to know all of our implementation's quirks.

e.g.,
```py
@overload
def create(self, email: str = ..., username: str = ..., password: str = ...) -> User:
    ...
```

We can utilize the @overload capabilities to guide users towards the correct set of parameters. For example, if the `password` isn't supplied, then we should set `user_must_set_password=True` during `POST /v1/users`.

e.g.,
```py
@overload
def create(self, email: str = ..., username: str = ...) -> User:
    ...
```

## Option 3

Another option is to force the user to know their Connect instances auth implementation and have them specify the type. Then, we can key the auth flow and client side assertions based on the provided auth type.


e.g.,
```py
def create(self, provider: str, *args, **kwargs) -> User:
      match provider:
            case "ldap":
                # remote flow
                pass
            case "pam":
                # normal flow
                pass
            case _:
                raise ValueError()
```

