### PR TITLE
ci: add Connect v2024.08.0 to integration test suite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,7 @@ jobs:
       matrix:
         CONNECT_VERSION:
           - preview
+          - 2024.08.0
           - 2024.06.0
           - 2024.05.0
           - 2024.04.1

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -14,7 +14,8 @@ include ../vars.mk
         help
 
 # Versions
-CONNECT_VERSIONS := 2024.06.0 \
+CONNECT_VERSIONS := 2024.08.0 \
+					2024.06.0 \
                     2024.05.0 \
                     2024.04.1 \
                     2024.04.0 \


### PR DESCRIPTION
Add the latest Connect release, v2024.08.0, to the integration test suite.