### PR TITLE
refactor: add url class in place of urls module functions

### DIFF
--- a/src/posit/connect/bundles.py
+++ b/src/posit/connect/bundles.py
@@ -142,7 +142,7 @@ class Bundle(resources.Resource):
     def delete(self) -> None:
         """Delete the bundle."""
         path = f"v1/content/{self.content_guid}/bundles/{self.id}"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         self.session.delete(url)
 
     def deploy(self) -> tasks.Task:
@@ -162,7 +162,7 @@ class Bundle(resources.Resource):
         None
         """
         path = f"v1/content/{self.content_guid}/deploy"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         response = self.session.post(url, json={"bundle_id": self.id})
         result = response.json()
         ts = tasks.Tasks(self.config, self.session)
@@ -200,7 +200,7 @@ class Bundle(resources.Resource):
             )
 
         path = f"v1/content/{self.content_guid}/bundles/{self.id}/download"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         response = self.session.get(url, stream=True)
         if isinstance(output, io.BufferedWriter):
             for chunk in response.iter_content():
@@ -287,7 +287,7 @@ class Bundles(resources.Resources):
             )
 
         path = f"v1/content/{self.content_guid}/bundles"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         response = self.session.post(url, data=data)
         result = response.json()
         return Bundle(self.config, self.session, **result)
@@ -301,7 +301,7 @@ class Bundles(resources.Resources):
             List of all found bundles.
         """
         path = f"v1/content/{self.content_guid}/bundles"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         response = self.session.get(url)
         results = response.json()
         return [
@@ -333,7 +333,7 @@ class Bundles(resources.Resources):
             The bundle with the specified ID.
         """
         path = f"v1/content/{self.content_guid}/bundles/{id}"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         response = self.session.get(url)
         result = response.json()
         return Bundle(self.config, self.session, **result)

--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -318,7 +318,7 @@ class Client:
         Response
             A [](`requests.Response`) object.
         """
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         return self.session.request(method, url, **kwargs)
 
     def get(self, path: str, **kwargs) -> Response:
@@ -339,7 +339,7 @@ class Client:
         Response
             A [](`requests.Response`) object.
         """
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         return self.session.get(url, **kwargs)
 
     def post(self, path: str, **kwargs) -> Response:
@@ -360,7 +360,7 @@ class Client:
         Response
             A [](`requests.Response`) object.
         """
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         return self.session.post(url, **kwargs)
 
     def put(self, path: str, **kwargs) -> Response:
@@ -381,7 +381,7 @@ class Client:
         Response
             A [](`requests.Response`) object.
         """
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         return self.session.put(url, **kwargs)
 
     def patch(self, path: str, **kwargs) -> Response:
@@ -402,7 +402,7 @@ class Client:
         Response
             A [](`requests.Response`) object.
         """
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         return self.session.patch(url, **kwargs)
 
     def delete(self, path: str, **kwargs) -> Response:
@@ -423,5 +423,5 @@ class Client:
         Response
             A [](`requests.Response`) object.
         """
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         return self.session.delete(url, **kwargs)

--- a/src/posit/connect/config.py
+++ b/src/posit/connect/config.py
@@ -56,4 +56,4 @@ class Config:
         self, api_key: Optional[str] = None, url: Optional[str] = None
     ) -> None:
         self.api_key = api_key or _get_api_key()
-        self.url = urls.create(url or _get_url())
+        self.url = urls.Url(url or _get_url())

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -144,7 +144,7 @@ class ContentItem(Resource):
     def delete(self) -> None:
         """Delete the content item."""
         path = f"v1/content/{self.guid}"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         self.session.delete(url)
 
     def deploy(self) -> tasks.Task:
@@ -164,7 +164,7 @@ class ContentItem(Resource):
         None
         """
         path = f"v1/content/{self.guid}/deploy"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         response = self.session.post(url, json={"bundle_id": None})
         result = response.json()
         ts = tasks.Tasks(self.config, self.session)
@@ -237,7 +237,7 @@ class ContentItem(Resource):
             self.environment_variables.create(key, random_hash)
             self.environment_variables.delete(key)
             # GET via the base Connect URL to force create a new worker thread.
-            url = urls.append(dirname(self.config.url), f"content/{self.guid}")
+            url = dirname(self.config.url) + f"/content/{self.guid}"
             self.session.get(url)
             return None
         else:
@@ -314,7 +314,7 @@ class ContentItem(Resource):
     def update(self, *args, **kwargs) -> None:
         """Update the content item."""
         body = dict(*args, **kwargs)
-        url = urls.append(self.config.url, f"v1/content/{self.guid}")
+        url = self.config.url + f"v1/content/{self.guid}"
         response = self.session.patch(url, json=body)
         super().update(**response.json())
 
@@ -548,7 +548,7 @@ class Content(Resources):
         *,
         owner_guid: str | None = None,
     ) -> None:
-        self.url = urls.append(config.url, "v1/content")
+        self.url = config.url + "v1/content"
         self.config = config
         self.session = session
         self.owner_guid = owner_guid
@@ -656,7 +656,7 @@ class Content(Resources):
         """
         body = dict(*args, **kwargs)
         path = "v1/content"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         response = self.session.post(url, json=body)
         return ContentItem(self.config, self.session, **response.json())
 
@@ -798,6 +798,6 @@ class Content(Resources):
         -------
         ContentItem
         """
-        url = urls.append(self.url, guid)
+        url = self.url + guid
         response = self.session.get(url)
         return ContentItem(self.config, self.session, **response.json())

--- a/src/posit/connect/env.py
+++ b/src/posit/connect/env.py
@@ -71,7 +71,7 @@ class EnvVars(Resources, MutableMapping[str, Optional[str]]):
         >>> clear()
         """
         path = f"v1/content/{self.content_guid}/environment"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         self.session.put(url, json=[])
 
     def create(self, key: str, value: str, /) -> None:
@@ -129,7 +129,7 @@ class EnvVars(Resources, MutableMapping[str, Optional[str]]):
         ['DATABASE_URL']
         """
         path = f"v1/content/{self.content_guid}/environment"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         response = self.session.get(url)
         return response.json()
 
@@ -204,5 +204,5 @@ class EnvVars(Resources, MutableMapping[str, Optional[str]]):
 
         body = [{"name": key, "value": value} for key, value in d.items()]
         path = f"v1/content/{self.content_guid}/environment"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         self.session.patch(url, json=body)

--- a/src/posit/connect/groups.py
+++ b/src/posit/connect/groups.py
@@ -39,7 +39,7 @@ class Group(Resource):
     def delete(self) -> None:
         """Delete the group."""
         path = f"v1/groups/{self.guid}"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         self.session.delete(url)
 
 
@@ -90,7 +90,7 @@ class Groups(Resources):
         ...
         body = dict(*args, **kwargs)
         path = "v1/groups"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         response = self.session.post(url, json=body)
         return Group(self.config, self.session, **response.json())
 
@@ -117,7 +117,7 @@ class Groups(Resources):
         """
         params = dict(*args, **kwargs)
         path = "v1/groups"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         paginator = Paginator(self.session, url, params=params)
         results = paginator.fetch_results()
         return [
@@ -152,7 +152,7 @@ class Groups(Resources):
         """
         params = dict(*args, **kwargs)
         path = "v1/groups"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         paginator = Paginator(self.session, url, params=params)
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)
@@ -177,7 +177,7 @@ class Groups(Resources):
         -------
         Group
         """
-        url = urls.append(self.config.url, f"v1/groups/{guid}")
+        url = self.config.url + f"v1/groups/{guid}"
         response = self.session.get(url)
         return Group(
             config=self.config,
@@ -193,7 +193,7 @@ class Groups(Resources):
         int
         """
         path = "v1/groups"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         response: requests.Response = self.session.get(
             url, params={"page_size": 1}
         )

--- a/src/posit/connect/me.py
+++ b/src/posit/connect/me.py
@@ -18,6 +18,6 @@ def get(config: Config, session: requests.Session) -> User:
     -------
         User: The current user.
     """
-    url = urls.append(config.url, "v1/user")
+    url = config.url + "v1/user"
     response = session.get(url)
     return User(config, session, **response.json())

--- a/src/posit/connect/metrics/shiny_usage.py
+++ b/src/posit/connect/metrics/shiny_usage.py
@@ -109,7 +109,7 @@ class ShinyUsage(Resources):
         params = rename_params(params)
 
         path = "/v1/instrumentation/shiny/usage"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         paginator = CursorPaginator(self.session, url, params=params)
         results = paginator.fetch_results()
         return [
@@ -168,7 +168,7 @@ class ShinyUsage(Resources):
         params = dict(*args, **kwargs)
         params = rename_params(params)
         path = "/v1/instrumentation/shiny/usage"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         paginator = CursorPaginator(self.session, url, params=params)
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)

--- a/src/posit/connect/metrics/visits.py
+++ b/src/posit/connect/metrics/visits.py
@@ -141,7 +141,7 @@ class Visits(Resources):
         params = rename_params(params)
 
         path = "/v1/instrumentation/content/visits"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         paginator = CursorPaginator(self.session, url, params=params)
         results = paginator.fetch_results()
         return [
@@ -200,7 +200,7 @@ class Visits(Resources):
         params = dict(*args, **kwargs)
         params = rename_params(params)
         path = "/v1/instrumentation/content/visits"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         paginator = CursorPaginator(self.session, url, params=params)
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)

--- a/src/posit/connect/oauth.py
+++ b/src/posit/connect/oauth.py
@@ -15,7 +15,7 @@ class Credentials(TypedDict, total=False):
 
 class OAuthIntegration:
     def __init__(self, config: Config, session: Session) -> None:
-        self.url = urls.append(config.url, "v1/oauth/integrations/credentials")
+        self.url = config.url + "v1/oauth/integrations/credentials"
         self.config = config
         self.session = session
 

--- a/src/posit/connect/permissions.py
+++ b/src/posit/connect/permissions.py
@@ -36,7 +36,7 @@ class Permission(Resource):
     def delete(self) -> None:
         """Delete the permission."""
         path = f"v1/content/{self.content_guid}/permissions/{self.id}"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         self.session.delete(url)
 
     @overload
@@ -64,7 +64,7 @@ class Permission(Resource):
         }
         body.update(*args, **kwargs)
         path = f"v1/content/{self.content_guid}/permissions/{self.id}"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         response = self.session.put(
             url,
             json=body,
@@ -126,7 +126,7 @@ class Permissions(Resources):
         ...
         body = dict(*args, **kwargs)
         path = f"v1/content/{self.content_guid}/permissions"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         response = self.session.post(url, json=body)
         return Permission(self.config, self.session, **response.json())
 
@@ -139,7 +139,7 @@ class Permissions(Resources):
         """
         body = dict(*args, **kwargs)
         path = f"v1/content/{self.content_guid}/permissions"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         response = self.session.get(url, json=body)
         results = response.json()
         return [
@@ -170,6 +170,6 @@ class Permissions(Resources):
         Permission
         """
         path = f"v1/content/{self.content_guid}/permissions/{id}"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         response = self.session.get(url)
         return Permission(self.config, self.session, **response.json())

--- a/src/posit/connect/tasks.py
+++ b/src/posit/connect/tasks.py
@@ -125,7 +125,7 @@ class Task(resources.Resource):
         """
         params = dict(*args, **kwargs)
         path = f"v1/tasks/{self.id}"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         response = self.session.get(url, params=params)
         result = response.json()
         super().update(**result)
@@ -191,7 +191,7 @@ class Tasks(resources.Resources):
         """
         params = dict(*args, **kwargs)
         path = f"v1/tasks/{id}"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         response = self.session.get(url, params=params)
         result = response.json()
         return Task(self.config, self.session, **result)

--- a/src/posit/connect/urls.py
+++ b/src/posit/connect/urls.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import posixpath
-
 from urllib.parse import urlsplit, urlunsplit
 
 
@@ -23,41 +22,21 @@ class Url(str):
 
     Examples
     --------
-    >>> url = Url("http://connect.example.com/)
+    >>> url = Url("http://connect.example.com/")
     http://connect.example.com/__api__
     >>> url + "endpoint"
     http://connect.example.com/__api__/endpoint
 
     Append works with string-like objects (e.g., objects that support casting to string)
-    >>> url = Url("http://connect.example.com/__api__/endpoint)
+    >>> url = Url("http://connect.example.com/__api__/endpoint")
     http://connect.example.com/__api__/endpoint
     >>> url + 1
     http://connect.example.com/__api__/endpoint/1
     """
 
     def __new__(cls, value: str):
-        """New.
-
-        Parameters
-        ----------
-        value : str
-            Any URL.
-
-        Returns
-        -------
-        Url
-
-        Raises
-        ------
-        ValueError
-            `value` is missing a scheme.
-        ValueError
-            `value` is missing a network location (i.e., a domain name).
-        """
-        return super(Url, cls).__new__(cls, _create(value))
-
-    def __init__(self, value):
-        super(Url, self).__init__()
+        url = _create(value)
+        return super(Url, cls).__new__(cls, url)
 
     def __add__(self, path: str):
         return self.append(path)
@@ -95,14 +74,12 @@ def _create(url: str) -> str:
 
     >>> _create("http://example.com/__api__")
     http://example.com/__api__
-
     """
     split = urlsplit(url, allow_fragments=False)
     if not split.scheme:
         raise ValueError(
             f"URL must specify a scheme (e.g., http://example.com/__api__): {url}"
         )
-
     if not split.netloc:
         raise ValueError(
             f"URL must be absolute (e.g., http://example.com/__api__): {url}"
@@ -136,14 +113,9 @@ def _append(url: str, path) -> str:
     >>> _append(url, "path")
     http://example.com/__api__/path
     """
-    path = str(path)
-    # Removes leading '/' from path to avoid double slashes.
-    path = path.lstrip("/")
-    # Removes trailing '/' from path to avoid double slashes.
-    path = path.rstrip("/")
-    # See https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlsplit
+    path = str(path).strip("/")
     split = urlsplit(url, allow_fragments=False)
-    # Append the path to unmodified Url path.
-    path = posixpath.join(split.path, path)
-    # See https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlunsplit
-    return urlunsplit((split.scheme, split.netloc, path, split.query, None))
+    new_path = posixpath.join(split.path, path)
+    return urlunsplit(
+        (split.scheme, split.netloc, new_path, split.query, None)
+    )

--- a/src/posit/connect/urls.py
+++ b/src/posit/connect/urls.py
@@ -6,9 +6,54 @@ from urllib.parse import urlsplit, urlunsplit
 
 
 class Url(str):
-    def __new__(cls, value):
-        if not isinstance(value, str):
-            raise ValueError("Value must be a string")
+    """URL representation for Connect.
+
+    An opinionated URL representation of a Connect URL. Maintains various
+    conventions:
+        - It begins with a scheme.
+        - It is absolute.
+        - It contains '__api__'.
+
+    Supports Python builtin __add__ for append.
+
+    Methods
+    -------
+    append(path: str)
+        Append a path to the URL.
+
+    Examples
+    --------
+    >>> url = Url("http://connect.example.com/)
+    http://connect.example.com/__api__
+    >>> url + "endpoint"
+    http://connect.example.com/__api__/endpoint
+
+    Append works with string-like objects (e.g., objects that support casting to string)
+    >>> url = Url("http://connect.example.com/__api__/endpoint)
+    http://connect.example.com/__api__/endpoint
+    >>> url + 1
+    http://connect.example.com/__api__/endpoint/1
+    """
+
+    def __new__(cls, value: str):
+        """New.
+
+        Parameters
+        ----------
+        value : str
+            Any URL.
+
+        Returns
+        -------
+        Url
+
+        Raises
+        ------
+        ValueError
+            `value` is missing a scheme.
+        ValueError
+            `value` is missing a network location (i.e., a domain name).
+        """
         return super(Url, cls).__new__(cls, _create(value))
 
     def __init__(self, value):
@@ -22,19 +67,19 @@ class Url(str):
 
 
 def _create(url: str) -> str:
-    """Create a Url.
+    """Create a URL.
 
-    Asserts that the Url is a proper Posit Connect endpoint. The path '__api__' is appended to the Url if it isn't already present.
+    Asserts that the URL is a proper Posit Connect endpoint. The path '__api__' is appended to the URL if it is missing.
 
     Parameters
     ----------
     url : str
-        The original Url.
+        The original URL.
 
     Returns
     -------
     Url
-        The validated and formatted Url.
+        The validated and formatted URL.
 
     Raises
     ------
@@ -45,22 +90,22 @@ def _create(url: str) -> str:
 
     Examples
     --------
-    >>> urls.create("http://example.com")
+    >>> _create("http://example.com")
     http://example.com/__api__
 
-    >>> urls.create("http://example.com/__api__")
+    >>> _create("http://example.com/__api__")
     http://example.com/__api__
 
     """
     split = urlsplit(url, allow_fragments=False)
     if not split.scheme:
         raise ValueError(
-            f"url must specify a scheme (e.g., http://example.com/__api__): {url}"
+            f"URL must specify a scheme (e.g., http://example.com/__api__): {url}"
         )
 
     if not split.netloc:
         raise ValueError(
-            f"url must be absolute (e.g., http://example.com/__api__): {url}"
+            f"URL must be absolute (e.g., http://example.com/__api__): {url}"
         )
 
     url = url.rstrip("/")
@@ -70,15 +115,15 @@ def _create(url: str) -> str:
     return url
 
 
-def _append(url: str, path: str) -> str:
+def _append(url: str, path) -> str:
     """Append a path to a Url.
 
     Parameters
     ----------
-    url : Url
-        A valid Url.
+    url : str
+        A valid URL.
     path : str
-        A valid Url path.
+        A valid path.
 
     Returns
     -------
@@ -87,10 +132,11 @@ def _append(url: str, path: str) -> str:
 
     Examples
     --------
-    >>> url = urls.create("http://example.com/__api__")
-    >>> url + "path"
+    >>> url = _create("http://example.com/__api__")
+    >>> _append(url, "path")
     http://example.com/__api__/path
     """
+    path = str(path)
     # Removes leading '/' from path to avoid double slashes.
     path = path.lstrip("/")
     # Removes trailing '/' from path to avoid double slashes.

--- a/src/posit/connect/urls.py
+++ b/src/posit/connect/urls.py
@@ -4,10 +4,25 @@ import posixpath
 
 from urllib.parse import urlsplit, urlunsplit
 
-Url = str
+
+class Url(str):
+    def __new__(cls, value):
+        if not isinstance(value, str):
+            raise ValueError("Value must be a string")
+        return super(Url, cls).__new__(cls, create(value))
+
+    def __init__(self, value):
+        # Call the parent class's __init__ method
+        super(Url, self).__init__()
+
+    def __add__(self, path: str):
+        return self.append(path)
+
+    def append(self, path: str) -> Url:
+        return Url(append(self, path))
 
 
-def create(url: str) -> Url:
+def create(url: str) -> str:
     """Create a Url.
 
     Asserts that the Url is a proper Posit Connect endpoint. The path '__api__' is appended to the Url if it isn't already present.
@@ -50,13 +65,13 @@ def create(url: str) -> Url:
         )
 
     url = url.rstrip("/")
-    if not url.endswith("__api__"):
+    if "/__api__" not in url:
         url = append(url, "__api__")
 
     return url
 
 
-def append(url: Url, path: str) -> Url:
+def append(url: str, path: str) -> str:
     """Append a path to a Url.
 
     Parameters
@@ -74,7 +89,7 @@ def append(url: Url, path: str) -> Url:
     Examples
     --------
     >>> url = urls.create("http://example.com/__api__")
-    >>> urls.append(url, "path")
+    >>> url + "path"
     http://example.com/__api__/path
     """
     # Removes leading '/' from path to avoid double slashes.

--- a/src/posit/connect/urls.py
+++ b/src/posit/connect/urls.py
@@ -9,20 +9,19 @@ class Url(str):
     def __new__(cls, value):
         if not isinstance(value, str):
             raise ValueError("Value must be a string")
-        return super(Url, cls).__new__(cls, create(value))
+        return super(Url, cls).__new__(cls, _create(value))
 
     def __init__(self, value):
-        # Call the parent class's __init__ method
         super(Url, self).__init__()
 
     def __add__(self, path: str):
         return self.append(path)
 
     def append(self, path: str) -> Url:
-        return Url(append(self, path))
+        return Url(_append(self, path))
 
 
-def create(url: str) -> str:
+def _create(url: str) -> str:
     """Create a Url.
 
     Asserts that the Url is a proper Posit Connect endpoint. The path '__api__' is appended to the Url if it isn't already present.
@@ -66,12 +65,12 @@ def create(url: str) -> str:
 
     url = url.rstrip("/")
     if "/__api__" not in url:
-        url = append(url, "__api__")
+        url = _append(url, "__api__")
 
     return url
 
 
-def append(url: str, path: str) -> str:
+def _append(url: str, path: str) -> str:
     """Append a path to a Url.
 
     Parameters

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -101,7 +101,7 @@ class User(Resource):
             raise RuntimeError(
                 "You cannot lock your own account. Set force=True to override this behavior."
             )
-        url = urls.append(self.config.url, f"v1/users/{self.guid}/lock")
+        url = self.config.url + f"v1/users/{self.guid}/lock"
         body = {"locked": True}
         self.session.post(url, json=body)
         super().update(locked=True)
@@ -114,7 +114,7 @@ class User(Resource):
         -------
             None
         """
-        url = urls.append(self.config.url, f"v1/users/{self.guid}/lock")
+        url = self.config.url + f"v1/users/{self.guid}/lock"
         body = {"locked": False}
         self.session.post(url, json=body)
         super().update(locked=False)
@@ -172,7 +172,7 @@ class User(Resource):
             None
         """
         body = dict(*args, **kwargs)
-        url = urls.append(self.config.url, f"v1/users/{self.guid}")
+        url = self.config.url + f"v1/users/{self.guid}"
         response = self.session.put(url, json=body)
         super().update(**response.json())
 
@@ -181,7 +181,7 @@ class Users(Resources):
     """Users resource."""
 
     def __init__(self, config: Config, session: requests.Session) -> None:
-        self.url = urls.append(config.url, "v1/users")
+        self.url = config.url + "v1/users"
         self.config = config
         self.session = session
 
@@ -236,7 +236,7 @@ class Users(Resources):
         return next(users, None)
 
     def get(self, id: str) -> User:
-        url = urls.append(self.config.url, f"v1/users/{id}")
+        url = self.config.url + f"v1/users/{id}"
         response = self.session.get(url)
         return User(
             config=self.config,

--- a/src/posit/connect/variants.py
+++ b/src/posit/connect/variants.py
@@ -18,7 +18,7 @@ class Variant(Resource):
 
     def render(self) -> Task:
         path = f"variants/{self.id}/render"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         response = self.session.post(url)
         return Task(self.config, self.session, **response.json())
 
@@ -32,7 +32,7 @@ class Variants(Resources):
 
     def find(self) -> List[Variant]:
         path = f"applications/{self.content_guid}/variants"
-        url = urls.append(self.config.url, path)
+        url = self.config.url + path
         response = self.session.get(url)
         results = response.json() or []
         return [

--- a/tests/posit/connect/test_urls.py
+++ b/tests/posit/connect/test_urls.py
@@ -6,34 +6,32 @@ from posit.connect import urls
 class TestCreate:
     def test(self):
         url = "http://example.com/__api__"
-        assert urls.create(url) == url
+        assert urls.Url(url) == url
 
     def test_append_path(self):
-        assert (
-            urls.create("http://example.com/") == "http://example.com/__api__"
-        )
+        assert urls.Url("http://example.com/") == "http://example.com/__api__"
 
     def test_missing_scheme(self):
         with pytest.raises(ValueError):
-            urls.create("example.com")
+            urls.Url("example.com")
 
     def test_missing_netloc(self):
         with pytest.raises(ValueError):
-            urls.create("http://")
+            urls.Url("http://")
 
 
 class TestAppend:
     def test(self):
         url = "http://example.com/__api__"
-        url = urls.create(url)
-        assert urls.append(url, "path") == "http://example.com/__api__/path"
+        url = urls.Url(url)
+        assert url + "path" == "http://example.com/__api__/path"
 
     def test_slash_prefix(self):
         url = "http://example.com/__api__"
-        url = urls.create(url)
-        assert urls.append(url, "/path") == "http://example.com/__api__/path"
+        url = urls.Url(url)
+        assert url + "/path" == "http://example.com/__api__/path"
 
     def test_slash_suffix(self):
         url = "http://example.com/__api__"
-        url = urls.create(url)
-        assert urls.append(url, "path/") == "http://example.com/__api__/path"
+        url = urls.Url(url)
+        assert url + "path/" == "http://example.com/__api__/path"


### PR DESCRIPTION
Adds a new class, `urls.Url`, which wraps the existing `urls.create` and `urls.append` methods. This alleviates the need to `import  .urls` in most situations (see https://github.com/posit-dev/posit-sdk-py/pull/246).

The new class `urls.Url` supports Python append via the special method `__add__`. This is convenient for appending paths to the base endpoint. (e.g., `new_url = base_url + '/path'`).