### PR TITLE
fix: use correct args and kwargs definitions

### DIFF
--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -229,6 +229,7 @@ class ContentItem(Resource):
     @overload
     def update(
         self,
+        *args,
         name: str = ...,
         title: Optional[str] = ...,
         description: str = ...,
@@ -254,6 +255,7 @@ class ContentItem(Resource):
         default_r_environment_management: Optional[bool] = ...,
         default_py_environment_management: Optional[bool] = ...,
         service_account_name: Optional[str] = ...,
+        **kwargs,
     ) -> None:
         """Update the content item.
 
@@ -578,6 +580,7 @@ class Content(Resources):
     @overload
     def create(
         self,
+        *,
         name: str = ...,
         title: Optional[str] = ...,
         description: str = ...,
@@ -639,7 +642,7 @@ class Content(Resources):
         ...
 
     @overload
-    def create(self, *args, **kwargs) -> ContentItem:
+    def create(self, **kwargs) -> ContentItem:
         """Create a content item.
 
         Returns
@@ -648,17 +651,16 @@ class Content(Resources):
         """
         ...
 
-    def create(self, *args, **kwargs) -> ContentItem:
+    def create(self, **kwargs) -> ContentItem:
         """Create a content item.
 
         Returns
         -------
         ContentItem
         """
-        body = dict(*args, **kwargs)
         path = "v1/content"
         url = self.url + path
-        response = self.session.post(url, json=body)
+        response = self.session.post(url, json=kwargs)
         return ContentItem(self.params, **response.json())
 
     @overload

--- a/src/posit/connect/groups.py
+++ b/src/posit/connect/groups.py
@@ -45,7 +45,7 @@ class Groups(Resources):
     """Groups resource."""
 
     @overload
-    def create(self, name: str, unique_id: str | None) -> Group:
+    def create(self, *, name: str, unique_id: str | None) -> Group:
         """Create a group.
 
         Parameters
@@ -60,7 +60,7 @@ class Groups(Resources):
         ...
 
     @overload
-    def create(self, *args, **kwargs) -> Group:
+    def create(self, **kwargs) -> Group:
         """Create a group.
 
         Returns
@@ -69,7 +69,7 @@ class Groups(Resources):
         """
         ...
 
-    def create(self, *args, **kwargs) -> Group:
+    def create(self, **kwargs) -> Group:
         """Create a group.
 
         Parameters
@@ -82,22 +82,22 @@ class Groups(Resources):
         Group
         """
         ...
-        body = dict(*args, **kwargs)
         path = "v1/groups"
         url = self.url + path
-        response = self.session.post(url, json=body)
+        response = self.session.post(url, json=kwargs)
         return Group(self.params, **response.json())
 
     @overload
     def find(
         self,
+        *,
         prefix: str = ...,
     ) -> List[Group]: ...
 
     @overload
-    def find(self, *args, **kwargs) -> List[Group]: ...
+    def find(self, **kwargs) -> List[Group]: ...
 
-    def find(self, *args, **kwargs):
+    def find(self, **kwargs):
         """Find groups.
 
         Parameters
@@ -109,10 +109,9 @@ class Groups(Resources):
         -------
         List[Group]
         """
-        params = dict(*args, **kwargs)
         path = "v1/groups"
         url = self.url + path
-        paginator = Paginator(self.session, url, params=params)
+        paginator = Paginator(self.session, url, params=kwargs)
         results = paginator.fetch_results()
         return [
             Group(
@@ -125,13 +124,14 @@ class Groups(Resources):
     @overload
     def find_one(
         self,
+        *,
         prefix: str = ...,
     ) -> Group | None: ...
 
     @overload
-    def find_one(self, *args, **kwargs) -> Group | None: ...
+    def find_one(self, **kwargs) -> Group | None: ...
 
-    def find_one(self, *args, **kwargs) -> Group | None:
+    def find_one(self, **kwargs) -> Group | None:
         """Find one group.
 
         Parameters
@@ -143,10 +143,10 @@ class Groups(Resources):
         -------
         Group | None
         """
-        params = dict(*args, **kwargs)
+        dict
         path = "v1/groups"
         url = self.url + path
-        paginator = Paginator(self.session, url, params=params)
+        paginator = Paginator(self.session, url, params=kwargs)
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)
         groups = (

--- a/src/posit/connect/metrics/shiny_usage.py
+++ b/src/posit/connect/metrics/shiny_usage.py
@@ -62,6 +62,7 @@ class ShinyUsage(Resources):
     @overload
     def find(
         self,
+        *,
         content_guid: str = ...,
         min_data_version: int = ...,
         start: str = ...,
@@ -87,7 +88,7 @@ class ShinyUsage(Resources):
         ...
 
     @overload
-    def find(self, *args, **kwargs) -> List[ShinyUsageEvent]:
+    def find(self, **kwargs) -> List[ShinyUsageEvent]:
         """Find usage.
 
         Returns
@@ -96,15 +97,14 @@ class ShinyUsage(Resources):
         """
         ...
 
-    def find(self, *args, **kwargs) -> List[ShinyUsageEvent]:
+    def find(self, **kwargs) -> List[ShinyUsageEvent]:
         """Find usage.
 
         Returns
         -------
         List[ShinyUsageEvent]
         """
-        params = dict(*args, **kwargs)
-        params = rename_params(params)
+        params = rename_params(kwargs)
 
         path = "/v1/instrumentation/shiny/usage"
         url = self.url + path
@@ -121,6 +121,7 @@ class ShinyUsage(Resources):
     @overload
     def find_one(
         self,
+        *,
         content_guid: str = ...,
         min_data_version: int = ...,
         start: str = ...,
@@ -146,7 +147,7 @@ class ShinyUsage(Resources):
         ...
 
     @overload
-    def find_one(self, *args, **kwargs) -> ShinyUsageEvent | None:
+    def find_one(self, **kwargs) -> ShinyUsageEvent | None:
         """Find a usage event.
 
         Returns
@@ -155,15 +156,14 @@ class ShinyUsage(Resources):
         """
         ...
 
-    def find_one(self, *args, **kwargs) -> ShinyUsageEvent | None:
+    def find_one(self, **kwargs) -> ShinyUsageEvent | None:
         """Find a usage event.
 
         Returns
         -------
         ShinyUsageEvent | None
         """
-        params = dict(*args, **kwargs)
-        params = rename_params(params)
+        params = rename_params(kwargs)
         path = "/v1/instrumentation/shiny/usage"
         url = self.url + path
         paginator = CursorPaginator(self.session, url, params=params)

--- a/src/posit/connect/metrics/usage.py
+++ b/src/posit/connect/metrics/usage.py
@@ -154,6 +154,7 @@ class Usage(resources.Resources):
     @overload
     def find(
         self,
+        *,
         content_guid: str = ...,
         min_data_version: int = ...,
         start: str = ...,
@@ -179,7 +180,7 @@ class Usage(resources.Resources):
         ...
 
     @overload
-    def find(self, *args, **kwargs) -> List[UsageEvent]:
+    def find(self, **kwargs) -> List[UsageEvent]:
         """Find view events.
 
         Returns
@@ -188,7 +189,7 @@ class Usage(resources.Resources):
         """
         ...
 
-    def find(self, *args, **kwargs) -> List[UsageEvent]:
+    def find(self, **kwargs) -> List[UsageEvent]:
         """Find view events.
 
         Returns
@@ -202,7 +203,7 @@ class Usage(resources.Resources):
             events.extend(
                 [
                     UsageEvent.from_event(event)
-                    for event in instance.find(*args, **kwargs)  # type: ignore[attr-defined]
+                    for event in instance.find(**kwargs)  # type: ignore[attr-defined]
                 ]
             )
         return events
@@ -210,6 +211,7 @@ class Usage(resources.Resources):
     @overload
     def find_one(
         self,
+        *,
         content_guid: str = ...,
         min_data_version: int = ...,
         start: str = ...,
@@ -235,7 +237,7 @@ class Usage(resources.Resources):
         ...
 
     @overload
-    def find_one(self, *args, **kwargs) -> UsageEvent | None:
+    def find_one(self, **kwargs) -> UsageEvent | None:
         """Find a view event.
 
         Returns
@@ -244,7 +246,7 @@ class Usage(resources.Resources):
         """
         ...
 
-    def find_one(self, *args, **kwargs) -> UsageEvent | None:
+    def find_one(self, **kwargs) -> UsageEvent | None:
         """Find a view event.
 
         Returns
@@ -254,7 +256,7 @@ class Usage(resources.Resources):
         finders = (visits.Visits, shiny_usage.ShinyUsage)
         for finder in finders:
             instance = finder(self.params)
-            event = instance.find_one(*args, **kwargs)  # type: ignore[attr-defined]
+            event = instance.find_one(**kwargs)  # type: ignore[attr-defined]
             if event:
                 return UsageEvent.from_event(event)
         return None

--- a/src/posit/connect/metrics/visits.py
+++ b/src/posit/connect/metrics/visits.py
@@ -94,6 +94,7 @@ class Visits(Resources):
     @overload
     def find(
         self,
+        *,
         content_guid: str = ...,
         min_data_version: int = ...,
         start: str = ...,
@@ -119,7 +120,7 @@ class Visits(Resources):
         ...
 
     @overload
-    def find(self, *args, **kwargs) -> List[VisitEvent]:
+    def find(self, **kwargs) -> List[VisitEvent]:
         """Find visits.
 
         Returns
@@ -128,15 +129,14 @@ class Visits(Resources):
         """
         ...
 
-    def find(self, *args, **kwargs) -> List[VisitEvent]:
+    def find(self, **kwargs) -> List[VisitEvent]:
         """Find visits.
 
         Returns
         -------
         List[Visit]
         """
-        params = dict(*args, **kwargs)
-        params = rename_params(params)
+        params = rename_params(kwargs)
 
         path = "/v1/instrumentation/content/visits"
         url = self.url + path
@@ -153,6 +153,7 @@ class Visits(Resources):
     @overload
     def find_one(
         self,
+        *,
         content_guid: str = ...,
         min_data_version: int = ...,
         start: str = ...,
@@ -178,7 +179,7 @@ class Visits(Resources):
         ...
 
     @overload
-    def find_one(self, *args, **kwargs) -> VisitEvent | None:
+    def find_one(self, **kwargs) -> VisitEvent | None:
         """Find a visit.
 
         Returns
@@ -187,15 +188,14 @@ class Visits(Resources):
         """
         ...
 
-    def find_one(self, *args, **kwargs) -> VisitEvent | None:
+    def find_one(self, **kwargs) -> VisitEvent | None:
         """Find a visit.
 
         Returns
         -------
         Visit | None
         """
-        params = dict(*args, **kwargs)
-        params = rename_params(params)
+        params = rename_params(kwargs)
         path = "/v1/instrumentation/content/visits"
         url = self.url + path
         paginator = CursorPaginator(self.session, url, params=params)

--- a/src/posit/connect/permissions.py
+++ b/src/posit/connect/permissions.py
@@ -37,7 +37,7 @@ class Permission(Resource):
         self.session.delete(url)
 
     @overload
-    def update(self, role: str) -> None:
+    def update(self, *args, role: str, **kwargs) -> None:
         """Update the permission.
 
         Parameters
@@ -59,7 +59,8 @@ class Permission(Resource):
             "principal_type": self.principal_type,
             "role": self.role,
         }
-        body.update(*args, **kwargs)
+        body.update(dict(*args))
+        body.update(**kwargs)
         path = f"v1/content/{self.content_guid}/permissions/{self.id}"
         url = self.url + path
         response = self.session.put(
@@ -85,7 +86,7 @@ class Permissions(Resources):
 
     @overload
     def create(
-        self, principal_guid: str, principal_type: str, role: str
+        self, *, principal_guid: str, principal_type: str, role: str
     ) -> Permission:
         """Create a permission.
 
@@ -102,7 +103,7 @@ class Permissions(Resources):
         ...
 
     @overload
-    def create(self, *args, **kwargs) -> Permission:
+    def create(self, **kwargs) -> Permission:
         """Create a permission.
 
         Returns
@@ -111,7 +112,7 @@ class Permissions(Resources):
         """
         ...
 
-    def create(self, *args, **kwargs) -> Permission:
+    def create(self, **kwargs) -> Permission:
         """Create a permission.
 
         Returns
@@ -119,34 +120,32 @@ class Permissions(Resources):
         Permission
         """
         ...
-        body = dict(*args, **kwargs)
         path = f"v1/content/{self.content_guid}/permissions"
         url = self.url + path
-        response = self.session.post(url, json=body)
+        response = self.session.post(url, json=kwargs)
         return Permission(self.params, **response.json())
 
-    def find(self, *args, **kwargs) -> List[Permission]:
+    def find(self, **kwargs) -> List[Permission]:
         """Find permissions.
 
         Returns
         -------
         List[Permission]
         """
-        body = dict(*args, **kwargs)
         path = f"v1/content/{self.content_guid}/permissions"
         url = self.url + path
-        response = self.session.get(url, json=body)
+        response = self.session.get(url, json=kwargs)
         results = response.json()
         return [Permission(self.params, **result) for result in results]
 
-    def find_one(self, *args, **kwargs) -> Permission | None:
+    def find_one(self, **kwargs) -> Permission | None:
         """Find a permission.
 
         Returns
         -------
         Permission | None
         """
-        permissions = self.find(*args, **kwargs)
+        permissions = self.find(**kwargs)
         return next(iter(permissions), None)
 
     def get(self, uid: str) -> Permission:

--- a/src/posit/connect/tasks.py
+++ b/src/posit/connect/tasks.py
@@ -82,7 +82,7 @@ class Task(resources.Resource):
     # CRUD Methods
 
     @overload
-    def update(self, first: int, wait: int, **kwargs) -> None:
+    def update(self, *args, first: int, wait: int, **kwargs) -> None:
         """Update the task.
 
         Parameters
@@ -126,7 +126,7 @@ class Task(resources.Resource):
         params = dict(*args, **kwargs)
         path = f"v1/tasks/{self.id}"
         url = self.url + path
-        response = self.session.get(url, params=params)
+        response = self.session.get(url, params=kwargs)
         result = response.json()
         super().update(**result)
 
@@ -144,7 +144,7 @@ class Task(resources.Resource):
 
 class Tasks(resources.Resources):
     @overload
-    def get(self, uid: str, first: int, wait: int) -> Task:
+    def get(self, *, uid: str, first: int, wait: int) -> Task:
         """Get a task.
 
         Parameters
@@ -163,7 +163,7 @@ class Tasks(resources.Resources):
         ...
 
     @overload
-    def get(self, uid: str, *args, **kwargs) -> Task:
+    def get(self, uid: str, **kwargs) -> Task:
         """Get a task.
 
         Parameters
@@ -177,7 +177,7 @@ class Tasks(resources.Resources):
         """
         ...
 
-    def get(self, uid: str, *args, **kwargs) -> Task:
+    def get(self, uid: str, **kwargs) -> Task:
         """Get a task.
 
         Parameters
@@ -189,9 +189,8 @@ class Tasks(resources.Resources):
         -------
         Task
         """
-        params = dict(*args, **kwargs)
         path = f"v1/tasks/{uid}"
         url = self.url + path
-        response = self.session.get(url, params=params)
+        response = self.session.get(url, params=kwargs)
         result = response.json()
         return Task(self.params, **result)

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -119,11 +119,13 @@ class User(Resource):
     @overload
     def update(
         self,
+        *args,
         email: str = ...,
         username: str = ...,
         first_name: str = ...,
         last_name: str = ...,
         user_role: str = ...,
+        **kwargs,
     ) -> None:
         """
         Update the user.
@@ -189,12 +191,11 @@ class Users(Resources):
     ) -> List[User]: ...
 
     @overload
-    def find(self, *args, **kwargs) -> List[User]: ...
+    def find(self, **kwargs) -> List[User]: ...
 
-    def find(self, *args, **kwargs):
+    def find(self, **kwargs):
         url = self.params.url + "v1/users"
-        params = dict(*args, **kwargs)
-        paginator = Paginator(self.session, url, params=params)
+        paginator = Paginator(self.session, url, params=kwargs)
         results = paginator.fetch_results()
         return [
             User(
@@ -207,18 +208,18 @@ class Users(Resources):
     @overload
     def find_one(
         self,
+        *,
         prefix: str = ...,
         user_role: str = ...,
         account_status: str = ...,
     ) -> User | None: ...
 
     @overload
-    def find_one(self, *args, **kwargs) -> User | None: ...
+    def find_one(self, **kwargs) -> User | None: ...
 
-    def find_one(self, *args, **kwargs) -> User | None:
+    def find_one(self, **kwargs) -> User | None:
         url = self.params.url + "v1/users"
-        params = dict(*args, **kwargs)
-        paginator = Paginator(self.session, url, params=params)
+        paginator = Paginator(self.session, url, params=kwargs)
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)
         users = (

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -472,5 +472,5 @@ class TestUsersFind:
         # validate input params are propagated to the query params
         con = Client(api_key="12345", url="https://connect.example/")
         not_dict_like = "string"
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             con.users.find(not_dict_like)


### PR DESCRIPTION
Various methods are defined with improper variadic positional and keyword arguments. The original intention for `@overload` signatures was to provide type support for pass-throughs to API query parameters or JSON arguments. Along the way, *args was introduced to these methods, assuming we wanted to match the dict function signature. This isn't very clear in practice since passing SupportsKeysAndGetItem typed variables is rare. Therefore, the *args part of the function signature is removed wherever possible. In the update(self, *args, **kwargs), we cannot remove *args since we inherit from dict, and dict enforces this method signature.