### PR TITLE
docs: set development status to alpha

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.8"
 license = { file = "LICENSE" }
 keywords = ["posit", "sdk"]
 classifiers = [
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
This is arbitrary, but I believe we have moved a pre-alpha state to alpha an alpha state. This information will be visible in  on PyPI on the next release.