### PR TITLE
feat!: improve compatibility with databricks sql client

### DIFF
--- a/examples/connect/.gitignore
+++ b/examples/connect/.gitignore
@@ -1,1 +1,1 @@
-.posit
+**/rsconnect-python/

--- a/examples/connect/dash/requirements.txt
+++ b/examples/connect/dash/requirements.txt
@@ -1,4 +1,4 @@
-databricks-sql-connector==3.0.1
-databricks-sdk==0.20.0
+databricks-sql-connector==3.3.0
+databricks-sdk==0.29.0
 dash==2.15.0
-git+https://github.com/posit-dev/posit-sdk-py.git
+posit-sdk>=0.4.0

--- a/examples/connect/fastapi/app.py
+++ b/examples/connect/fastapi/app.py
@@ -4,9 +4,11 @@ import os
 from typing import Annotated
 
 from databricks import sql
+from databricks.sdk.core import Config, databricks_cli
 from fastapi import FastAPI, Header
 from fastapi.responses import JSONResponse
-from posit.connect.external.databricks import viewer_credentials_provider
+from posit.connect.external.databricks import PositCredentialsStrategy
+
 
 DATABRICKS_HOST = os.getenv("DATABRICKS_HOST")
 DATABRICKS_HOST_URL = f"https://{DATABRICKS_HOST}"
@@ -26,9 +28,14 @@ async def get_fares(
     """
     global rows
 
-    credentials_provider = viewer_credentials_provider(
-        user_session_token=posit_connect_user_session_token
-    )
+    posit_strategy = PositCredentialsStrategy(
+        local_strategy=databricks_cli,
+        user_session_token=posit_connect_user_session_token)
+    cfg = Config(
+        host=DATABRICKS_HOST_URL,
+        # uses Posit's custom credential_strategy if running on Connect,
+        # otherwise falls back to the strategy defined by local_strategy
+        credentials_strategy=posit_strategy)
 
     if rows is None:
         query = "SELECT * FROM samples.nyctaxi.trips LIMIT 10;"
@@ -36,8 +43,8 @@ async def get_fares(
         with sql.connect(
             server_hostname=DATABRICKS_HOST,
             http_path=SQL_HTTP_PATH,
-            auth_type="databricks-oauth",
-            credentials_provider=credentials_provider,
+            # https://github.com/databricks/databricks-sql-python/issues/148#issuecomment-2271561365
+            credentials_provider=posit_strategy.sql_credentials_provider(cfg)
         ) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(query)

--- a/examples/connect/fastapi/app.py
+++ b/examples/connect/fastapi/app.py
@@ -9,7 +9,6 @@ from fastapi import FastAPI, Header
 from fastapi.responses import JSONResponse
 from posit.connect.external.databricks import PositCredentialsStrategy
 
-
 DATABRICKS_HOST = os.getenv("DATABRICKS_HOST")
 DATABRICKS_HOST_URL = f"https://{DATABRICKS_HOST}"
 SQL_HTTP_PATH = os.getenv("DATABRICKS_PATH")

--- a/examples/connect/fastapi/requirements.txt
+++ b/examples/connect/fastapi/requirements.txt
@@ -1,4 +1,4 @@
-databricks-sql-connector==3.0.1
-databricks-sdk==0.20.0
+databricks-sql-connector==3.3.0
+databricks-sdk==0.29.0
 fastapi==0.110.0
-git+https://github.com/posit-dev/posit-sdk-py.git
+posit-sdk>=0.4.0

--- a/examples/connect/flask/app.py
+++ b/examples/connect/flask/app.py
@@ -3,8 +3,9 @@
 import os
 
 from databricks import sql
+from databricks.sdk.core import Config, databricks_cli
 from flask import Flask, request
-from posit.connect.external.databricks import viewer_credentials_provider
+from posit.connect.external.databricks import PositCredentialsStrategy
 
 DATABRICKS_HOST = os.getenv("DATABRICKS_HOST")
 DATABRICKS_HOST_URL = f"https://{DATABRICKS_HOST}"
@@ -28,9 +29,14 @@ def get_fares():
     global rows
 
     session_token = request.headers.get("Posit-Connect-User-Session-Token")
-    credentials_provider = viewer_credentials_provider(
-        user_session_token=session_token
-    )
+    posit_strategy = PositCredentialsStrategy(
+        local_strategy=databricks_cli,
+        user_session_token=session_token)
+    cfg = Config(
+        host=DATABRICKS_HOST_URL,
+        # uses Posit's custom credential_strategy if running on Connect,
+        # otherwise falls back to the strategy defined by local_strategy
+        credentials_strategy=posit_strategy)
 
     if rows is None:
         query = "SELECT * FROM samples.nyctaxi.trips LIMIT 10;"
@@ -38,8 +44,8 @@ def get_fares():
         with sql.connect(
             server_hostname=DATABRICKS_HOST,
             http_path=SQL_HTTP_PATH,
-            auth_type="databricks-oauth",
-            credentials_provider=credentials_provider,
+            # https://github.com/databricks/databricks-sql-python/issues/148#issuecomment-2271561365
+            credentials_provider=posit_strategy.sql_credentials_provider(cfg)
         ) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(query)

--- a/examples/connect/flask/requirements.txt
+++ b/examples/connect/flask/requirements.txt
@@ -1,4 +1,4 @@
-databricks-sql-connector==3.0.1
-databricks-sdk==0.20.0
+databricks-sql-connector==3.3.0
+databricks-sdk==0.29.0
 flask==3.0.2
-git+https://github.com/posit-dev/posit-sdk-py.git
+posit-sdk>=0.4.0

--- a/examples/connect/shiny-python/requirements.txt
+++ b/examples/connect/shiny-python/requirements.txt
@@ -1,4 +1,4 @@
-databricks-sql-connector==3.0.1
-databricks-sdk==0.20.0
+databricks-sql-connector==3.3.0
+databricks-sdk==0.29.0
 shiny==0.7.1
-git+https://github.com/posit-dev/posit-sdk-py.git
+posit-sdk>=0.4.0

--- a/examples/connect/streamlit/app.py
+++ b/examples/connect/streamlit/app.py
@@ -5,34 +5,32 @@ import os
 import pandas as pd
 import streamlit as st
 from databricks import sql
-from databricks.sdk.core import ApiClient, Config
+from databricks.sdk.core import ApiClient, Config, databricks_cli
 from databricks.sdk.service.iam import CurrentUserAPI
-from posit.connect.external.databricks import viewer_credentials_provider
-from streamlit.web.server.websocket_headers import _get_websocket_headers
+from posit.connect.external.databricks import PositCredentialsStrategy
 
 DATABRICKS_HOST = os.getenv("DATABRICKS_HOST")
 DATABRICKS_HOST_URL = f"https://{DATABRICKS_HOST}"
 SQL_HTTP_PATH = os.getenv("DATABRICKS_PATH")
 
-session_token = _get_websocket_headers().get(
-    "Posit-Connect-User-Session-Token"
-)
-
-credentials_provider = viewer_credentials_provider(
-    user_session_token=session_token
-)
-
+session_token = st.context.headers.get("Posit-Connect-User-Session-Token")
+posit_strategy = PositCredentialsStrategy(
+    local_strategy=databricks_cli,
+    user_session_token=session_token)
 cfg = Config(
-    host=DATABRICKS_HOST_URL, credentials_provider=credentials_provider
-)
+    host=DATABRICKS_HOST_URL,
+    # uses Posit's custom credential_strategy if running on Connect,
+    # otherwise falls back to the strategy defined by local_strategy
+    credentials_strategy=posit_strategy)
+
 databricks_user = CurrentUserAPI(ApiClient(cfg)).me()
 st.write(f"Hello, {databricks_user.display_name}!")
 
 with sql.connect(
     server_hostname=DATABRICKS_HOST,
     http_path=SQL_HTTP_PATH,
-    auth_type="databricks-oauth",
-    credentials_provider=credentials_provider,
+    # https://github.com/databricks/databricks-sql-python/issues/148#issuecomment-2271561365
+    credentials_provider=posit_strategy.sql_credentials_provider(cfg)
 ) as connection:
     with connection.cursor() as cursor:
         cursor.execute("SELECT * FROM samples.nyctaxi.trips LIMIT 10;")

--- a/examples/connect/streamlit/requirements.txt
+++ b/examples/connect/streamlit/requirements.txt
@@ -1,4 +1,4 @@
-databricks-sql-connector==3.0.1
-databricks-sdk==0.20.0
-streamlit==1.31.1
-git+https://github.com/posit-dev/posit-sdk-py.git
+databricks-sql-connector==3.3.0
+databricks-sdk==0.29.0
+streamlit==1.37.0
+posit-sdk>=0.4.0

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -5,73 +5,108 @@ from typing import Callable, Dict, Optional
 from ..client import Client
 from ..oauth import OAuthIntegration
 
-HeaderFactory = Callable[[], Dict[str, str]]
+"""
+NOTE: These APIs are provided as a convenience and are subject to breaking changes:
+https://github.com/databricks/databricks-sdk-py#interface-stability
+"""
 
+# The Databricks SDK CredentialsProvider == Databricks SQL HeaderFactory
+CredentialsProvider = Callable[[], Dict[str, str]]
 
-# https://github.com/databricks/databricks-sdk-py/blob/v0.20.0/databricks/sdk/credentials_provider.py
-# https://github.com/databricks/databricks-sql-python/blob/v3.1.0/src/databricks/sql/auth/authenticators.py
-# In order to keep compatibility with the Databricks SDK
-class CredentialsProvider(abc.ABC):
-    """Protocol Databricks authentication.
+class CredentialsStrategy(abc.ABC):
+    """Maintain compatibility with the Databricks SQL/SDK client libraries.
 
-    A call-side interface for the Databricks Rest API.
+    https://github.com/databricks/databricks-sql-python/blob/v3.3.0/src/databricks/sql/auth/authenticators.py#L19-L33
+    https://github.com/databricks/databricks-sdk-py/blob/v0.29.0/databricks/sdk/credentials_provider.py#L44-L54
     """
-
     @abc.abstractmethod
     def auth_type(self) -> str:
         raise NotImplementedError
 
     @abc.abstractmethod
-    def __call__(self, *args, **kwargs) -> HeaderFactory:
+    def __call__(self, *args, **kwargs) -> CredentialsProvider:
         raise NotImplementedError
 
 
-class PositOAuthIntegrationCredentialsProvider(CredentialsProvider):
+def _is_local() -> bool:
+    """Returns true if called from a piece of content running on a Connect server.
+
+    The connect server will always set the environment variable `RSTUDIO_PRODUCT=CONNECT`.
+    We can use this environment variable to determine if the content is running locally
+    or on a Connect server.
+    """
+    return not os.getenv("RSTUDIO_PRODUCT") == "CONNECT"
+
+
+class PositCredentialsProvider:
     def __init__(self, posit_oauth: OAuthIntegration, user_session_token: str):
         self.posit_oauth = posit_oauth
         self.user_session_token = user_session_token
 
+    def __call__(self) -> Dict[str, str]:
+        access_token = self.posit_oauth.get_credentials(
+            self.user_session_token
+        )["access_token"]
+        return {"Authorization": f"Bearer {access_token}"}
+
+
+class PositCredentialsStrategy(CredentialsStrategy):
+
+    def __init__(self,
+        local_strategy: CredentialsStrategy,
+        user_session_token: Optional[str] = None,
+        client: Optional[Client] = None
+    ):
+        self.user_session_token = user_session_token
+        self.local_strategy = local_strategy
+        self.client = client
+
+    def sql_credentials_provider(self, *args, **kwargs):
+        """The sql connector attempts to call the credentials provider w/o any args.
+
+        The SQL client's `ExternalAuthProvider` is not compatible w/ the SDK's implementation of
+        `CredentialsProvider`, so create a no-arg lambda that wraps the args defined by the real caller.
+        This way we can pass in a databricks `Config` object required by most of the SDK's `CredentialsProvider`
+        implementations from where `sql.connect` is called.
+
+        https://github.com/databricks/databricks-sql-python/issues/148#issuecomment-2271561365
+        """
+        return lambda: self.__call__(*args, **kwargs)
+
     def auth_type(self) -> str:
-        return "posit-oauth-integration"
+        """Returns the auth type currently in use.
 
-    def __call__(self, *args, **kwargs) -> HeaderFactory:
-        def inner() -> Dict[str, str]:
-            access_token = self.posit_oauth.get_credentials(
-                self.user_session_token
-            )["access_token"]
-            return {"Authorization": f"Bearer {access_token}"}
+        The databricks-sdk client uses the configurated auth_type to create
+        a user-agent string which is used for attribution. We should only
+        overwrite the auth_type if we are using the PositCredentialsStrategy (non-local),
+        otherwise, we should return the auth_type of the configured local_strategy instead
+        to avoid breaking someone elses attribution.
 
-        return inner
+        https://github.com/databricks/databricks-sdk-py/blob/v0.29.0/databricks/sdk/config.py#L261-L269
 
+        NOTE: The databricks-sql client does not use auth_type to set the user-agent.
+        https://github.com/databricks/databricks-sql-python/blob/v3.3.0/src/databricks/sql/client.py#L214-L219
+        """
+        if _is_local():
+            return self.local_strategy.auth_type()
+        else:
+            return "posit-oauth-integration"
 
-# Use this environment variable to determine if the
-# client SDK was initialized from a piece of content running on a Connect server.
-def is_local() -> bool:
-    return not os.getenv("RSTUDIO_PRODUCT") == "CONNECT"
+    def __call__(self, *args, **kwargs) -> CredentialsProvider:
+        # If the content is not running on Connect then fall back to local_strategy
+        if _is_local():
+            return self.local_strategy(*args, **kwargs)
 
+        # If the user-session-token wasn't provided and we're running on Connect then we raise an exception.
+        # user_session_token is required to impersonate the viewer.
+        if self.user_session_token is None:
+            raise ValueError(
+                "The user-session-token is required for viewer authentication."
+            )
 
-def viewer_credentials_provider(
-    client: Optional[Client] = None, user_session_token: Optional[str] = None
-) -> Optional[CredentialsProvider]:
-    # If the content is not running on Connect then viewer auth should
-    # fall back to the locally configured credentials hierarchy
-    if is_local():
-        return None
+        if self.client is None:
+            self.client = Client()
 
-    if client is None:
-        client = Client()
-
-    # If the user-session-token wasn't provided and we're running on Connect then we raise an exception.
-    # user_session_token is required to impersonate the viewer.
-    if user_session_token is None:
-        raise ValueError(
-            "The user-session-token is required for viewer authentication."
+        return PositCredentialsProvider(
+            self.client.oauth, self.user_session_token
         )
-
-    return PositOAuthIntegrationCredentialsProvider(
-        client.oauth, user_session_token
-    )
-
-
-def service_account_credentials_provider(client: Optional[Client] = None):
-    raise NotImplementedError

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -19,6 +19,7 @@ class CredentialsStrategy(abc.ABC):
     https://github.com/databricks/databricks-sql-python/blob/v3.3.0/src/databricks/sql/auth/authenticators.py#L19-L33
     https://github.com/databricks/databricks-sdk-py/blob/v0.29.0/databricks/sdk/credentials_provider.py#L44-L54
     """
+
     @abc.abstractmethod
     def auth_type(self) -> str:
         raise NotImplementedError

--- a/tests/posit/connect/external/test_databricks.py
+++ b/tests/posit/connect/external/test_databricks.py
@@ -1,0 +1,72 @@
+from typing import Dict
+from unittest.mock import patch
+
+import responses
+from posit.connect import Client
+from posit.connect.external.databricks import (
+    CredentialsProvider,
+    PositCredentialsProvider,
+    PositCredentialsStrategy,
+)
+
+
+class mock_strategy:
+    def auth_type(self) -> str:
+        return "local"
+    def __call__(self) -> CredentialsProvider:
+        def inner() -> Dict[str,str]:
+            return {"Authorization": "Bearer static-pat-token"}
+        return inner
+
+
+def register_mocks():
+    responses.post(
+        "https://connect.example/__api__/v1/oauth/integrations/credentials",
+        match=[
+            responses.matchers.urlencoded_params_matcher(
+                {
+                    "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                    "subject_token_type": "urn:posit:connect:user-session-token",
+                    "subject_token": "cit",
+                }
+            )
+        ],
+        json={
+            "access_token": "dynamic-viewer-access-token",
+            "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+            "token_type": "Bearer",
+        },
+    )
+
+
+class TestPositCredentialsHelpers:
+    @responses.activate
+    def test_posit_credentials_provider(self):
+        register_mocks()
+
+        client = Client(api_key="12345", url="https://connect.example/")
+        cp = PositCredentialsProvider(posit_oauth=client.oauth, user_session_token="cit")
+        assert cp() == {"Authorization": f"Bearer dynamic-viewer-access-token"}
+
+    @responses.activate
+    @patch.dict("os.environ", {"RSTUDIO_PRODUCT": "CONNECT"})
+    def test_posit_credentials_strategy(self):
+        register_mocks()
+
+        client = Client(api_key="12345", url="https://connect.example/")
+        cs = PositCredentialsStrategy(local_strategy=mock_strategy(),
+                                      user_session_token="cit",
+                                      client=client)
+        cp = cs()
+        assert cs.auth_type() == "posit-oauth-integration"
+        assert cp() == {"Authorization": "Bearer dynamic-viewer-access-token"}
+
+    def test_posit_credentials_strategy_fallback(self):
+        # local_strategy is used when the content is running locally
+        client = Client(api_key="12345", url="https://connect.example/")
+        cs = PositCredentialsStrategy(local_strategy=mock_strategy(),
+                                      user_session_token="cit",
+                                      client=client)
+        cp = cs()
+        assert cs.auth_type() == "local"
+        assert cp() == {"Authorization": "Bearer static-pat-token"}


### PR DESCRIPTION
- Improves compatibility/usability between the Databricks python SDK and the Databricks SQL client credentials_provider interfaces: https://github.com/databricks/databricks-sql-python/issues/148#issuecomment-2271561365
- Updates all databricks viewer-auth examples to refer to the next posit-sdk release (0.4.0) in their requirements.txt

For reviewers: The important changes relevant for this PR's functionality are in `src/posit/connect/external/databricks.py`

The new credentials_strategy takes a fallback option that will be used automatically during local development, this way content can run locally and on Connect w/o requiring any code changes.

```python
import streamlit as st
from databricks import sql
from databricks.sdk.core import ApiClient, Config, databricks_cli
from databricks.sdk.service.iam import CurrentUserAPI
from posit.connect.external.databricks import PositCredentialsStrategy

session_token = st.context.headers.get("Posit-Connect-User-Session-Token")
posit_strategy = PositCredentialsStrategy(
    local_strategy=databricks_cli,
    user_session_token=session_token)
cfg = Config(
    host=DATABRICKS_HOST_URL,
    # uses Posit's custom credential_strategy if running on Connect,
    # otherwise falls back to the strategy defined by local_strategy
    credentials_strategy=posit_strategy)

databricks_user = CurrentUserAPI(ApiClient(cfg)).me()
st.write(f"Hello, {databricks_user.display_name}!")

with sql.connect(
    server_hostname=DATABRICKS_HOST,
    http_path=SQL_HTTP_PATH,
    # https://github.com/databricks/databricks-sql-python/issues/148#issuecomment-2271561365
    credentials_provider=posit_strategy.sql_credentials_provider(cfg)
) as connection:
    with connection.cursor() as cursor:
        cursor.execute("SELECT * FROM samples.nyctaxi.trips LIMIT 10;")
        result = cursor.fetchall()
```