### PR TITLE
feat!: renames `Client` to `Connect`

### DIFF
--- a/examples/0001-overview.qmd
+++ b/examples/0001-overview.qmd
@@ -7,41 +7,41 @@ The examples cover various aspects, including authentication, data retrieval, an
 ## Example - Print information for each user where `user_role='publisher'`
 
 ```python
-from posit.connect import Client
+from posit.connect import Connect
 
-with Client() as client:
-    for user in client.users.find(user_role='publisher'):
+with Connect() as connect:
+    for user in connect.users.find(user_role='publisher'):
         print(user)
 ```
 
 ## Example - Print information for a single user where `prefix='b'`
 
 ```python
-from posit.connect import Client
+from posit.connect import Connect
 
-with Client() as client:
-    user = client.users.find_one(prefix='b')
+with Connect() as connect:
+    user = connect.users.find_one(prefix='b')
     print(user)
 ```
 
 ## Example - Print the title for each content item that I own.
 
 ```python
-from posit.connect import Client
+from posit.connect import Connect
 
-with Client() as client:
-    guid = client.me.guid
-    for item in client.content.find(owner_guid=guid)
+with Connect() as connect:
+    guid = connect.me.guid
+    for item in connect.content.find(owner_guid=guid)
         print(item.title)
 ```
 
 ## Example - Update the title for a content item.
 
 ```python
-from posit.connect import Client
+from posit.connect import Connect
 
-with Client() as client:
+with Connect() as connect:
     guid = ... # the guid for a content item
-    item = client.content.get(guid)
+    item = connect.content.get(guid)
     item.update(title='New Title')
 ```

--- a/src/posit/__init__.py
+++ b/src/posit/__init__.py
@@ -1,1 +1,3 @@
 """The Posit SDK."""
+
+from .connect import Connect  # noqa

--- a/src/posit/connect/__init__.py
+++ b/src/posit/connect/__init__.py
@@ -1,1 +1,1 @@
-from .client import Client  # noqa
+from .client import Connect  # noqa

--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -1,6 +1,8 @@
-"""Contains the Client class."""
+"""The Connect interface."""
 
 from __future__ import annotations
+
+import contextlib
 
 from requests import Response, Session
 from typing import Optional
@@ -14,7 +16,7 @@ from .content import Content
 from .users import User, Users
 
 
-class Client:
+class Connect(contextlib.AbstractContextManager):
     """Main interface for Posit Connect."""
 
     def __init__(
@@ -22,12 +24,17 @@ class Client:
         api_key: Optional[str] = None,
         url: Optional[str] = None,
     ) -> None:
-        """
-        Initialize the Client instance.
+        """Initialize a Connect client.
 
-        Args:
-            api_key (str, optional): API key for authentication. Defaults to None.
+        api_key (str, optional): API key for authentication. Defaults to None.
             url (str, optional): API url URL. Defaults to None.
+
+        Parameters
+        ----------
+        api_key : Optional[str], optional
+            API key for authentication, by default None
+        url : Optional[str], optional
+            API url, by default None
         """
         # Create a Config object.
         self.config = Config(api_key=api_key, url=url)
@@ -96,22 +103,26 @@ class Client:
         return Content(config=self.config, session=self.session)
 
     def __del__(self):
-        """Close the session when the Client instance is deleted."""
+        """Finalize the instance.
+
+        Closes the open requests.Session if it exists.
+        """
         if hasattr(self, "session") and self.session is not None:
             self.session.close()
 
-    def __enter__(self):
-        """Enter method for using the client as a context manager."""
-        return self
-
     def __exit__(self, exc_type, exc_value, exc_tb):
-        """
-        Close the session if it exists.
+        """Exit the runtime context.
 
-        Args:
-            exc_type: The type of the exception raised (if any).
-            exc_value: The exception instance raised (if any).
-            exc_tb: The traceback for the exception raised (if any).
+        Closes the open requests.Session if it exists.
+
+        Parameters
+        ----------
+        exc_type : _type_
+            The type of the exception raised (if any).
+        exc_value : _type_
+            The exception instance raised (if any).
+        exc_tb : _type_
+            The traceback for the exception raised (if any).
         """
         if hasattr(self, "session") and self.session is not None:
             self.session.close()

--- a/src/posit/connect/config.py
+++ b/src/posit/connect/config.py
@@ -1,4 +1,4 @@
-"""Client configuration."""
+"""Configuration."""
 
 import os
 

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -2,7 +2,7 @@ import abc
 import os
 from typing import Callable, Dict, Optional
 
-from ..client import Client
+from ..client import Connect
 from ..oauth import OAuthIntegration
 
 HeaderFactory = Callable[[], Dict[str, str]]
@@ -51,7 +51,7 @@ def is_local() -> bool:
 
 
 def viewer_credentials_provider(
-    client: Optional[Client] = None, user_session_token: Optional[str] = None
+    client: Optional[Connect] = None, user_session_token: Optional[str] = None
 ) -> Optional[CredentialsProvider]:
     # If the content is not running on Connect then viewer auth should
     # fall back to the locally configured credentials hierarchy
@@ -59,7 +59,7 @@ def viewer_credentials_provider(
         return None
 
     if client is None:
-        client = Client()
+        client = Connect()
 
     # If the user-session-token wasn't provided and we're running on Connect then we raise an exception.
     # user_session_token is required to impersonate the viewer.
@@ -71,5 +71,5 @@ def viewer_credentials_provider(
     return PositOAuthIntegrationCredentialsProvider(client.oauth, user_session_token)
 
 
-def service_account_credentials_provider(client: Optional[Client] = None):
+def service_account_credentials_provider(client: Optional[Connect] = None):
     raise NotImplementedError

--- a/tests/posit/connect/test_client.py
+++ b/tests/posit/connect/test_client.py
@@ -3,7 +3,7 @@ import responses
 
 from unittest.mock import MagicMock, patch
 
-from posit.connect import Client
+from posit.connect import Connect
 
 from .api import load_mock  # type: ignore
 
@@ -26,7 +26,7 @@ def MockSession():
         yield mock
 
 
-class TestClient:
+class TestConnect:
     def test_init(
         self,
         MockAuth: MagicMock,
@@ -35,7 +35,7 @@ class TestClient:
     ):
         api_key = "foobar"
         url = "http://foo.bar/__api__"
-        Client(api_key=api_key, url=url)
+        Connect(api_key=api_key, url=url)
         MockAuth.assert_called_once_with(config=MockConfig.return_value)
         MockConfig.assert_called_once_with(api_key=api_key, url=url)
         MockSession.assert_called_once()
@@ -43,30 +43,30 @@ class TestClient:
     def test__del__(self, MockAuth, MockConfig, MockSession):
         api_key = "foobar"
         url = "http://foo.bar/__api__"
-        client = Client(api_key=api_key, url=url)
-        del client
+        con = Connect(api_key=api_key, url=url)
+        del con
         MockSession.return_value.close.assert_called_once()
 
     def test__enter__(self):
         api_key = "foobar"
         url = "http://foo.bar/__api__"
-        with Client(api_key=api_key, url=url) as client:
-            assert isinstance(client, Client)
+        with Connect(api_key=api_key, url=url) as con:
+            assert isinstance(con, Connect)
 
     def test__exit__(self, MockSession):
         api_key = "foobar"
         url = "http://foo.bar/__api__"
         api_key = "foobar"
         url = "http://foo.bar/__api__"
-        with Client(api_key=api_key, url=url) as client:
-            assert isinstance(client, Client)
+        with Connect(api_key=api_key, url=url) as con:
+            assert isinstance(con, Connect)
         MockSession.return_value.close.assert_called_once()
 
     @responses.activate
     def test_connect_version(self):
         api_key = "foobar"
         url = "http://foo.bar/__api__"
-        client = Client(api_key=api_key, url=url)
+        con = Connect(api_key=api_key, url=url)
 
         # The actual server_settings response has a lot more attributes, but we
         # don't need to include them all here because we don't use them
@@ -74,7 +74,7 @@ class TestClient:
             "http://foo.bar/__api__/server_settings",
             json={"version": "2024.01.0"},
         )
-        assert client.connect_version == "2024.01.0"
+        assert con.connect_version == "2024.01.0"
 
     @responses.activate
     def test_me_request(self):
@@ -83,14 +83,14 @@ class TestClient:
             json=load_mock("v1/user.json"),
         )
 
-        con = Client(api_key="12345", url="https://connect.example/")
+        con = Connect(api_key="12345", url="https://connect.example/")
         assert con.me.username == "carlos12"
 
     def test_request(self, MockSession):
         api_key = "foobar"
         url = "http://foo.bar/__api__"
-        client = Client(api_key=api_key, url=url)
-        client.request("GET", "/foo")
+        con = Connect(api_key=api_key, url=url)
+        con.request("GET", "/foo")
         MockSession.return_value.request.assert_called_once_with(
             "GET", "http://foo.bar/__api__/foo"
         )
@@ -98,33 +98,33 @@ class TestClient:
     def test_get(self, MockSession):
         api_key = "foobar"
         url = "http://foo.bar/__api__"
-        client = Client(api_key=api_key, url=url)
-        client.get("/foo")
-        client.session.get.assert_called_once_with("http://foo.bar/__api__/foo")
+        con = Connect(api_key=api_key, url=url)
+        con.get("/foo")
+        con.session.get.assert_called_once_with("http://foo.bar/__api__/foo")
 
     def test_post(self, MockSession):
         api_key = "foobar"
         url = "http://foo.bar/__api__"
-        client = Client(api_key=api_key, url=url)
-        client.post("/foo")
-        client.session.post.assert_called_once_with("http://foo.bar/__api__/foo")
+        con = Connect(api_key=api_key, url=url)
+        con.post("/foo")
+        con.session.post.assert_called_once_with("http://foo.bar/__api__/foo")
 
     def test_put(self, MockSession):
         api_key = "foobar"
         url = "http://foo.bar/__api__"
-        client = Client(api_key=api_key, url=url)
-        client.put("/foo")
-        client.session.put.assert_called_once_with("http://foo.bar/__api__/foo")
+        con = Connect(api_key=api_key, url=url)
+        con.put("/foo")
+        con.session.put.assert_called_once_with("http://foo.bar/__api__/foo")
 
     def test_patch(self, MockSession):
         api_key = "foobar"
         url = "http://foo.bar/__api__"
-        client = Client(api_key=api_key, url=url)
-        client.patch("/foo")
-        client.session.patch.assert_called_once_with("http://foo.bar/__api__/foo")
+        con = Connect(api_key=api_key, url=url)
+        con.patch("/foo")
+        con.session.patch.assert_called_once_with("http://foo.bar/__api__/foo")
 
     def test_delete(self, MockSession):
         api_key = "foobar"
         url = "http://foo.bar/__api__"
-        client = Client(api_key=api_key, url=url)
-        client.delete("/foo")
+        con = Connect(api_key=api_key, url=url)
+        con.delete("/foo")

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -1,6 +1,6 @@
 import responses
 
-from posit.connect.client import Client
+from posit.connect import Connect
 from posit.connect.content import ContentItem
 
 from .api import load_mock  # type: ignore
@@ -14,7 +14,7 @@ class TestContent:
             f"https://connect.example/__api__/v1/content/{guid}",
             json=load_mock(f"v1/content/{guid}.json"),
         )
-        con = Client("12345", "https://connect.example")
+        con = Connect("12345", "https://connect.example")
         content = con.content.get(guid)
         assert content.guid == guid
 
@@ -35,7 +35,7 @@ class TestContents:
             "https://connect.example/__api__/v1/content",
             json=load_mock("v1/content.json"),
         )
-        con = Client("12345", "https://connect.example")
+        con = Connect("12345", "https://connect.example")
         all_content = con.content.find()
         assert len(all_content) == 3
         assert [c.name for c in all_content] == [
@@ -50,7 +50,7 @@ class TestContents:
             "https://connect.example/__api__/v1/content",
             json=load_mock("v1/content.json"),
         )
-        con = Client("12345", "https://connect.example")
+        con = Connect("12345", "https://connect.example")
 
         one = con.content.find_one()
         assert isinstance(one, ContentItem)
@@ -62,7 +62,7 @@ class TestContents:
             "https://connect.example/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066",
             json=load_mock("v1/content/f2f37341-e21d-3d80-c698-a935ad614066.json"),
         )
-        con = Client("12345", "https://connect.example")
+        con = Connect("12345", "https://connect.example")
         get_one = con.content.get("f2f37341-e21d-3d80-c698-a935ad614066")
         assert get_one.name == "Performance-Data-1671216053560"
 
@@ -72,6 +72,6 @@ class TestContents:
             "https://connect.example/__api__/v1/content",
             json=load_mock("v1/content.json"),
         )
-        con = Client(api_key="12345", url="https://connect.example/")
+        con = Connect(api_key="12345", url="https://connect.example/")
         count = con.content.count()
         assert count == 3

--- a/tests/posit/connect/test_oauth.py
+++ b/tests/posit/connect/test_oauth.py
@@ -1,6 +1,6 @@
 import responses
 
-from posit.connect import Client
+from posit.connect import Connect
 
 
 class TestOAuthIntegrations:
@@ -40,6 +40,6 @@ class TestOAuthIntegrations:
                 "token_type": "Bearer",
             },
         )
-        con = Client(api_key="12345", url="https://connect.example/")
+        con = Connect(api_key="12345", url="https://connect.example/")
         assert con.oauth.get_credentials()["access_token"] == "sdk-user-token"
         assert con.oauth.get_credentials("cit")["access_token"] == "viewer-token"

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -4,7 +4,7 @@ import pytest
 import requests
 import responses
 
-from posit.connect.client import Client
+from posit.connect import Connect
 from posit.connect.users import User
 
 from .api import load_mock  # type: ignore
@@ -99,7 +99,7 @@ class TestUserLock:
             "https://connect.example/__api__/v1/users/a1b2c3d4-e5f6-g7h8-i9j0-k1l2m3n4o5p6",
             json=load_mock("v1/users/a1b2c3d4-e5f6-g7h8-i9j0-k1l2m3n4o5p6.json"),
         )
-        c = Client(api_key="12345", url="https://connect.example/")
+        c = Connect(api_key="12345", url="https://connect.example/")
         user = c.users.get("a1b2c3d4-e5f6-g7h8-i9j0-k1l2m3n4o5p6")
         assert user.guid == "a1b2c3d4-e5f6-g7h8-i9j0-k1l2m3n4o5p6"
 
@@ -120,7 +120,7 @@ class TestUserLock:
             "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",
             json=load_mock("v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
         )
-        c = Client(api_key="12345", url="https://connect.example/")
+        c = Connect(api_key="12345", url="https://connect.example/")
         user = c.users.get("20a79ce3-6e87-4522-9faf-be24228800a4")
         assert user.guid == "20a79ce3-6e87-4522-9faf-be24228800a4"
 
@@ -141,7 +141,7 @@ class TestUserLock:
             "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",
             json=load_mock("v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
         )
-        c = Client(api_key="12345", url="https://connect.example/")
+        c = Connect(api_key="12345", url="https://connect.example/")
         user = c.users.get("20a79ce3-6e87-4522-9faf-be24228800a4")
         assert user.guid == "20a79ce3-6e87-4522-9faf-be24228800a4"
 
@@ -165,7 +165,7 @@ class TestUserUnlock:
             "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",
             json=load_mock("v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
         )
-        c = Client(api_key="12345", url="https://connect.example/")
+        c = Connect(api_key="12345", url="https://connect.example/")
         user = c.users.get("20a79ce3-6e87-4522-9faf-be24228800a4")
         assert user.guid == "20a79ce3-6e87-4522-9faf-be24228800a4"
 
@@ -185,7 +185,7 @@ class TestUsers:
             json=load_mock("v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
         )
 
-        con = Client(api_key="12345", url="https://connect.example/")
+        con = Connect(api_key="12345", url="https://connect.example/")
         carlos = con.users.get("20a79ce3-6e87-4522-9faf-be24228800a4")
         assert carlos.username == "carlos12"
         assert carlos.first_name == "Carlos"
@@ -202,7 +202,7 @@ class TestUsers:
             },
         )
 
-        con = Client(api_key="12345", url="https://connect.example/")
+        con = Connect(api_key="12345", url="https://connect.example/")
         carlos = con.users.get("20a79ce3-6e87-4522-9faf-be24228800a4")
         assert carlos.username == "carlos12"
         assert carlos["some_new_field"] == "some_new_value"
@@ -219,7 +219,7 @@ class TestUsers:
             json={"first_name": "Carlitos"},
         )
 
-        con = Client(api_key="12345", url="https://connect.example/")
+        con = Connect(api_key="12345", url="https://connect.example/")
         carlos = con.users.get("20a79ce3-6e87-4522-9faf-be24228800a4")
 
         assert patch_request.call_count == 0
@@ -241,7 +241,7 @@ class TestUsers:
             status=500,
         )
 
-        con = Client(api_key="12345", url="https://connect.example/")
+        con = Connect(api_key="12345", url="https://connect.example/")
         carlos = con.users.get("20a79ce3-6e87-4522-9faf-be24228800a4")
         with pytest.raises(requests.HTTPError, match="500 Server Error"):
             carlos.update(first_name="Carlitos")
@@ -253,7 +253,7 @@ class TestUsers:
             json=load_mock("v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
         )
 
-        con = Client(api_key="12345", url="https://connect.example/")
+        con = Connect(api_key="12345", url="https://connect.example/")
         carlos = con.users.get("20a79ce3-6e87-4522-9faf-be24228800a4")
 
         with pytest.raises(
@@ -269,7 +269,7 @@ class TestUsers:
             json=load_mock("v1/users?page_number=1&page_size=500.jsonc"),
             match=[responses.matchers.query_param_matcher({"page_size": 1})],
         )
-        con = Client(api_key="12345", url="https://connect.example/")
+        con = Connect(api_key="12345", url="https://connect.example/")
         count = con.users.count()
         assert count == 3
 
@@ -282,7 +282,7 @@ class TestUsersFindOne:
             "https://connect.example/__api__/v1/users",
             json=load_mock("v1/users?page_number=1&page_size=500.jsonc"),
         )
-        con = Client(api_key="12345", url="https://connect.example/")
+        con = Connect(api_key="12345", url="https://connect.example/")
         user = con.users.find_one()
         assert user.username == "al"
         assert len(responses.calls) == 1
@@ -300,7 +300,7 @@ class TestUsersFindOne:
             ],
             json=load_mock("v1/users?page_number=1&page_size=500.jsonc"),
         )
-        con = Client(api_key="12345", url="https://connect.example/")
+        con = Connect(api_key="12345", url="https://connect.example/")
         con.users.find_one(**params)
         responses.assert_call_count(
             "https://connect.example/__api__/v1/users?key1=value1&key2=value2&key3=value3&page_number=1&page_size=500",
@@ -314,7 +314,7 @@ class TestUsersFindOne:
             json={"total": 0, "current_page": 1, "results": []},
         )
 
-        con = Client(api_key="12345", url="https://connect.example/")
+        con = Connect(api_key="12345", url="https://connect.example/")
         user = con.users.find_one()
         assert user is None
 
@@ -341,7 +341,7 @@ class TestUsersFind:
             ],
             json=load_mock("v1/users?page_number=2&page_size=500.jsonc"),
         )
-        con = Client(api_key="12345", url="https://connect.example/")
+        con = Connect(api_key="12345", url="https://connect.example/")
         users = con.users.find()
         assert len(users) == 3
         assert users[0] == {
@@ -380,7 +380,7 @@ class TestUsersFind:
             ],
             json=load_mock("v1/users?page_number=2&page_size=500.jsonc"),
         )
-        con = Client(api_key="12345", url="https://connect.example/")
+        con = Connect(api_key="12345", url="https://connect.example/")
         con.users.find(**params)
         responses.assert_call_count(
             "https://connect.example/__api__/v1/users?key1=value1&key2=value2&key3=value3&page_number=1&page_size=500",
@@ -390,7 +390,7 @@ class TestUsersFind:
     @responses.activate
     def test_params_not_dict_like(self):
         # validate input params are propagated to the query params
-        con = Client(api_key="12345", url="https://connect.example/")
+        con = Connect(api_key="12345", url="https://connect.example/")
         not_dict_like = "string"
         with pytest.raises(ValueError):
             con.users.find(not_dict_like)


### PR DESCRIPTION
BREAKING CHANGE: `posit.connect.Client` has been renamed as `posit.Connect`. Please replace all references to `Client` with `Connect` when upgrading.

Previous:

```
from posit.connect import Client

c = Client()
```

Current:

```
from posit import Connect

c = Connect()
```