### PR TITLE
fix: removes resource warning messages.

### DIFF
--- a/src/posit/connect/resources.py
+++ b/src/posit/connect/resources.py
@@ -19,27 +19,6 @@ class Resource(ABC, dict):
         self.session: requests.Session
         super().__setattr__("session", session)
 
-    def __getitem__(self, key):
-        warnings.warn(
-            f"__getitem__ for '{key}' does not support backwards compatibility. Consider using field based access instead: 'instance.{key}'",
-            FutureWarning,
-        )
-        return super().__getitem__(key)
-
-    def __setitem__(self, key, value):
-        warnings.warn(
-            f"__setitem__ for '{key}' does not support backwards compatibility. Consider using field based access instead: 'instance.{key} = {value}",
-            FutureWarning,
-        )
-        return super().__setitem__(key, value)
-
-    def __delitem__(self, key):
-        warnings.warn(
-            f"__delitem__ for '{key}' does not support backwards compatibility. Consider using field based access instead: 'del instance.{key}'",
-            FutureWarning,
-        )
-        return super().__delitem__(key)
-
     def __setattr__(self, name: str, value: Any) -> None:
         raise AttributeError("cannot set attributes: use update() instead")
 


### PR DESCRIPTION
IPython utilizes custom i/o handlers when writing to stdout and stderr. During normal usages (.e.g, `client.users.find()`), these handlers invoke __getitem__ resulting in a warning messages for each key in the resource.

This conclusion is based on observed behavior using IPython. I haven't determined the root cause of the issue. Another fix could be checking if __getitem__, __setitem__, and __delitem__ are invoked in an IPython process.