### PR TITLE
refactor: context pattern

### DIFF
--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -156,12 +156,12 @@ class Client:
             if "url" in kwargs and isinstance(kwargs["url"], str):
                 url = kwargs["url"]
 
-        cfg = Config(api_key=api_key, url=url)
+        self.cfg = Config(api_key=api_key, url=url)
         session = Session()
-        session.auth = Auth(config=cfg)
+        session.auth = Auth(config=self.cfg)
         session.hooks["response"].append(hooks.check_for_deprecation_header)
         session.hooks["response"].append(hooks.handle_errors)
-        self.ctx = Context(api_key=cfg.api_key, session=session, url=cfg.url)
+        self.ctx = Context(session=session, url=self.cfg.url)
 
     @property
     def version(self) -> str:
@@ -197,7 +197,7 @@ class Client:
         OAuthIntegration
             The OAuth integration instance.
         """
-        return OAuthIntegration(self.ctx)
+        return OAuthIntegration(self.ctx, self.cfg.api_key)
 
     @property
     def groups(self) -> Groups:

--- a/src/posit/connect/context.py
+++ b/src/posit/connect/context.py
@@ -5,6 +5,20 @@ import requests
 
 @dataclass(frozen=True)
 class Context:
-    api_key: str
+    """Context for information shared across the resource stack.
+
+    Attributes
+    ----------
+        session: request.Session
+        url: str
+            The Connect API URL (e.g., 'https://connect.example.com/__api__')
+
+    Notes
+    -----
+    This class should only contain attributes that are common across all resources.
+
+    Adding attributes for convenience that are not required by all resources is an anti-pattern.
+    """
+
     session: requests.Session
     url: str

--- a/src/posit/connect/context.py
+++ b/src/posit/connect/context.py
@@ -1,12 +1,10 @@
-from typing import Final
+from dataclasses import dataclass
 
 import requests
 
 
+@dataclass(frozen=True)
 class Context:
-    def __init__(
-        self, *, api_key: str, session: requests.Session, url: str
-    ) -> None:
-        self.api_key: Final[str] = api_key
-        self.session: Final[requests.Session] = session
-        self.url: Final[str] = url
+    api_key: str
+    session: requests.Session
+    url: str

--- a/src/posit/connect/context.py
+++ b/src/posit/connect/context.py
@@ -1,0 +1,10 @@
+import requests
+
+
+class Context:
+    def __init__(
+        self, *, api_key: str, session: requests.Session, url: str
+    ) -> None:
+        self.api_key = api_key
+        self.session = session
+        self.url = url

--- a/src/posit/connect/context.py
+++ b/src/posit/connect/context.py
@@ -1,3 +1,5 @@
+from typing import Final
+
 import requests
 
 
@@ -5,6 +7,6 @@ class Context:
     def __init__(
         self, *, api_key: str, session: requests.Session, url: str
     ) -> None:
-        self.api_key = api_key
-        self.session = session
-        self.url = url
+        self.api_key: Final[str] = api_key
+        self.session: Final[requests.Session] = session
+        self.url: Final[str] = url

--- a/src/posit/connect/cursors.py
+++ b/src/posit/connect/cursors.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, make_dataclass
 from typing import Generator, List
 
-import requests
+from .context import Context
 
 # The maximum page size supported by the API.
 _MAX_PAGE_SIZE = 500
@@ -16,10 +16,8 @@ class CursorPage:
 
 
 class CursorPaginator:
-    def __init__(
-        self, session: requests.Session, url: str, params: dict = {}
-    ) -> None:
-        self.session = session
+    def __init__(self, ctx: Context, url: str, params: dict = {}) -> None:
+        self.ctx = ctx
         self.url = url
         self.params = params
 
@@ -72,5 +70,5 @@ class CursorPaginator:
             "next": next,
             "limit": _MAX_PAGE_SIZE,
         }
-        response = self.session.get(self.url, params=params)
+        response = self.ctx.session.get(self.url, params=params)
         return CursorPage(**response.json())

--- a/src/posit/connect/groups.py
+++ b/src/posit/connect/groups.py
@@ -39,16 +39,12 @@ class Group(Resource):
     def delete(self) -> None:
         """Delete the group."""
         path = f"v1/groups/{self.guid}"
-        url = urls.append(self.config.url, path)
-        self.session.delete(url)
+        url = urls.append(self.ctx.url, path)
+        self.ctx.session.delete(url)
 
 
 class Groups(Resources):
     """Groups resource."""
-
-    def __init__(self, config: Config, session: requests.Session) -> None:
-        self.config = config
-        self.session = session
 
     @overload
     def create(self, name: str, unique_id: str | None) -> Group:
@@ -90,9 +86,9 @@ class Groups(Resources):
         ...
         body = dict(*args, **kwargs)
         path = "v1/groups"
-        url = urls.append(self.config.url, path)
-        response = self.session.post(url, json=body)
-        return Group(self.config, self.session, **response.json())
+        url = urls.append(self.ctx.url, path)
+        response = self.ctx.session.post(url, json=body)
+        return Group(self.ctx, **response.json())
 
     @overload
     def find(
@@ -117,13 +113,12 @@ class Groups(Resources):
         """
         params = dict(*args, **kwargs)
         path = "v1/groups"
-        url = urls.append(self.config.url, path)
-        paginator = Paginator(self.session, url, params=params)
+        url = urls.append(self.ctx.url, path)
+        paginator = Paginator(self.ctx, url, params=params)
         results = paginator.fetch_results()
         return [
             Group(
-                config=self.config,
-                session=self.session,
+                self.ctx,
                 **result,
             )
             for result in results
@@ -152,14 +147,13 @@ class Groups(Resources):
         """
         params = dict(*args, **kwargs)
         path = "v1/groups"
-        url = urls.append(self.config.url, path)
-        paginator = Paginator(self.session, url, params=params)
+        url = urls.append(self.ctx.url, path)
+        paginator = Paginator(self.ctx, url, params=params)
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)
         groups = (
             Group(
-                config=self.config,
-                session=self.session,
+                self.ctx,
                 **result,
             )
             for result in results
@@ -177,11 +171,10 @@ class Groups(Resources):
         -------
         Group
         """
-        url = urls.append(self.config.url, f"v1/groups/{guid}")
-        response = self.session.get(url)
+        url = urls.append(self.ctx.url, f"v1/groups/{guid}")
+        response = self.ctx.session.get(url)
         return Group(
-            config=self.config,
-            session=self.session,
+            self.ctx,
             **response.json(),
         )
 
@@ -193,8 +186,8 @@ class Groups(Resources):
         int
         """
         path = "v1/groups"
-        url = urls.append(self.config.url, path)
-        response: requests.Response = self.session.get(
+        url = urls.append(self.ctx.url, path)
+        response: requests.Response = self.ctx.session.get(
             url, params={"page_size": 1}
         )
         result: dict = response.json()

--- a/src/posit/connect/me.py
+++ b/src/posit/connect/me.py
@@ -1,23 +1,22 @@
-import requests
-
 from . import urls
 
-from .config import Config
+from .context import Context
 from .users import User
 
 
-def get(config: Config, session: requests.Session) -> User:
-    """
-    Gets the current user.
+def get(ctx: Context) -> User:
+    """Get the current user.
 
-    Args:
-        config (Config): The configuration object containing the URL.
-        session (requests.Session): The session object used for making HTTP requests.
+    Get the user information from Connect for the user assumed via the provided API key.
+
+    Parameters
+    ----------
+    ctx : Context
 
     Returns
     -------
-        User: The current user.
+    User
     """
-    url = urls.append(config.url, "v1/user")
-    response = session.get(url)
-    return User(config, session, **response.json())
+    url = urls.append(ctx.url, "v1/user")
+    response = ctx.session.get(url)
+    return User(ctx, **response.json())

--- a/src/posit/connect/metrics/__init__.py
+++ b/src/posit/connect/metrics/__init__.py
@@ -17,4 +17,4 @@ class Metrics(resources.Resources):
 
     @property
     def usage(self) -> Usage:
-        return Usage(self.config, self.session)
+        return Usage(self.ctx)

--- a/src/posit/connect/metrics/shiny_usage.py
+++ b/src/posit/connect/metrics/shiny_usage.py
@@ -109,13 +109,12 @@ class ShinyUsage(Resources):
         params = rename_params(params)
 
         path = "/v1/instrumentation/shiny/usage"
-        url = urls.append(self.config.url, path)
-        paginator = CursorPaginator(self.session, url, params=params)
+        url = urls.append(self.ctx.url, path)
+        paginator = CursorPaginator(self.ctx, url, params=params)
         results = paginator.fetch_results()
         return [
             ShinyUsageEvent(
-                config=self.config,
-                session=self.session,
+                self.ctx,
                 **result,
             )
             for result in results
@@ -168,14 +167,13 @@ class ShinyUsage(Resources):
         params = dict(*args, **kwargs)
         params = rename_params(params)
         path = "/v1/instrumentation/shiny/usage"
-        url = urls.append(self.config.url, path)
-        paginator = CursorPaginator(self.session, url, params=params)
+        url = urls.append(self.ctx.url, path)
+        paginator = CursorPaginator(self.ctx, url, params=params)
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)
         visits = (
             ShinyUsageEvent(
-                config=self.config,
-                session=self.session,
+                self.ctx,
                 **result,
             )
             for result in results

--- a/src/posit/connect/metrics/usage.py
+++ b/src/posit/connect/metrics/usage.py
@@ -27,8 +27,7 @@ class UsageEvent(resources.Resource):
     @staticmethod
     def from_visit_event(event: visits.VisitEvent) -> UsageEvent:
         return UsageEvent(
-            event.config,
-            event.session,
+            event.ctx,
             content_guid=event.content_guid,
             user_guid=event.user_guid,
             variant_key=event.variant_key,
@@ -45,8 +44,7 @@ class UsageEvent(resources.Resource):
         event: shiny_usage.ShinyUsageEvent,
     ) -> UsageEvent:
         return UsageEvent(
-            event.config,
-            event.session,
+            event.ctx,
             content_guid=event.content_guid,
             user_guid=event.user_guid,
             variant_key=None,
@@ -57,9 +55,6 @@ class UsageEvent(resources.Resource):
             data_version=event.data_version,
             path=None,
         )
-
-    def __init__(self, config: resources.Config, session: Session, **kwargs):
-        super().__init__(config, session, **kwargs)
 
     @property
     def content_guid(self) -> str:
@@ -204,7 +199,7 @@ class Usage(resources.Resources):
         events = []
         finders = (visits.Visits, shiny_usage.ShinyUsage)
         for finder in finders:
-            instance = finder(self.config, self.session)
+            instance = finder(self.ctx)
             events.extend(
                 [
                     UsageEvent.from_event(event)
@@ -259,7 +254,7 @@ class Usage(resources.Resources):
         """
         finders = (visits.Visits, shiny_usage.ShinyUsage)
         for finder in finders:
-            instance = finder(self.config, self.session)
+            instance = finder(self.ctx)
             event = instance.find_one(*args, **kwargs)  # type: ignore[attr-defined]
             if event:
                 return UsageEvent.from_event(event)

--- a/src/posit/connect/metrics/visits.py
+++ b/src/posit/connect/metrics/visits.py
@@ -141,13 +141,12 @@ class Visits(Resources):
         params = rename_params(params)
 
         path = "/v1/instrumentation/content/visits"
-        url = urls.append(self.config.url, path)
-        paginator = CursorPaginator(self.session, url, params=params)
+        url = urls.append(self.ctx.url, path)
+        paginator = CursorPaginator(self.ctx, url, params=params)
         results = paginator.fetch_results()
         return [
             VisitEvent(
-                config=self.config,
-                session=self.session,
+                self.ctx,
                 **result,
             )
             for result in results
@@ -200,14 +199,13 @@ class Visits(Resources):
         params = dict(*args, **kwargs)
         params = rename_params(params)
         path = "/v1/instrumentation/content/visits"
-        url = urls.append(self.config.url, path)
-        paginator = CursorPaginator(self.session, url, params=params)
+        url = urls.append(self.ctx.url, path)
+        paginator = CursorPaginator(self.ctx, url, params=params)
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)
         visits = (
             VisitEvent(
-                config=self.config,
-                session=self.session,
+                self.ctx,
                 **result,
             )
             for result in results

--- a/src/posit/connect/oauth.py
+++ b/src/posit/connect/oauth.py
@@ -14,9 +14,10 @@ class Credentials(TypedDict, total=False):
 
 
 class OAuthIntegration:
-    def __init__(self, ctx: Context) -> None:
-        self.url = urls.append(ctx.url, "v1/oauth/integrations/credentials")
+    def __init__(self, ctx: Context, api_key: str) -> None:
         self.ctx = ctx
+        self.api_key = api_key
+        self.url = urls.append(ctx.url, "v1/oauth/integrations/credentials")
 
     def get_credentials(
         self, user_session_token: Optional[str] = None
@@ -26,7 +27,7 @@ class OAuthIntegration:
         data = dict()
         data["grant_type"] = "urn:ietf:params:oauth:grant-type:token-exchange"
         data["subject_token_type"] = "urn:posit:connect:api-key"
-        data["subject_token"] = self.ctx.api_key
+        data["subject_token"] = self.api_key
 
         # if this content is running on Connect, then it is allowed to request
         # the content viewer's credentials

--- a/src/posit/connect/oauth.py
+++ b/src/posit/connect/oauth.py
@@ -4,7 +4,7 @@ from requests import Session
 from typing import Optional, TypedDict
 
 from . import urls
-from .config import Config
+from .context import Context
 
 
 class Credentials(TypedDict, total=False):
@@ -14,10 +14,9 @@ class Credentials(TypedDict, total=False):
 
 
 class OAuthIntegration:
-    def __init__(self, config: Config, session: Session) -> None:
-        self.url = urls.append(config.url, "v1/oauth/integrations/credentials")
-        self.config = config
-        self.session = session
+    def __init__(self, ctx: Context) -> None:
+        self.url = urls.append(ctx.url, "v1/oauth/integrations/credentials")
+        self.ctx = ctx
 
     def get_credentials(
         self, user_session_token: Optional[str] = None
@@ -27,7 +26,7 @@ class OAuthIntegration:
         data = dict()
         data["grant_type"] = "urn:ietf:params:oauth:grant-type:token-exchange"
         data["subject_token_type"] = "urn:posit:connect:api-key"
-        data["subject_token"] = self.config.api_key
+        data["subject_token"] = self.ctx.api_key
 
         # if this content is running on Connect, then it is allowed to request
         # the content viewer's credentials
@@ -35,5 +34,5 @@ class OAuthIntegration:
             data["subject_token_type"] = "urn:posit:connect:user-session-token"
             data["subject_token"] = user_session_token
 
-        response = self.session.post(self.url, data=data)
+        response = self.ctx.session.post(self.url, data=data)
         return Credentials(**response.json())

--- a/src/posit/connect/paginator.py
+++ b/src/posit/connect/paginator.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
 from typing import Generator, List
 
-import requests
-
+from .context import Context
 
 # The maximum page size supported by the API.
 _MAX_PAGE_SIZE = 500
@@ -39,10 +38,8 @@ class Paginator:
         url (str): The URL of the paginated API endpoint.
     """
 
-    def __init__(
-        self, session: requests.Session, url: str, params: dict = {}
-    ) -> None:
-        self.session = session
+    def __init__(self, ctx: Context, url: str, params: dict = {}) -> None:
+        self.ctx = ctx
         self.url = url
         self.params = params
 
@@ -103,5 +100,5 @@ class Paginator:
             "page_number": page_number,
             "page_size": _MAX_PAGE_SIZE,
         }
-        response = self.session.get(self.url, params=params)
+        response = self.ctx.session.get(self.url, params=params)
         return Page(**response.json())

--- a/src/posit/connect/permissions.py
+++ b/src/posit/connect/permissions.py
@@ -8,7 +8,7 @@ from requests.sessions import Session as Session
 
 from . import urls
 
-from .config import Config
+from .context import Context
 from .resources import Resource, Resources
 
 
@@ -36,8 +36,8 @@ class Permission(Resource):
     def delete(self) -> None:
         """Delete the permission."""
         path = f"v1/content/{self.content_guid}/permissions/{self.id}"
-        url = urls.append(self.config.url, path)
-        self.session.delete(url)
+        url = urls.append(self.ctx.url, path)
+        self.ctx.session.delete(url)
 
     @overload
     def update(self, role: str) -> None:
@@ -64,8 +64,8 @@ class Permission(Resource):
         }
         body.update(*args, **kwargs)
         path = f"v1/content/{self.content_guid}/permissions/{self.id}"
-        url = urls.append(self.config.url, path)
-        response = self.session.put(
+        url = urls.append(self.ctx.url, path)
+        response = self.ctx.session.put(
             url,
             json=body,
         )
@@ -73,10 +73,8 @@ class Permission(Resource):
 
 
 class Permissions(Resources):
-    def __init__(
-        self, config: Config, session: Session, content_guid: str
-    ) -> None:
-        super().__init__(config, session)
+    def __init__(self, ctx: Context, content_guid: str) -> None:
+        super().__init__(ctx)
         self.content_guid = content_guid
 
     def count(self) -> int:
@@ -126,9 +124,9 @@ class Permissions(Resources):
         ...
         body = dict(*args, **kwargs)
         path = f"v1/content/{self.content_guid}/permissions"
-        url = urls.append(self.config.url, path)
-        response = self.session.post(url, json=body)
-        return Permission(self.config, self.session, **response.json())
+        url = urls.append(self.ctx.url, path)
+        response = self.ctx.session.post(url, json=body)
+        return Permission(self.ctx, **response.json())
 
     def find(self, *args, **kwargs) -> List[Permission]:
         """Find permissions.
@@ -139,13 +137,10 @@ class Permissions(Resources):
         """
         body = dict(*args, **kwargs)
         path = f"v1/content/{self.content_guid}/permissions"
-        url = urls.append(self.config.url, path)
-        response = self.session.get(url, json=body)
+        url = urls.append(self.ctx.url, path)
+        response = self.ctx.session.get(url, json=body)
         results = response.json()
-        return [
-            Permission(self.config, self.session, **result)
-            for result in results
-        ]
+        return [Permission(self.ctx, **result) for result in results]
 
     def find_one(self, *args, **kwargs) -> Permission | None:
         """Find a permission.
@@ -170,6 +165,6 @@ class Permissions(Resources):
         Permission
         """
         path = f"v1/content/{self.content_guid}/permissions/{id}"
-        url = urls.append(self.config.url, path)
-        response = self.session.get(url)
-        return Permission(self.config, self.session, **response.json())
+        url = urls.append(self.ctx.url, path)
+        response = self.ctx.session.get(url)
+        return Permission(self.ctx, **response.json())

--- a/src/posit/connect/resources.py
+++ b/src/posit/connect/resources.py
@@ -1,24 +1,20 @@
 from abc import ABC
 from typing import Any
 
-import requests
-
 from .config import Config
+from .context import Context
 
 
 class Resource(ABC, dict):
-    def __init__(self, config: Config, session: requests.Session, **kwargs):
+    def __init__(self, ctx: Context, **kwargs):
         super().__init__(**kwargs)
-        self.config: Config
-        super().__setattr__("config", config)
-        self.session: requests.Session
-        super().__setattr__("session", session)
+        self.ctx: Context
+        super().__setattr__("ctx", ctx)
 
     def __setattr__(self, name: str, value: Any) -> None:
         raise AttributeError("cannot set attributes: use update() instead")
 
 
 class Resources(ABC):
-    def __init__(self, config: Config, session: requests.Session) -> None:
-        self.config = config
-        self.session = session
+    def __init__(self, ctx: Context) -> None:
+        self.ctx = ctx

--- a/src/posit/connect/tasks.py
+++ b/src/posit/connect/tasks.py
@@ -125,8 +125,8 @@ class Task(resources.Resource):
         """
         params = dict(*args, **kwargs)
         path = f"v1/tasks/{self.id}"
-        url = urls.append(self.config.url, path)
-        response = self.session.get(url, params=params)
+        url = urls.append(self.ctx.url, path)
+        response = self.ctx.session.get(url, params=params)
         result = response.json()
         super().update(**result)
 
@@ -191,7 +191,7 @@ class Tasks(resources.Resources):
         """
         params = dict(*args, **kwargs)
         path = f"v1/tasks/{id}"
-        url = urls.append(self.config.url, path)
-        response = self.session.get(url, params=params)
+        url = urls.append(self.ctx.url, path)
+        response = self.ctx.session.get(url, params=params)
         result = response.json()
-        return Task(self.config, self.session, **result)
+        return Task(self.ctx, **result)

--- a/tests/posit/connect/metrics/test_shiny_usage.py
+++ b/tests/posit/connect/metrics/test_shiny_usage.py
@@ -4,6 +4,7 @@ import requests
 from responses import matchers
 
 from posit.connect import Client, config
+from posit.connect.context import Context
 from posit.connect.metrics import shiny_usage
 
 from ..api import load_mock  # type: ignore
@@ -12,7 +13,6 @@ from ..api import load_mock  # type: ignore
 class TestShinyUsageEventAttributes:
     def setup_class(cls):
         cls.event = shiny_usage.ShinyUsageEvent(
-            None,
             None,
             **load_mock("v1/instrumentation/shiny/usage?limit=500.json")[
                 "results"
@@ -70,11 +70,14 @@ class TestShinyUsageFind:
         )
 
         # setup
-        c = config.Config("12345", "https://connect.example")
-        session = requests.Session()
+        ctx = Context(
+            api_key="12345",
+            session=requests.Session(),
+            url="https://connect.example/__api__",
+        )
 
         # invoke
-        events = shiny_usage.ShinyUsage(c, session).find()
+        events = shiny_usage.ShinyUsage(ctx).find()
 
         # assert
         assert mock_get[0].call_count == 1
@@ -115,11 +118,14 @@ class TestShinyUsageFindOne:
         )
 
         # setup
-        c = config.Config("12345", "https://connect.example")
-        session = requests.Session()
+        ctx = Context(
+            api_key="12345",
+            session=requests.Session(),
+            url="https://connect.example/__api__",
+        )
 
         # invoke
-        event = shiny_usage.ShinyUsage(c, session).find_one()
+        event = shiny_usage.ShinyUsage(ctx).find_one()
 
         # assert
         assert mock_get[0].call_count == 1

--- a/tests/posit/connect/metrics/test_shiny_usage.py
+++ b/tests/posit/connect/metrics/test_shiny_usage.py
@@ -71,7 +71,6 @@ class TestShinyUsageFind:
 
         # setup
         ctx = Context(
-            api_key="12345",
             session=requests.Session(),
             url="https://connect.example/__api__",
         )
@@ -119,7 +118,6 @@ class TestShinyUsageFindOne:
 
         # setup
         ctx = Context(
-            api_key="12345",
             session=requests.Session(),
             url="https://connect.example/__api__",
         )

--- a/tests/posit/connect/metrics/test_usage.py
+++ b/tests/posit/connect/metrics/test_usage.py
@@ -20,7 +20,6 @@ class TestUsageEventFromVisitEvent:
     def setup_class(cls):
         visit_event = visits.VisitEvent(
             None,
-            None,
             **load_mock("v1/instrumentation/content/visits?limit=500.json")[
                 "results"
             ][0],
@@ -63,7 +62,6 @@ class TestUsageEventFromVisitEvent:
 class TestUsageEventFromShinyUsageEvent:
     def setup_class(cls):
         visit_event = shiny_usage.ShinyUsageEvent(
-            None,
             None,
             **load_mock("v1/instrumentation/shiny/usage?limit=500.json")[
                 "results"

--- a/tests/posit/connect/metrics/test_visits.py
+++ b/tests/posit/connect/metrics/test_visits.py
@@ -80,7 +80,6 @@ class TestVisitsFind:
 
         # setup
         ctx = Context(
-            api_key="12345",
             session=requests.Session(),
             url="https://connect.example/__api__",
         )
@@ -128,7 +127,6 @@ class TestVisitsFindOne:
 
         # setup
         ctx = Context(
-            api_key="12345",
             session=requests.Session(),
             url="https://connect.example/__api__",
         )

--- a/tests/posit/connect/metrics/test_visits.py
+++ b/tests/posit/connect/metrics/test_visits.py
@@ -4,6 +4,7 @@ import requests
 from responses import matchers
 
 from posit.connect import Client, config
+from posit.connect.context import Context
 from posit.connect.metrics import visits
 
 from ..api import load_mock  # type: ignore
@@ -12,7 +13,6 @@ from ..api import load_mock  # type: ignore
 class TestVisitAttributes:
     def setup_class(cls):
         cls.visit = visits.VisitEvent(
-            None,
             None,
             **load_mock("v1/instrumentation/content/visits?limit=500.json")[
                 "results"
@@ -79,11 +79,14 @@ class TestVisitsFind:
         )
 
         # setup
-        c = config.Config("12345", "https://connect.example")
-        session = requests.Session()
+        ctx = Context(
+            api_key="12345",
+            session=requests.Session(),
+            url="https://connect.example/__api__",
+        )
 
         # invoke
-        events = visits.Visits(c, session).find()
+        events = visits.Visits(ctx).find()
 
         # assert
         assert mock_get[0].call_count == 1
@@ -124,11 +127,14 @@ class TestVisitsFindOne:
         )
 
         # setup
-        c = config.Config("12345", "https://connect.example")
-        session = requests.Session()
+        ctx = Context(
+            api_key="12345",
+            session=requests.Session(),
+            url="https://connect.example/__api__",
+        )
 
         # invoke
-        event = visits.Visits(c, session).find_one()
+        event = visits.Visits(ctx).find_one()
 
         # assert
         assert mock_get[0].call_count == 1

--- a/tests/posit/connect/test_bundles.py
+++ b/tests/posit/connect/test_bundles.py
@@ -16,11 +16,8 @@ from .api import load_mock, get_path  # type: ignore
 
 class TestBundleProperties:
     def setup_class(cls):
-        config = Config(api_key="12345", url="https://connect.example/")
-        session = requests.Session()
         cls.bundle = Bundle(
-            config,
-            session,
+            mock.Mock(),
             **load_mock(
                 f"v1/content/f2f37341-e21d-3d80-c698-a935ad614066/bundles/101.json"
             ),

--- a/tests/posit/connect/test_client.py
+++ b/tests/posit/connect/test_client.py
@@ -143,7 +143,7 @@ class TestClient:
         url = "https://connect.example.com"
         client = Client(api_key=api_key, url=url)
         client.get("/foo")
-        client.session.get.assert_called_once_with(
+        client.ctx.session.get.assert_called_once_with(
             "https://connect.example.com/__api__/foo"
         )
 
@@ -152,7 +152,7 @@ class TestClient:
         url = "https://connect.example.com"
         client = Client(api_key=api_key, url=url)
         client.post("/foo")
-        client.session.post.assert_called_once_with(
+        client.ctx.session.post.assert_called_once_with(
             "https://connect.example.com/__api__/foo"
         )
 
@@ -161,7 +161,7 @@ class TestClient:
         url = "https://connect.example.com"
         client = Client(api_key=api_key, url=url)
         client.put("/foo")
-        client.session.put.assert_called_once_with(
+        client.ctx.session.put.assert_called_once_with(
             "https://connect.example.com/__api__/foo"
         )
 
@@ -170,7 +170,7 @@ class TestClient:
         url = "https://connect.example.com"
         client = Client(api_key=api_key, url=url)
         client.patch("/foo")
-        client.session.patch.assert_called_once_with(
+        client.ctx.session.patch.assert_called_once_with(
             "https://connect.example.com/__api__/foo"
         )
 
@@ -179,6 +179,6 @@ class TestClient:
         url = "https://connect.example.com"
         client = Client(api_key=api_key, url=url)
         client.delete("/foo")
-        client.session.delete.assert_called_once_with(
+        client.ctx.session.delete.assert_called_once_with(
             "https://connect.example.com/__api__/foo"
         )

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -227,7 +227,6 @@ class TestContentItemDelete:
 
         # setup
         ctx = Context(
-            api_key="12345",
             session=requests.Session(),
             url="https://connect.example/__api__",
         )

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -1,3 +1,5 @@
+from unittest import mock
+from unittest.mock import Mock
 import requests
 import responses
 
@@ -6,6 +8,7 @@ from responses import matchers
 from posit.connect.client import Client
 from posit.connect.config import Config
 from posit.connect.content import ContentItem, ContentItemOwner
+from posit.connect.context import Context
 from posit.connect.permissions import Permissions
 
 from .api import load_mock  # type: ignore
@@ -15,10 +18,8 @@ class TestContentOwnerAttributes:
     @classmethod
     def setup_class(cls):
         guid = "20a79ce3-6e87-4522-9faf-be24228800a4"
-        config = Config(api_key="12345", url="https://connect.example/")
-        session = requests.Session()
         fake_item = load_mock(f"v1/users/{guid}.json")
-        cls.item = ContentItemOwner(config, session, **fake_item)
+        cls.item = ContentItemOwner(mock.Mock(), **fake_item)
 
     def test_guid(self):
         assert self.item.guid == "20a79ce3-6e87-4522-9faf-be24228800a4"
@@ -37,10 +38,8 @@ class TestContentItemAttributes:
     @classmethod
     def setup_class(cls):
         guid = "f2f37341-e21d-3d80-c698-a935ad614066"
-        config = Config(api_key="12345", url="https://connect.example/")
-        session = requests.Session()
         fake_item = load_mock(f"v1/content/{guid}.json")
-        cls.item = ContentItem(config, session, **fake_item)
+        cls.item = ContentItem(Mock(), **fake_item)
 
     def test_id(self):
         assert self.item.id == "8274"
@@ -227,10 +226,13 @@ class TestContentItemDelete:
         )
 
         # setup
-        config = Config(api_key="12345", url="https://connect.example/")
-        session = requests.Session()
+        ctx = Context(
+            api_key="12345",
+            session=requests.Session(),
+            url="https://connect.example/__api__",
+        )
         fake_item = load_mock(f"v1/content/{guid}.json")
-        item = ContentItem(config, session, **fake_item)
+        item = ContentItem(ctx, **fake_item)
 
         # invoke
         item.delete()

--- a/tests/posit/connect/test_groups.py
+++ b/tests/posit/connect/test_groups.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from unittest.mock import Mock
 
 import pytest
@@ -19,10 +20,8 @@ class TestGroupAttributes:
     @classmethod
     def setup_class(cls):
         guid = "6f300623-1e0c-48e6-a473-ddf630c0c0c3"
-        config = Config(api_key="12345", url="https://connect.example.com/")
-        session = requests.Session()
         fake_item = load_mock(f"v1/groups/{guid}.json")
-        cls.item = Group(config, session, **fake_item)
+        cls.item = Group(mock.Mock(), **fake_item)
 
     def test_guid(self):
         assert self.item.guid == "6f300623-1e0c-48e6-a473-ddf630c0c0c3"

--- a/tests/posit/connect/test_permissions.py
+++ b/tests/posit/connect/test_permissions.py
@@ -9,6 +9,7 @@ import responses
 from responses import matchers
 
 from posit.connect.config import Config
+from posit.connect.context import Context
 from posit.connect.permissions import Permission, Permissions
 
 from .api import load_mock  # type: ignore
@@ -27,12 +28,15 @@ class TestPermissionDelete:
         )
 
         # setup
-        config = Config(api_key="12345", url="https://connect.example/")
-        session = requests.Session()
+        ctx = Context(
+            api_key="12345",
+            session=requests.Session(),
+            url="https://connect.example/__api__",
+        )
         fake_permission = load_mock(
             f"v1/content/{content_guid}/permissions/{id}.json"
         )
-        permission = Permission(config, session, **fake_permission)
+        permission = Permission(ctx, **fake_permission)
 
         # invoke
         permission.delete()
@@ -74,11 +78,13 @@ class TestPermissionUpdate:
         )
 
         # setup
-        config = Config(api_key="12345", url="https://connect.example/")
-        session = requests.Session()
+        ctx = Context(
+            api_key="12345",
+            session=requests.Session(),
+            url="https://connect.example/__api__",
+        )
         permission = Permission(
-            config,
-            session,
+            ctx,
             id=id,
             content_guid=content_guid,
             principal_guid=principal_guid,
@@ -121,10 +127,13 @@ class TestPermissionUpdate:
         )
 
         # setup
-        config = Config(api_key="12345", url="https://connect.example/")
-        session = requests.Session()
+        ctx = Context(
+            api_key="12345",
+            session=requests.Session(),
+            url="https://connect.example/__api__",
+        )
         permission = Permission(
-            config, session, id=id, content_guid=content_guid, role=old_role
+            ctx, id=id, content_guid=content_guid, role=old_role
         )
 
         # assert role change with respect to api response
@@ -149,9 +158,12 @@ class TestPermissionsCount:
         )
 
         # setup
-        config = Config(api_key="12345", url="https://connect.example/")
-        session = requests.Session()
-        permissions = Permissions(config, session, content_guid=content_guid)
+        ctx = Context(
+            api_key="12345",
+            session=requests.Session(),
+            url="https://connect.example/__api__",
+        )
+        permissions = Permissions(ctx, content_guid=content_guid)
 
         # invoke
         count = permissions.count()
@@ -192,9 +204,12 @@ class TestPermissionsCreate:
         )
 
         # setup
-        config = Config(api_key="12345", url="https://connect.example/")
-        session = requests.Session()
-        permissions = Permissions(config, session, content_guid=content_guid)
+        ctx = Context(
+            api_key="12345",
+            session=requests.Session(),
+            url="https://connect.example/__api__",
+        )
+        permissions = Permissions(ctx, content_guid=content_guid)
 
         # invoke
         permission = permissions.create(
@@ -223,9 +238,12 @@ class TestPermissionsFind:
         )
 
         # setup
-        config = Config(api_key="12345", url="https://connect.example/")
-        session = requests.Session()
-        permissions = Permissions(config, session, content_guid=content_guid)
+        ctx = Context(
+            api_key="12345",
+            session=requests.Session(),
+            url="https://connect.example/__api__",
+        )
+        permissions = Permissions(ctx, content_guid=content_guid)
 
         # invoke
         permissions = permissions.find()
@@ -250,9 +268,12 @@ class TestPermissionsFindOne:
         )
 
         # setup
-        config = Config(api_key="12345", url="https://connect.example/")
-        session = requests.Session()
-        permissions = Permissions(config, session, content_guid=content_guid)
+        ctx = Context(
+            api_key="12345",
+            session=requests.Session(),
+            url="https://connect.example/__api__",
+        )
+        permissions = Permissions(ctx, content_guid=content_guid)
 
         # invoke
         permission = permissions.find_one()
@@ -278,9 +299,12 @@ class TestPermissionsGet:
         )
 
         # setup
-        config = Config(api_key="12345", url="https://connect.example/")
-        session = requests.Session()
-        permissions = Permissions(config, session, content_guid=content_guid)
+        ctx = Context(
+            api_key="12345",
+            session=requests.Session(),
+            url="https://connect.example/__api__",
+        )
+        permissions = Permissions(ctx, content_guid=content_guid)
 
         # invoke
         permission = permissions.get(id)

--- a/tests/posit/connect/test_permissions.py
+++ b/tests/posit/connect/test_permissions.py
@@ -29,7 +29,6 @@ class TestPermissionDelete:
 
         # setup
         ctx = Context(
-            api_key="12345",
             session=requests.Session(),
             url="https://connect.example/__api__",
         )
@@ -79,7 +78,6 @@ class TestPermissionUpdate:
 
         # setup
         ctx = Context(
-            api_key="12345",
             session=requests.Session(),
             url="https://connect.example/__api__",
         )
@@ -128,7 +126,6 @@ class TestPermissionUpdate:
 
         # setup
         ctx = Context(
-            api_key="12345",
             session=requests.Session(),
             url="https://connect.example/__api__",
         )
@@ -159,7 +156,6 @@ class TestPermissionsCount:
 
         # setup
         ctx = Context(
-            api_key="12345",
             session=requests.Session(),
             url="https://connect.example/__api__",
         )
@@ -205,7 +201,6 @@ class TestPermissionsCreate:
 
         # setup
         ctx = Context(
-            api_key="12345",
             session=requests.Session(),
             url="https://connect.example/__api__",
         )
@@ -239,7 +234,6 @@ class TestPermissionsFind:
 
         # setup
         ctx = Context(
-            api_key="12345",
             session=requests.Session(),
             url="https://connect.example/__api__",
         )
@@ -269,7 +263,6 @@ class TestPermissionsFindOne:
 
         # setup
         ctx = Context(
-            api_key="12345",
             session=requests.Session(),
             url="https://connect.example/__api__",
         )
@@ -300,7 +293,6 @@ class TestPermissionsGet:
 
         # setup
         ctx = Context(
-            api_key="12345",
             session=requests.Session(),
             url="https://connect.example/__api__",
         )

--- a/tests/posit/connect/test_resources.py
+++ b/tests/posit/connect/test_resources.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from unittest.mock import Mock
 import pytest
 import warnings
@@ -6,6 +7,7 @@ from typing import Any, List, Optional
 
 from requests.sessions import Session as Session
 
+from posit.connect.context import Context
 from posit.connect.resources import Resource, Resources
 
 config = Mock()
@@ -23,16 +25,16 @@ class TestResource:
         k = "foo"
         v = "bar"
         d = dict({k: v})
-        r = FakeResource(config, session, **d)
-        assert r.session == session
-        assert r.config == config
+        c = mock.Mock()
+        r = FakeResource(c, **d)
+        assert r.ctx == c
 
     def test__getitem__(self):
         warnings.filterwarnings("ignore", category=FutureWarning)
         k = "foo"
         v = "bar"
         d = dict({k: v})
-        r = FakeResource(config, session, **d)
+        r = FakeResource(mock.Mock(), **d)
         assert r.__getitem__(k) == d.__getitem__(k)
         assert r[k] == d[k]
 
@@ -42,7 +44,7 @@ class TestResource:
         v1 = "bar"
         v2 = "baz"
         d = dict({k: v1})
-        r = FakeResource(config, session, **d)
+        r = FakeResource(mock.Mock(), **d)
         assert r[k] == v1
         r[k] = v2
         assert r[k] == v2
@@ -52,7 +54,7 @@ class TestResource:
         k = "foo"
         v = "bar"
         d = dict({k: v})
-        r = FakeResource(config, session, **d)
+        r = FakeResource(mock.Mock(), **d)
         assert k in r
         assert r[k] == v
         del r[k]
@@ -62,5 +64,5 @@ class TestResource:
         k = "foo"
         v = "bar"
         d = dict({k: v})
-        r = FakeResource(config, session, **d)
+        r = FakeResource(mock.Mock(), **d)
         assert r.foo == v

--- a/tests/posit/connect/test_tasks.py
+++ b/tests/posit/connect/test_tasks.py
@@ -13,7 +13,6 @@ class TestTaskAttributes:
     def setup_class(cls):
         cls.task = tasks.Task(
             None,
-            None,
             **load_mock("v1/tasks/jXhOhdm5OOSkGhJw.json"),
         )
 

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from unittest.mock import Mock
 
 import pytest
@@ -17,80 +18,80 @@ url = Mock()
 
 class TestUserAttributes:
     def test_guid(self):
-        user = User(session, url)
+        user = User(mock.Mock())
         assert hasattr(user, "guid")
         assert user.guid is None
-        user = User(session, url, guid="test_guid")
+        user = User(mock.Mock(), guid="test_guid")
         assert user.guid == "test_guid"
 
     def test_email(self):
-        user = User(session, url)
+        user = User(mock.Mock())
         assert hasattr(user, "email")
         assert user.email is None
-        user = User(session, url, email="test@example.com")
+        user = User(mock.Mock(), email="test@example.com")
         assert user.email == "test@example.com"
 
     def test_username(self):
-        user = User(session, url)
+        user = User(mock.Mock())
         assert hasattr(user, "username")
         assert user.username is None
-        user = User(session, url, username="test_user")
+        user = User(mock.Mock(), username="test_user")
         assert user.username == "test_user"
 
     def test_first_name(self):
-        user = User(session, url)
+        user = User(mock.Mock())
         assert hasattr(user, "first_name")
         assert user.first_name is None
-        user = User(session, url, first_name="John")
+        user = User(mock.Mock(), first_name="John")
         assert user.first_name == "John"
 
     def test_last_name(self):
-        user = User(session, url)
+        user = User(mock.Mock())
         assert hasattr(user, "last_name")
         assert user.last_name is None
-        user = User(session, url, last_name="Doe")
+        user = User(mock.Mock(), last_name="Doe")
         assert user.last_name == "Doe"
 
     def test_user_role(self):
-        user = User(session, url)
+        user = User(mock.Mock())
         assert hasattr(user, "user_role")
         assert user.user_role is None
-        user = User(session, url, user_role="admin")
+        user = User(mock.Mock(), user_role="admin")
         assert user.user_role == "admin"
 
     def test_created_time(self):
-        user = User(session, url)
+        user = User(mock.Mock())
         assert hasattr(user, "created_time")
         assert user.created_time is None
-        user = User(session, url, created_time="2022-01-01T00:00:00")
+        user = User(mock.Mock(), created_time="2022-01-01T00:00:00")
         assert user.created_time == "2022-01-01T00:00:00"
 
     def test_updated_time(self):
-        user = User(session, url)
+        user = User(mock.Mock())
         assert hasattr(user, "updated_time")
         assert user.updated_time is None
-        user = User(session, url, updated_time="2022-01-01T00:00:00")
+        user = User(mock.Mock(), updated_time="2022-01-01T00:00:00")
         assert user.updated_time == "2022-01-01T00:00:00"
 
     def test_active_time(self):
-        user = User(session, url)
+        user = User(mock.Mock())
         assert hasattr(user, "active_time")
         assert user.active_time is None
-        user = User(session, url, active_time="2022-01-01T00:00:00")
+        user = User(mock.Mock(), active_time="2022-01-01T00:00:00")
         assert user.active_time == "2022-01-01T00:00:00"
 
     def test_confirmed(self):
-        user = User(session, url)
+        user = User(mock.Mock())
         assert hasattr(user, "confirmed")
         assert user.confirmed is None
-        user = User(session, url, confirmed=True)
+        user = User(mock.Mock(), confirmed=True)
         assert user.confirmed is True
 
     def test_locked(self):
-        user = User(session, url)
+        user = User(mock.Mock())
         assert hasattr(user, "locked")
         assert user.locked is None
-        user = User(session, url, locked=False)
+        user = User(mock.Mock(), locked=False)
         assert user.locked is False
 
 


### PR DESCRIPTION
Replace standard dependency injection with the context pattern.

This has been on my mind for a while, and I needed to scratch my creativity itch. This simplifies the complexity of obtaining additional information throughout the resource stack. 

The existing implementation requires a large change every time we add a variable to the resource stack, such as passing the Connect version from the `Client` to the `Bundle`. Now that there is a standard code flow throughout the abstraction, migrating to a Context pattern makes sense. 

After this, we can add the Connect version to the `Context`, and then it will be available on the resource stack.