### PR TITLE
feat: Check for X-Deprecated-Endpoint header

### DIFF
--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -5,15 +5,13 @@ from __future__ import annotations
 from requests import Response, Session
 from typing import Optional
 
-from . import config, hooks, me, metrics, tasks, urls
+from . import hooks, me, metrics, tasks, urls
 
 from .auth import Auth
 from .config import Config
 from .oauth import OAuthIntegration
 from .content import Content
-from .metrics.shiny_usage import ShinyUsage
 from .users import User, Users
-from .metrics.visits import Visits
 
 
 class Client:
@@ -37,6 +35,8 @@ class Client:
         session = Session()
         # Authenticate the session using the provided Config.
         session.auth = Auth(config=self.config)
+        # Add hook for checking for deprecation warnings.
+        session.hooks["response"].append(hooks.check_for_deprecation_header)
         # Add error handling hooks to the session.
         session.hooks["response"].append(hooks.handle_errors)
 

--- a/src/posit/connect/hooks.py
+++ b/src/posit/connect/hooks.py
@@ -1,3 +1,5 @@
+import warnings
+
 from http.client import responses
 from requests import JSONDecodeError, Response
 
@@ -12,10 +14,27 @@ def handle_errors(response: Response, *args, **kwargs) -> Response:
             message = data["error"]
             http_status = response.status_code
             http_status_message = responses[http_status]
-            raise ClientError(
-                error_code, message, http_status, http_status_message
-            )
+            raise ClientError(error_code, message, http_status, http_status_message)
         except JSONDecodeError:
             # No JSON error message from Connect, so just raise
             response.raise_for_status()
+    return response
+
+
+def check_for_deprecation_header(response: Response, *args, **kwargs) -> Response:
+    """
+    Check for deprecation warnings from the server.
+
+    You might get these if you've upgraded the Connect server but not posit-sdk.
+    posit-sdk will make the right request based on the version of the server,
+    but if you have an old version of the package, it won't know the new URL
+    to request.
+    """
+    if "X-Deprecated-Endpoint" in response.headers:
+        msg = (
+            response.url
+            + " is deprecated and will be removed in a future version of Connect."
+            + " Please upgrade `posit-sdk` in order to use the new APIs."
+        )
+        warnings.warn(msg, DeprecationWarning)
     return response

--- a/tests/posit/connect/test_hooks.py
+++ b/tests/posit/connect/test_hooks.py
@@ -1,10 +1,12 @@
 import io
 
 import pytest
+import responses
 
 from requests import HTTPError, Response
 from unittest.mock import Mock, patch
 
+from posit.connect import Client
 from posit.connect.errors import ClientError
 from posit.connect.hooks import handle_errors
 
@@ -64,3 +66,14 @@ def test_response_client_error_without_payload():
     response.raw = io.BytesIO(b"Plain text 404 Not Found")
     with pytest.raises(HTTPError):
         handle_errors(response)
+
+
+@responses.activate
+def test_deprecation_warning():
+    responses.get(
+        "https://connect.example/__api__/v0", headers={"X-Deprecated-Endpoint": "v1/"}
+    )
+    c = Client("12345", "https://connect.example")
+
+    with pytest.warns(DeprecationWarning):
+        c.get("v0")


### PR DESCRIPTION
Analogous to https://github.com/rstudio/connectapi/pull/268. `posit-sdk` shouldn't be calling deprecated endpoints--when we deprecate endpoints that it uses, we'll make sure to check the Connect server version and call the correct endpoints accordingly, so that it only calls deprecated endpoints on older Connect versions where they aren't deprecated. The only circumstance where `posit-sdk` would hit a deprecated endpoint would be if you're pointing at a newer version of Connect but an old version of`posit-sdk` that doesn't know about the new, non-deprecated endpoints. So, when receiving a X-Deprecated-Endpoint response header, the recommendation to the user is to upgrade `posit-sdk`.