### PR TITLE
feat: adds metrics view events

### DIFF
--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -110,9 +110,7 @@ class Client:
         >>> from posit import (
         ...     connect,
         ... )
-        >>> client = (
-        ...     connect.Client()
-        ... )
+        >>> client = connect.Client()
         >>> client.metrics.views.find_one()
         {'content_guid': '2243770d-ace0-4782-87f9-fe2aeca14fc8', 'user_guid': '434f97ab-4b97-4443-8490-ed1052f37b29', 'variant_key': 'dZnFUBMR', 'rendering_id': '3029259', 'bundle_id': '49747', 'started': '2023-10-27T16:19:40Z', 'ended': '2023-10-27T16:19:40Z', 'data_version': 3, 'path': None}
         """

--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -101,7 +101,12 @@ class Client:
     def metrics(self) -> metrics.Metrics:
         """The Metrics API interface.
 
-        The Metrics API is a software interface designed for capturing, retrieving, and managing quantitative data measurements. It is commonly used for monitoring and analyzing system performance, user behavior, and business processes. This API facilitates real-time data collection and accessibility, enabling organizations to make informed decisions based on key performance indicators (KPIs).
+        The Metrics API is designed for capturing, retrieving, and managing
+        quantitative measurements of Connect interactions. It is commonly used
+        for monitoring and analyzing system performance, user behavior, and
+        business processes. This API facilitates real-time data collection and
+        accessibility, enabling organizations to make informed decisions based
+        on key performance indicators (KPIs).
 
         Returns
         -------

--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 from requests import Response, Session
 from typing import Optional
 
-from . import hooks, me, urls
+from . import config, hooks, me, metrics, urls
 
 from .auth import Auth
 from .config import Config
 from .oauth import OAuthIntegration
 from .content import Content
-from .usage import Usage
+from .metrics.usage import Usage
 from .users import User, Users
-from .visits import Visits
+from .metrics.visits import Visits
 
 
 class Client:
@@ -98,12 +98,14 @@ class Client:
         return Content(config=self.config, session=self.session)
 
     @property
-    def usage(self) -> Usage:
-        return Usage(self.config, self.session)
+    def metrics(self) -> metrics.Metrics:
+        """The metrics API interface.
 
-    @property
-    def visits(self) -> Visits:
-        return Visits(self.config, self.session)
+        Returns
+        -------
+        metrics.Metrics
+        """
+        return metrics.Metrics(self.config, self.session)
 
     def __del__(self):
         """Close the session when the Client instance is deleted."""

--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -104,6 +104,17 @@ class Client:
         Returns
         -------
         metrics.Metrics
+
+        Examples
+        --------
+        >>> from posit import (
+        ...     connect,
+        ... )
+        >>> client = (
+        ...     connect.Client()
+        ... )
+        >>> client.metrics.views.find_one()
+        {'content_guid': '2243770d-ace0-4782-87f9-fe2aeca14fc8', 'user_guid': '434f97ab-4b97-4443-8490-ed1052f37b29', 'variant_key': 'dZnFUBMR', 'rendering_id': '3029259', 'bundle_id': '49747', 'started': '2023-10-27T16:19:40Z', 'ended': '2023-10-27T16:19:40Z', 'data_version': 3, 'path': None}
         """
         return metrics.Metrics(self.config, self.session)
 

--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -99,7 +99,9 @@ class Client:
 
     @property
     def metrics(self) -> metrics.Metrics:
-        """The metrics API interface.
+        """The Metrics API interface.
+
+        The Metrics API is a software interface designed for capturing, retrieving, and managing quantitative data measurements. It is commonly used for monitoring and analyzing system performance, user behavior, and business processes. This API facilitates real-time data collection and accessibility, enabling organizations to make informed decisions based on key performance indicators (KPIs).
 
         Returns
         -------
@@ -107,12 +109,12 @@ class Client:
 
         Examples
         --------
-        >>> from posit import (
-        ...     connect,
-        ... )
+        >>> from posit import connect
         >>> client = connect.Client()
-        >>> client.metrics.views.find_one()
-        {'content_guid': '2243770d-ace0-4782-87f9-fe2aeca14fc8', 'user_guid': '434f97ab-4b97-4443-8490-ed1052f37b29', 'variant_key': 'dZnFUBMR', 'rendering_id': '3029259', 'bundle_id': '49747', 'started': '2023-10-27T16:19:40Z', 'ended': '2023-10-27T16:19:40Z', 'data_version': 3, 'path': None}
+        >>> content_guid = "2243770d-ace0-4782-87f9-fe2aeca14fc8"
+        >>> view_events = client.metrics.views.find(content_guid=content_guid)
+        >>> len(view_events)
+        24
         """
         return metrics.Metrics(self.config, self.session)
 

--- a/src/posit/connect/metrics/__init__.py
+++ b/src/posit/connect/metrics/__init__.py
@@ -1,0 +1,9 @@
+from .. import resources
+
+from . import views
+
+
+class Metrics(resources.Resources):
+    @property
+    def views(self) -> views.Views:
+        return views.Views(self.config, self.session)

--- a/src/posit/connect/metrics/usage.py
+++ b/src/posit/connect/metrics/usage.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from typing import List, overload
 
-from . import urls
+from .. import urls
 
-from .cursors import CursorPaginator
-from .resources import Resource, Resources
+from ..cursors import CursorPaginator
+from ..resources import Resource, Resources
 
 
-class Visit(Resource):
+class UsageEvent(Resource):
     @property
     def content_guid(self) -> str:
         """The associated unique content identifier.
@@ -30,46 +30,24 @@ class Visit(Resource):
         return self["user_guid"]
 
     @property
-    def rendering_id(self) -> int | None:
-        """The render id associated with the visit.
-
-        Returns
-        -------
-        int | None
-            The render id, or None if the associated content type is static.
-        """
-        return self["rendering_id"]
-
-    @property
-    def bundle_id(self) -> int:
-        """The bundle id associated with the visit.
-
-        Returns
-        -------
-        int
-        """
-        return self["bundle_id"]
-
-    @property
-    def variant_key(self) -> str | None:
-        """The variant key associated with the visit.
-
-        Returns
-        -------
-        str | None
-            The variant key, or None if the associated content type is static.
-        """
-        return self.get("variant_key")
-
-    @property
-    def time(self) -> str:
-        """The visit timestamp.
+    def started(self) -> str:
+        """The started timestamp.
 
         Returns
         -------
         str
         """
-        return self["time"]
+        return self["started"]
+
+    @property
+    def ended(self) -> str:
+        """The ended timestamp.
+
+        Returns
+        -------
+        str
+        """
+        return self["ended"]
 
     @property
     def data_version(self) -> int:
@@ -81,18 +59,8 @@ class Visit(Resource):
         """
         return self["data_version"]
 
-    @property
-    def path(self) -> str:
-        """The path requested by the user.
 
-        Returns
-        -------
-        str
-        """
-        return self["path"]
-
-
-class Visits(Resources):
+class Usage(Resources):
     @overload
     def find(
         self,
@@ -100,8 +68,8 @@ class Visits(Resources):
         min_data_version: int = ...,
         start: str = ...,
         end: str = ...,
-    ) -> List[Visit]:
-        """Find visits.
+    ) -> List[UsageEvent]:
+        """Find usage.
 
         Parameters
         ----------
@@ -116,36 +84,36 @@ class Visits(Resources):
 
         Returns
         -------
-        List[Visit]
+        List[UsageEvent]
         """
         ...
 
     @overload
-    def find(self, *args, **kwargs) -> List[Visit]:
-        """Find visits.
+    def find(self, *args, **kwargs) -> List[UsageEvent]:
+        """Find usage.
 
         Returns
         -------
-        List[Visit]
+        List[UsageEvent]
         """
         ...
 
-    def find(self, *args, **kwargs) -> List[Visit]:
-        """Find visits.
+    def find(self, *args, **kwargs) -> List[UsageEvent]:
+        """Find usage.
 
         Returns
         -------
-        List[Visit]
+        List[UsageEvent]
         """
         params = dict(*args, **kwargs)
         params = rename_params(params)
 
-        path = "/v1/instrumentation/content/visits"
+        path = "/v1/instrumentation/shiny/usage"
         url = urls.append(self.config.url, path)
         paginator = CursorPaginator(self.session, url, params=params)
         results = paginator.fetch_results()
         return [
-            Visit(
+            UsageEvent(
                 config=self.config,
                 session=self.session,
                 **result,
@@ -160,8 +128,8 @@ class Visits(Resources):
         min_data_version: int = ...,
         start: str = ...,
         end: str = ...,
-    ) -> Visit | None:
-        """Find a visit.
+    ) -> UsageEvent | None:
+        """Find a usage event.
 
         Parameters
         ----------
@@ -176,37 +144,36 @@ class Visits(Resources):
 
         Returns
         -------
-        Visit | None
-            _description_
+        UsageEvent | None
         """
         ...
 
     @overload
-    def find_one(self, *args, **kwargs) -> Visit | None:
-        """Find a visit.
+    def find_one(self, *args, **kwargs) -> UsageEvent | None:
+        """Find a usage event.
 
         Returns
         -------
-        Visit | None
+        UsageEvent | None
         """
         ...
 
-    def find_one(self, *args, **kwargs) -> Visit | None:
-        """Find a visit.
+    def find_one(self, *args, **kwargs) -> UsageEvent | None:
+        """Find a usage event.
 
         Returns
         -------
-        Visit | None
+        UsageEvent | None
         """
         params = dict(*args, **kwargs)
         params = rename_params(params)
-        path = "/v1/instrumentation/content/visits"
+        path = "/v1/instrumentation/shiny/usage"
         url = urls.append(self.config.url, path)
         paginator = CursorPaginator(self.session, url, params=params)
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)
         visits = (
-            Visit(
+            UsageEvent(
                 config=self.config,
                 session=self.session,
                 **result,

--- a/src/posit/connect/metrics/views.py
+++ b/src/posit/connect/metrics/views.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import itertools
 
-from typing import List
+from typing import List, overload
 
 from requests.sessions import Session as Session
 
@@ -147,7 +147,50 @@ class ViewEvent(resources.Resource):
 
 
 class Views(resources.Resources):
+    @overload
+    def find(
+        self,
+        content_guid: str = ...,
+        min_data_version: int = ...,
+        start: str = ...,
+        end: str = ...,
+    ) -> List[ViewEvent]:
+        """Find view events.
+
+        Parameters
+        ----------
+        content_guid : str, optional
+            Filter by an associated unique content identifer, by default ...
+        min_data_version : int, optional
+            Filter by a minimum data version, by default ...
+        start : str, optional
+            Filter by the start time, by default ...
+        end : str, optional
+            Filter by the end time, by default ...
+
+        Returns
+        -------
+        List[ViewEvent]
+        """
+        ...
+
+    @overload
     def find(self, *args, **kwargs) -> List[ViewEvent]:
+        """Find view events.
+
+        Returns
+        -------
+        List[ViewEvent]
+        """
+        ...
+
+    def find(self, *args, **kwargs) -> List[ViewEvent]:
+        """Find view events.
+
+        Returns
+        -------
+        List[ViewEvent]
+        """
         events = []
         finders = (visits.Visits, usage.Usage)
         for finder in finders:
@@ -160,7 +203,50 @@ class Views(resources.Resources):
             )
         return events
 
+    @overload
+    def find_one(
+        self,
+        content_guid: str = ...,
+        min_data_version: int = ...,
+        start: str = ...,
+        end: str = ...,
+    ) -> ViewEvent | None:
+        """Find a view event.
+
+        Parameters
+        ----------
+        content_guid : str, optional
+            Filter by an associated unique content identifer, by default ...
+        min_data_version : int, optional
+            Filter by a minimum data version, by default ...
+        start : str, optional
+            Filter by the start time, by default ...
+        end : str, optional
+            Filter by the end time, by default ...
+
+        Returns
+        -------
+        Visit | None
+        """
+        ...
+
+    @overload
     def find_one(self, *args, **kwargs) -> ViewEvent | None:
+        """Find a view event.
+
+        Returns
+        -------
+        Visit | None
+        """
+        ...
+
+    def find_one(self, *args, **kwargs) -> ViewEvent | None:
+        """Find a view event.
+
+        Returns
+        -------
+        ViewEvent | None
+        """
         finders = (visits.Visits, usage.Usage)
         for finder in finders:
             instance = finder(self.config, self.session)

--- a/src/posit/connect/metrics/views.py
+++ b/src/posit/connect/metrics/views.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import itertools
+
+from typing import List
+
+from requests.sessions import Session as Session
+
+from . import usage, visits
+
+from .. import resources
+
+
+class ViewEvent(resources.Resource):
+    @staticmethod
+    def from_event(event: visits.VisitEvent | usage.UsageEvent) -> ViewEvent:
+        if type(event) == visits.VisitEvent:
+            return ViewEvent.from_visit_event(event)
+
+        if type(event) == usage.UsageEvent:
+            return ViewEvent.from_usage_event(event)
+
+        raise TypeError
+
+    @staticmethod
+    def from_visit_event(event: visits.VisitEvent) -> ViewEvent:
+        return ViewEvent(
+            event.config,
+            event.session,
+            content_guid=event.content_guid,
+            user_guid=event.user_guid,
+            variant_key=event.variant_key,
+            rendering_id=event.rendering_id,
+            bundle_id=event.bundle_id,
+            started=event.time,
+            ended=event.time,
+            data_version=event.data_version,
+            path=event.path,
+        )
+
+    @staticmethod
+    def from_usage_event(event: usage.UsageEvent) -> ViewEvent:
+        return ViewEvent(
+            event.config,
+            event.session,
+            content_guid=event.content_guid,
+            user_guid=event.user_guid,
+            started=event.started,
+            ended=event.ended,
+            data_version=event.data_version,
+        )
+
+    def __init__(self, config: resources.Config, session: Session, **kwargs):
+        super().__init__(config, session, **kwargs)
+
+    @property
+    def content_guid(self) -> str:
+        """The associated unique content identifier.
+
+        Returns
+        -------
+        str
+        """
+        return self["content_guid"]
+
+    @property
+    def user_guid(self) -> str:
+        """The associated unique user identifier.
+
+        Returns
+        -------
+        str
+        """
+        return self["user_guid"]
+
+    @property
+    def variant_key(self) -> str | None:
+        """The variant key associated with the visit.
+
+        Returns
+        -------
+        str | None
+            The variant key, or None if the associated content type is static.
+        """
+        return self.get("variant_key")
+
+    @property
+    def rendering_id(self) -> int | None:
+        """The render id associated with the visit.
+
+        Returns
+        -------
+        int | None
+            The render id, or None if the associated content type is static.
+        """
+        return self.get("rendering_id")
+
+    @property
+    def bundle_id(self) -> int | None:
+        """The bundle id associated with the visit.
+
+        Returns
+        -------
+        int
+        """
+        return self.get("bundle_id")
+
+    @property
+    def started(self) -> str:
+        """The visit timestamp.
+
+        Returns
+        -------
+        str
+        """
+        return self["started"]
+
+    @property
+    def ended(self) -> str:
+        """The visit timestamp.
+
+        Returns
+        -------
+        str
+        """
+        return self["ended"]
+
+    @property
+    def data_version(self) -> int:
+        """The data version.
+
+        Returns
+        -------
+        int
+        """
+        return self["data_version"]
+
+    @property
+    def path(self) -> str | None:
+        """The path requested by the user.
+
+        Returns
+        -------
+        str
+        """
+        return self.get("path")
+
+
+class Views(resources.Resources):
+    def find(self, *args, **kwargs) -> List[ViewEvent]:
+        events = []
+        finders = (visits.Visits, usage.Usage)
+        for finder in finders:
+            instance = finder(self.config, self.session)
+            events.extend(
+                [
+                    ViewEvent.from_event(event)
+                    for event in instance.find(*args, **kwargs)  # type: ignore[attr-defined]
+                ]
+            )
+        return events
+
+    def find_one(self, *args, **kwargs) -> ViewEvent | None:
+        finders = (visits.Visits, usage.Usage)
+        for finder in finders:
+            instance = finder(self.config, self.session)
+            event = instance.find_one(*args, **kwargs)  # type: ignore[attr-defined]
+            if event:
+                return ViewEvent.from_event(event)
+        return None

--- a/src/posit/connect/metrics/visits.py
+++ b/src/posit/connect/metrics/visits.py
@@ -177,7 +177,6 @@ class Visits(Resources):
         Returns
         -------
         Visit | None
-            _description_
         """
         ...
 

--- a/src/posit/connect/metrics/visits.py
+++ b/src/posit/connect/metrics/visits.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from typing import List, overload
 
-from . import urls
+from .. import urls
 
-from .cursors import CursorPaginator
-from .resources import Resource, Resources
+from ..cursors import CursorPaginator
+from ..resources import Resource, Resources
 
 
-class UsageEvent(Resource):
+class VisitEvent(Resource):
     @property
     def content_guid(self) -> str:
         """The associated unique content identifier.
@@ -30,24 +30,46 @@ class UsageEvent(Resource):
         return self["user_guid"]
 
     @property
-    def started(self) -> str:
-        """The started timestamp.
+    def rendering_id(self) -> int | None:
+        """The render id associated with the visit.
 
         Returns
         -------
-        str
+        int | None
+            The render id, or None if the associated content type is static.
         """
-        return self["started"]
+        return self["rendering_id"]
 
     @property
-    def ended(self) -> str:
-        """The ended timestamp.
+    def bundle_id(self) -> int:
+        """The bundle id associated with the visit.
+
+        Returns
+        -------
+        int
+        """
+        return self["bundle_id"]
+
+    @property
+    def variant_key(self) -> str | None:
+        """The variant key associated with the visit.
+
+        Returns
+        -------
+        str | None
+            The variant key, or None if the associated content type is static.
+        """
+        return self.get("variant_key")
+
+    @property
+    def time(self) -> str:
+        """The visit timestamp.
 
         Returns
         -------
         str
         """
-        return self["ended"]
+        return self["time"]
 
     @property
     def data_version(self) -> int:
@@ -59,8 +81,18 @@ class UsageEvent(Resource):
         """
         return self["data_version"]
 
+    @property
+    def path(self) -> str:
+        """The path requested by the user.
 
-class Usage(Resources):
+        Returns
+        -------
+        str
+        """
+        return self["path"]
+
+
+class Visits(Resources):
     @overload
     def find(
         self,
@@ -68,8 +100,8 @@ class Usage(Resources):
         min_data_version: int = ...,
         start: str = ...,
         end: str = ...,
-    ) -> List[UsageEvent]:
-        """Find usage.
+    ) -> List[VisitEvent]:
+        """Find visits.
 
         Parameters
         ----------
@@ -84,36 +116,36 @@ class Usage(Resources):
 
         Returns
         -------
-        List[UsageEvent]
+        List[Visit]
         """
         ...
 
     @overload
-    def find(self, *args, **kwargs) -> List[UsageEvent]:
-        """Find usage.
+    def find(self, *args, **kwargs) -> List[VisitEvent]:
+        """Find visits.
 
         Returns
         -------
-        List[UsageEvent]
+        List[Visit]
         """
         ...
 
-    def find(self, *args, **kwargs) -> List[UsageEvent]:
-        """Find usage.
+    def find(self, *args, **kwargs) -> List[VisitEvent]:
+        """Find visits.
 
         Returns
         -------
-        List[UsageEvent]
+        List[Visit]
         """
         params = dict(*args, **kwargs)
         params = rename_params(params)
 
-        path = "/v1/instrumentation/shiny/usage"
+        path = "/v1/instrumentation/content/visits"
         url = urls.append(self.config.url, path)
         paginator = CursorPaginator(self.session, url, params=params)
         results = paginator.fetch_results()
         return [
-            UsageEvent(
+            VisitEvent(
                 config=self.config,
                 session=self.session,
                 **result,
@@ -128,8 +160,8 @@ class Usage(Resources):
         min_data_version: int = ...,
         start: str = ...,
         end: str = ...,
-    ) -> UsageEvent | None:
-        """Find a usage event.
+    ) -> VisitEvent | None:
+        """Find a visit.
 
         Parameters
         ----------
@@ -144,36 +176,37 @@ class Usage(Resources):
 
         Returns
         -------
-        UsageEvent | None
+        Visit | None
+            _description_
         """
         ...
 
     @overload
-    def find_one(self, *args, **kwargs) -> UsageEvent | None:
-        """Find a usage event.
+    def find_one(self, *args, **kwargs) -> VisitEvent | None:
+        """Find a visit.
 
         Returns
         -------
-        UsageEvent | None
+        Visit | None
         """
         ...
 
-    def find_one(self, *args, **kwargs) -> UsageEvent | None:
-        """Find a usage event.
+    def find_one(self, *args, **kwargs) -> VisitEvent | None:
+        """Find a visit.
 
         Returns
         -------
-        UsageEvent | None
+        Visit | None
         """
         params = dict(*args, **kwargs)
         params = rename_params(params)
-        path = "/v1/instrumentation/shiny/usage"
+        path = "/v1/instrumentation/content/visits"
         url = urls.append(self.config.url, path)
         paginator = CursorPaginator(self.session, url, params=params)
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)
         visits = (
-            UsageEvent(
+            VisitEvent(
                 config=self.config,
                 session=self.session,
                 **result,

--- a/src/posit/connect/resources.py
+++ b/src/posit/connect/resources.py
@@ -1,14 +1,9 @@
-import warnings
-
-from abc import ABC, abstractmethod
-from typing import Any, Generic, List, Optional, TypeVar
+from abc import ABC
+from typing import Any
 
 import requests
 
 from .config import Config
-
-
-T = TypeVar("T")
 
 
 class Resource(ABC, dict):

--- a/tests/posit/connect/metrics/test_views.py
+++ b/tests/posit/connect/metrics/test_views.py
@@ -1,0 +1,286 @@
+import pytest
+import responses
+
+from responses import matchers
+
+from posit import connect
+from posit.connect.metrics import views, visits, usage
+
+
+from ..api import load_mock  # type: ignore
+
+
+class TestViewEventFromEvent:
+    def test(self):
+        with pytest.raises(TypeError):
+            views.ViewEvent.from_event(None)
+
+
+class TestViewEventFromVisitEvent:
+    def setup_class(cls):
+        visit_event = visits.VisitEvent(
+            None,
+            None,
+            **load_mock("v1/instrumentation/content/visits?limit=500.json")[
+                "results"
+            ][0],
+        )
+        cls.view_event = views.ViewEvent.from_visit_event(visit_event)
+
+    def test_content_guid(self):
+        assert (
+            self.view_event.content_guid
+            == "bd1d2285-6c80-49af-8a83-a200effe3cb3"
+        )
+
+    def test_user_guid(self):
+        assert (
+            self.view_event.user_guid == "08e3a41d-1f8e-47f2-8855-f05ea3b0d4b2"
+        )
+
+    def test_variant_key(self):
+        assert self.view_event.variant_key == "HidI2Kwq"
+
+    def test_rendering_id(self):
+        assert self.view_event.rendering_id == 7
+
+    def test_bundle_id(self):
+        assert self.view_event.bundle_id == 33
+
+    def test_started(self):
+        assert self.view_event.started == "2018-09-15T18:00:00-05:00"
+
+    def test_ended(self):
+        assert self.view_event.ended == "2018-09-15T18:00:00-05:00"
+
+    def test_data_version(self):
+        assert self.view_event.data_version == 1
+
+    def test_path(self):
+        assert self.view_event.path == "/logs"
+
+
+class TestViewEventFromUsageEvent:
+    def setup_class(cls):
+        visit_event = usage.UsageEvent(
+            None,
+            None,
+            **load_mock("v1/instrumentation/shiny/usage?limit=500.json")[
+                "results"
+            ][0],
+        )
+        cls.view_event = views.ViewEvent.from_usage_event(visit_event)
+
+    def test_content_guid(self):
+        assert (
+            self.view_event.content_guid
+            == "bd1d2285-6c80-49af-8a83-a200effe3cb3"
+        )
+
+    def test_user_guid(self):
+        assert (
+            self.view_event.user_guid == "08e3a41d-1f8e-47f2-8855-f05ea3b0d4b2"
+        )
+
+    def test_variant_key(self):
+        assert self.view_event.variant_key is None
+
+    def test_rendering_id(self):
+        assert self.view_event.rendering_id is None
+
+    def test_bundle_id(self):
+        assert self.view_event.bundle_id is None
+
+    def test_started(self):
+        assert self.view_event.started == "2018-09-15T18:00:00-05:00"
+
+    def test_ended(self):
+        assert self.view_event.ended == "2018-09-15T18:01:00-05:00"
+
+    def test_data_version(self):
+        assert self.view_event.data_version == 1
+
+    def test_path(self):
+        assert self.view_event.path is None
+
+
+class TestViewsFind:
+    @responses.activate
+    def test(self):
+        # behavior
+        mock_get = [None] * 4
+
+        mock_get[0] = responses.get(
+            f"https://connect.example/__api__/v1/instrumentation/content/visits",
+            json=load_mock("v1/instrumentation/content/visits?limit=500.json"),
+            match=[
+                matchers.query_param_matcher(
+                    {
+                        "limit": 500,
+                    }
+                )
+            ],
+        )
+
+        mock_get[1] = responses.get(
+            f"https://connect.example/__api__/v1/instrumentation/content/visits",
+            json=load_mock(
+                "v1/instrumentation/content/visits?limit=500&next=23948901087.json"
+            ),
+            match=[
+                matchers.query_param_matcher(
+                    {
+                        "next": "23948901087",
+                        "limit": 500,
+                    }
+                )
+            ],
+        )
+
+        mock_get[2] = responses.get(
+            f"https://connect.example/__api__/v1/instrumentation/shiny/usage",
+            json=load_mock("v1/instrumentation/shiny/usage?limit=500.json"),
+            match=[
+                matchers.query_param_matcher(
+                    {
+                        "limit": 500,
+                    }
+                )
+            ],
+        )
+
+        mock_get[3] = responses.get(
+            f"https://connect.example/__api__/v1/instrumentation/shiny/usage",
+            json=load_mock(
+                "v1/instrumentation/shiny/usage?limit=500&next=23948901087.json"
+            ),
+            match=[
+                matchers.query_param_matcher(
+                    {
+                        "next": "23948901087",
+                        "limit": 500,
+                    }
+                )
+            ],
+        )
+
+        # setup
+        c = connect.Client("12345", "https://connect.example")
+
+        # invoke
+        events = c.metrics.views.find()
+
+        # assert
+        assert mock_get[0].call_count == 1
+        assert mock_get[1].call_count == 1
+        assert mock_get[2].call_count == 1
+        assert mock_get[3].call_count == 1
+        assert len(events) == 2
+
+
+class TestViewsFindOne:
+    @responses.activate
+    def test(self):
+        # behavior
+        mock_get = [None] * 4
+
+        mock_get[0] = responses.get(
+            f"https://connect.example/__api__/v1/instrumentation/content/visits",
+            json=load_mock("v1/instrumentation/content/visits?limit=500.json"),
+            match=[
+                matchers.query_param_matcher(
+                    {
+                        "limit": 500,
+                    }
+                )
+            ],
+        )
+
+        mock_get[1] = responses.get(
+            f"https://connect.example/__api__/v1/instrumentation/content/visits",
+            json=load_mock(
+                "v1/instrumentation/content/visits?limit=500&next=23948901087.json"
+            ),
+            match=[
+                matchers.query_param_matcher(
+                    {
+                        "next": "23948901087",
+                        "limit": 500,
+                    }
+                )
+            ],
+        )
+
+        mock_get[2] = responses.get(
+            f"https://connect.example/__api__/v1/instrumentation/shiny/usage",
+            json=load_mock("v1/instrumentation/shiny/usage?limit=500.json"),
+            match=[
+                matchers.query_param_matcher(
+                    {
+                        "limit": 500,
+                    }
+                )
+            ],
+        )
+
+        mock_get[3] = responses.get(
+            f"https://connect.example/__api__/v1/instrumentation/shiny/usage",
+            json=load_mock(
+                "v1/instrumentation/shiny/usage?limit=500&next=23948901087.json"
+            ),
+            match=[
+                matchers.query_param_matcher(
+                    {
+                        "next": "23948901087",
+                        "limit": 500,
+                    }
+                )
+            ],
+        )
+
+        # setup
+        c = connect.Client("12345", "https://connect.example")
+
+        # invoke
+        view_event = c.metrics.views.find_one()
+
+        # assert
+        assert mock_get[0].call_count == 1
+        assert mock_get[1].call_count == 0
+        assert mock_get[2].call_count == 0
+        assert mock_get[3].call_count == 0
+        assert view_event
+        assert (
+            view_event.content_guid == "bd1d2285-6c80-49af-8a83-a200effe3cb3"
+        )
+
+    @responses.activate
+    def test_none(self):
+        # behavior
+        mock_get = [None] * 2
+
+        # return an empty result set to push through the iterator
+        mock_get[0] = responses.get(
+            f"https://connect.example/__api__/v1/instrumentation/content/visits",
+            json=load_mock(
+                "v1/instrumentation/content/visits?limit=500&next=23948901087.json"
+            ),
+        )
+
+        mock_get[1] = responses.get(
+            f"https://connect.example/__api__/v1/instrumentation/shiny/usage",
+            json=load_mock(
+                "v1/instrumentation/shiny/usage?limit=500&next=23948901087.json"
+            ),
+        )
+
+        # setup
+        c = connect.Client("12345", "https://connect.example")
+
+        # invoke
+        view_event = c.metrics.views.find_one(content_guid="not-found")
+
+        # assert
+        assert mock_get[0].call_count == 1
+        assert mock_get[1].call_count == 1
+        assert view_event is None

--- a/tests/posit/connect/metrics/test_visits.py
+++ b/tests/posit/connect/metrics/test_visits.py
@@ -1,49 +1,59 @@
 import responses
+import requests
 
 from responses import matchers
 
-from posit.connect import Client
-from posit.connect.usage import UsageEvent, rename_params
+from posit.connect import Client, config
+from posit.connect.metrics import visits
 
-from .api import load_mock  # type: ignore
+from ..api import load_mock  # type: ignore
 
 
-class TestUsageEventAttributes:
+class TestVisitAttributes:
     def setup_class(cls):
-        cls.event = UsageEvent(
+        cls.visit = visits.VisitEvent(
             None,
             None,
-            **load_mock("v1/instrumentation/shiny/usage?limit=500.json")[
+            **load_mock("v1/instrumentation/content/visits?limit=500.json")[
                 "results"
             ][0],
         )
 
     def test_content_guid(self):
         assert (
-            self.event.content_guid == "bd1d2285-6c80-49af-8a83-a200effe3cb3"
+            self.visit.content_guid == "bd1d2285-6c80-49af-8a83-a200effe3cb3"
         )
 
     def test_user_guid(self):
-        assert self.event.user_guid == "08e3a41d-1f8e-47f2-8855-f05ea3b0d4b2"
+        assert self.visit.user_guid == "08e3a41d-1f8e-47f2-8855-f05ea3b0d4b2"
 
-    def test_started(self):
-        assert self.event.started == "2018-09-15T18:00:00-05:00"
+    def test_variant_key(self):
+        assert self.visit.variant_key == "HidI2Kwq"
 
-    def test_ended(self):
-        assert self.event.ended == "2018-09-15T18:01:00-05:00"
+    def test_rendering_id(self):
+        assert self.visit.rendering_id == 7
+
+    def test_bundle_id(self):
+        assert self.visit.bundle_id == 33
+
+    def test_time(self):
+        assert self.visit.time == "2018-09-15T18:00:00-05:00"
 
     def test_data_version(self):
-        assert self.event.data_version == 1
+        assert self.visit.data_version == 1
+
+    def test_path(self):
+        assert self.visit.path == "/logs"
 
 
-class TestUsageFind:
+class TestVisitsFind:
     @responses.activate
     def test(self):
         # behavior
         mock_get = [None] * 2
         mock_get[0] = responses.get(
-            f"https://connect.example/__api__/v1/instrumentation/shiny/usage",
-            json=load_mock("v1/instrumentation/shiny/usage?limit=500.json"),
+            f"https://connect.example/__api__/v1/instrumentation/content/visits",
+            json=load_mock("v1/instrumentation/content/visits?limit=500.json"),
             match=[
                 matchers.query_param_matcher(
                     {
@@ -54,9 +64,9 @@ class TestUsageFind:
         )
 
         mock_get[1] = responses.get(
-            f"https://connect.example/__api__/v1/instrumentation/shiny/usage",
+            f"https://connect.example/__api__/v1/instrumentation/content/visits",
             json=load_mock(
-                "v1/instrumentation/shiny/usage?limit=500&next=23948901087.json"
+                "v1/instrumentation/content/visits?limit=500&next=23948901087.json"
             ),
             match=[
                 matchers.query_param_matcher(
@@ -69,25 +79,26 @@ class TestUsageFind:
         )
 
         # setup
-        c = Client("12345", "https://connect.example")
+        c = config.Config("12345", "https://connect.example")
+        session = requests.Session()
 
         # invoke
-        usage = c.usage.find()
+        events = visits.Visits(c, session).find()
 
         # assert
         assert mock_get[0].call_count == 1
         assert mock_get[1].call_count == 1
-        assert len(usage) == 1
+        assert len(events) == 1
 
 
-class TestUsageFindOne:
+class TestVisitsFindOne:
     @responses.activate
     def test(self):
         # behavior
         mock_get = [None] * 2
         mock_get[0] = responses.get(
-            f"https://connect.example/__api__/v1/instrumentation/shiny/usage",
-            json=load_mock("v1/instrumentation/shiny/usage?limit=500.json"),
+            f"https://connect.example/__api__/v1/instrumentation/content/visits",
+            json=load_mock("v1/instrumentation/content/visits?limit=500.json"),
             match=[
                 matchers.query_param_matcher(
                     {
@@ -98,9 +109,9 @@ class TestUsageFindOne:
         )
 
         mock_get[1] = responses.get(
-            f"https://connect.example/__api__/v1/instrumentation/shiny/usage",
+            f"https://connect.example/__api__/v1/instrumentation/content/visits",
             json=load_mock(
-                "v1/instrumentation/shiny/usage?limit=500&next=23948901087.json"
+                "v1/instrumentation/content/visits?limit=500&next=23948901087.json"
             ),
             match=[
                 matchers.query_param_matcher(
@@ -113,10 +124,11 @@ class TestUsageFindOne:
         )
 
         # setup
-        c = Client("12345", "https://connect.example")
+        c = config.Config("12345", "https://connect.example")
+        session = requests.Session()
 
         # invoke
-        event = c.usage.find_one()
+        event = visits.Visits(c, session).find_one()
 
         # assert
         assert mock_get[0].call_count == 1
@@ -128,12 +140,12 @@ class TestUsageFindOne:
 class TestRenameParams:
     def test_start_to_from(self):
         params = {"start": ...}
-        params = rename_params(params)
+        params = visits.rename_params(params)
         assert "start" not in params
         assert "from" in params
 
     def test_end_to_to(self):
         params = {"end": ...}
-        params = rename_params(params)
+        params = visits.rename_params(params)
         assert "end" not in params
         assert "to" in params


### PR DESCRIPTION
The `metrics.views` package coalesces the existing instrumentation APIs into a single interface. The new event type `metrics.views.ViewEvent` encapsulates the `metrics.usage.UsageEvent` and `metrics.visits.VisitEvent`. The `ViewEvent` schema is a mashup of the two underlying schemas, with the exception of the `time` field on `VisitEvent`. In `ViewEvent` this field is removed and mapped to `started` and `ended`.  Otherwise, fields that do not exist in the underlying schema return `None`. 

Resolves #137 