### PR TITLE
feat: add dataclass to represent ContentItem owner

### DIFF
--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -15,6 +15,26 @@ from .permissions import Permissions
 from .resources import Resources, Resource
 
 
+class ContentItemOwner(Resource):
+    """The owner of a piece of content."""
+
+    @property
+    def guid(self) -> str:
+        return self.get("guid")  # type: ignore
+
+    @property
+    def username(self) -> str:
+        return self.get("username")  # type: ignore
+
+    @property
+    def first_name(self) -> Optional[str]:
+        return self.get("first_name")  # type: ignore
+
+    @property
+    def last_name(self) -> Optional[str]:
+        return self.get("last_name")  # type: ignore
+
+
 class ContentItem(Resource):
     """A piece of content."""
 
@@ -191,7 +211,7 @@ class ContentItem(Resource):
         return self.get("owner_guid")  # type: ignore
 
     @property
-    def owner(self) -> str:
+    def owner(self) -> ContentItemOwner:
         return self.get("owner", {})  # type: ignore
 
     @property


### PR DESCRIPTION
Addresses the owner property of ContentItem as discussed in #165 

I ran all the steps required plus a manual test with the following output:

```python
from posit.connect import Client

with Client() as client:
  all_content = client.content.find()
  print(all_content[0].owner)
# {'guid': '867f7ef5-6cb4-4a4d-908d-21f7ccacf273', 'username': 'michael.beigelmacher@posit.co', 'first_name': 'Michael', 'last_name': 'Beigelmacher'}
```