### PR TITLE
feat: deprecates field access by attribute.

### DIFF
--- a/src/posit/connect/bundles.py
+++ b/src/posit/connect/bundles.py
@@ -9,130 +9,10 @@ from . import resources, tasks
 
 
 class BundleMetadata(resources.Resource):
-    """Bundle metadata resource.
-
-    Attributes
-    ----------
-    source : str | None
-        Source of the bundle.
-    source_repo : str | None
-        Source repository of the bundle.
-    source_branch : str | None
-        Source branch of the bundle.
-    source_commit : str | None
-        Source commit of the bundle.
-    archive_md5 : str | None
-        MD5 checksum of the bundle archive.
-    archive_sha1 : str | None
-        SHA-1 checksum of the bundle archive.
-    """
-
-    @property
-    def source(self) -> str | None:
-        return self.get("source")
-
-    @property
-    def source_repo(self) -> str | None:
-        return self.get("source_repo")
-
-    @property
-    def source_branch(self) -> str | None:
-        return self.get("source_branch")
-
-    @property
-    def source_commit(self) -> str | None:
-        return self.get("source_commit")
-
-    @property
-    def archive_md5(self) -> str | None:
-        return self.get("archive_md5")
-
-    @property
-    def archive_sha1(self) -> str | None:
-        return self.get("archive_sha1")
+    pass
 
 
 class Bundle(resources.Resource):
-    """Bundle resource.
-
-    Attributes
-    ----------
-    id : str
-        Identifier of the bundle.
-    content_guid : str
-        Content GUID of the bundle.
-    created_time : str
-        Creation time of the bundle.
-    cluster_name : str | None
-        Cluster name associated with the bundle.
-    image_name : str | None
-        Image name of the bundle.
-    r_version : str | None
-        R version used in the bundle.
-    r_environment_management : bool | None
-        Indicates if R environment management is enabled.
-    py_version : str | None
-        Python version used in the bundle.
-    py_environment_management : bool | None
-        Indicates if Python environment management is enabled.
-    quarto_version : str | None
-        Quarto version used in the bundle.
-    active : bool | None
-        Indicates if the bundle is active.
-    size : int | None
-        Size of the bundle.
-    metadata : BundleMetadata
-        Metadata of the bundle.
-    """
-
-    @property
-    def id(self) -> str:
-        return self["id"]
-
-    @property
-    def content_guid(self) -> str:
-        return self["content_guid"]
-
-    @property
-    def created_time(self) -> str:
-        return self["created_time"]
-
-    @property
-    def cluster_name(self) -> str | None:
-        return self.get("cluster_name")
-
-    @property
-    def image_name(self) -> str | None:
-        return self.get("image_name")
-
-    @property
-    def r_version(self) -> str | None:
-        return self.get("r_version")
-
-    @property
-    def r_environment_management(self) -> bool | None:
-        return self.get("r_environment_management")
-
-    @property
-    def py_version(self) -> str | None:
-        return self.get("py_version")
-
-    @property
-    def py_environment_management(self) -> bool | None:
-        return self.get("py_environment_management")
-
-    @property
-    def quarto_version(self) -> str | None:
-        return self.get("quarto_version")
-
-    @property
-    def active(self) -> bool | None:
-        return self["active"]
-
-    @property
-    def size(self) -> int | None:
-        return self["size"]
-
     @property
     def metadata(self) -> BundleMetadata:
         return BundleMetadata(self.params, **self.get("metadata", {}))
@@ -140,8 +20,8 @@ class Bundle(resources.Resource):
     def delete(self) -> None:
         """Delete the bundle."""
         path = f"v1/content/{self.content_guid}/bundles/{self.id}"
-        url = self.url + path
-        self.session.delete(url)
+        url = self.params.url + path
+        self.params.session.delete(url)
 
     def deploy(self) -> tasks.Task:
         """Deploy the bundle.
@@ -160,8 +40,8 @@ class Bundle(resources.Resource):
         None
         """
         path = f"v1/content/{self.content_guid}/deploy"
-        url = self.url + path
-        response = self.session.post(url, json={"bundle_id": self.id})
+        url = self.params.url + path
+        response = self.params.session.post(url, json={"bundle_id": self.id})
         result = response.json()
         ts = tasks.Tasks(self.params)
         return ts.get(result["task_id"])
@@ -198,8 +78,8 @@ class Bundle(resources.Resource):
             )
 
         path = f"v1/content/{self.content_guid}/bundles/{self.id}/download"
-        url = self.url + path
-        response = self.session.get(url, stream=True)
+        url = self.params.url + path
+        response = self.params.session.get(url, stream=True)
         if isinstance(output, io.BufferedWriter):
             for chunk in response.iter_content():
                 output.write(chunk)
@@ -284,8 +164,8 @@ class Bundles(resources.Resources):
             )
 
         path = f"v1/content/{self.content_guid}/bundles"
-        url = self.url + path
-        response = self.session.post(url, data=data)
+        url = self.params.url + path
+        response = self.params.session.post(url, data=data)
         result = response.json()
         return Bundle(self.params, **result)
 
@@ -298,8 +178,8 @@ class Bundles(resources.Resources):
             List of all found bundles.
         """
         path = f"v1/content/{self.content_guid}/bundles"
-        url = self.url + path
-        response = self.session.get(url)
+        url = self.params.url + path
+        response = self.params.session.get(url)
         results = response.json()
         return [Bundle(self.params, **result) for result in results]
 
@@ -328,7 +208,7 @@ class Bundles(resources.Resources):
             The bundle with the specified ID.
         """
         path = f"v1/content/{self.content_guid}/bundles/{uid}"
-        url = self.url + path
-        response = self.session.get(url)
+        url = self.params.url + path
+        response = self.params.session.get(url)
         result = response.json()
         return Bundle(self.params, **result)

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import posixpath
 import time
 from posixpath import dirname
-from typing import List, Optional, overload
+from typing import Any, List, Optional, overload
 
 from . import tasks
 from .bundles import Bundles
@@ -17,133 +17,21 @@ from .variants import Variants
 
 
 class ContentItemOwner(Resource):
-    """Content item owner resource."""
-
-    @property
-    def guid(self) -> str:
-        return self.get("guid")  # type: ignore
-
-    @property
-    def username(self) -> str:
-        return self.get("username")  # type: ignore
-
-    @property
-    def first_name(self) -> Optional[str]:
-        return self.get("first_name")  # type: ignore
-
-    @property
-    def last_name(self) -> Optional[str]:
-        return self.get("last_name")  # type: ignore
+    pass
 
 
 class ContentItem(Resource):
-    """Content item resource.
-
-    Attributes
-    ----------
-    bundles : Bundles
-        Bundles resource for the content item.
-    permissions : Permissions
-        Permissions resource for the content item.
-    id : str
-        Unique identifier of the content item.
-    guid : str
-        Globally unique identifier of the content item.
-    name : str
-        Name of the content item.
-    title : Optional[str]
-        Title of the content item.
-    description : str
-        Description of the content item.
-    access_type : str
-        Access type of the content item.
-    connection_timeout : Optional[int]
-        Connection timeout setting for the content item.
-    read_timeout : Optional[int]
-        Read timeout setting for the content item.
-    init_timeout : Optional[int]
-        Initialization timeout setting for the content item.
-    idle_timeout : Optional[int]
-        Idle timeout setting for the content item.
-    max_processes : Optional[int]
-        Maximum number of processes allowed for the content item.
-    min_processes : Optional[int]
-        Minimum number of processes required for the content item.
-    max_conns_per_process : Optional[int]
-        Maximum number of connections per process for the content item.
-    load_factor : Optional[float]
-        Load factor for the content item.
-    cpu_request : Optional[float]
-        CPU request for the content item.
-    cpu_limit : Optional[float]
-        CPU limit for the content item.
-    memory_request : Optional[int]
-        Memory request for the content item.
-    memory_limit : Optional[int]
-        Memory limit for the content item.
-    amd_gpu_limit : Optional[int]
-        AMD GPU limit for the content item.
-    nvidia_gpu_limit : Optional[int]
-        NVIDIA GPU limit for the content item.
-    created_time : str
-        Creation time of the content item.
-    last_deployed_time : str
-        Last deployment time of the content item.
-    bundle_id : Optional[str]
-        Bundle ID associated with the content item.
-    app_mode : str
-        Application mode of the content item.
-    content_category : Optional[str]
-        Content category of the content item.
-    parameterized : bool
-        Indicates if the content item is parameterized.
-    cluster_name : Optional[str]
-        Name of the cluster associated with the content item.
-    image_name : Optional[str]
-        Name of the image associated with the content item.
-    default_image_name : Optional[str]
-        Default image name for the content item.
-    default_r_environment_management : Optional[bool]
-        Indicates if R environment management is enabled by default.
-    default_py_environment_management : Optional[bool]
-        Indicates if Python environment management is enabled by default.
-    service_account_name : Optional[str]
-        Name of the service account associated with the content item.
-    r_version : Optional[str]
-        R version used by the content item.
-    r_environment_management : Optional[bool]
-        Indicates if R environment management is enabled.
-    py_version : Optional[str]
-        Python version used by the content item.
-    py_environment_management : Optional[bool]
-        Indicates if Python environment management is enabled.
-    quarto_version : Optional[str]
-        Quarto version used by the content item.
-    run_as : Optional[str]
-        User to run the content item as.
-    run_as_current_user : bool
-        Indicates if the content item runs as the current user.
-    owner_guid : str
-        GUID of the owner of the content item.
-    owner : ContentItemOwner
-        Owner information of the content item.
-    content_url : str
-        URL of the content item.
-    dashboard_url : str
-        Dashboard URL of the content item.
-    app_role : str
-        Application role of the content item.
-    tags : List[dict]
-        Tags associated with the content item.
-    """
-
-    # CRUD Methods
+    def __getitem__(self, key: Any) -> Any:
+        v = super().__getitem__(key)
+        if key == "owner" and isinstance(v, dict):
+            return ContentItemOwner(params=self.params, **v)
+        return v
 
     def delete(self) -> None:
         """Delete the content item."""
         path = f"v1/content/{self.guid}"
-        url = self.url + path
-        self.session.delete(url)
+        url = self.params.url + path
+        self.params.session.delete(url)
 
     def deploy(self) -> tasks.Task:
         """Deploy the content.
@@ -162,8 +50,8 @@ class ContentItem(Resource):
         None
         """
         path = f"v1/content/{self.guid}/deploy"
-        url = self.url + path
-        response = self.session.post(url, json={"bundle_id": None})
+        url = self.params.url + path
+        response = self.params.session.post(url, json={"bundle_id": None})
         result = response.json()
         ts = tasks.Tasks(self.params)
         return ts.get(result["task_id"])
@@ -218,8 +106,10 @@ class ContentItem(Resource):
             self.environment_variables.create(key, unix_epoch_in_seconds)
             self.environment_variables.delete(key)
             # GET via the base Connect URL to force create a new worker thread.
-            url = posixpath.join(dirname(self.url), f"content/{self.guid}")
-            self.session.get(url)
+            url = posixpath.join(
+                dirname(self.params.url), f"content/{self.guid}"
+            )
+            self.params.session.get(url)
             return None
         else:
             raise ValueError(
@@ -297,8 +187,8 @@ class ContentItem(Resource):
     def update(self, *args, **kwargs) -> None:
         """Update the content item."""
         body = dict(*args, **kwargs)
-        url = self.url + f"v1/content/{self.guid}"
-        response = self.session.patch(url, json=body)
+        url = self.params.url + f"v1/content/{self.guid}"
+        response = self.params.session.patch(url, json=body)
         super().update(**response.json())
 
     # Relationships
@@ -316,7 +206,7 @@ class ContentItem(Resource):
         return Permissions(self.params, self.guid)
 
     @property
-    def owner(self) -> ContentItemOwner:
+    def owner(self) -> dict:
         if "owner" not in self:
             # It is possible to get a content item that does not contain owner.
             # "owner" is an optional additional request param.
@@ -324,189 +214,11 @@ class ContentItem(Resource):
             from .users import Users
 
             self["owner"] = Users(self.params).get(self.owner_guid)
-        return ContentItemOwner(self.params, **self["owner"])
+        return self["owner"]
 
     @property
     def _variants(self) -> Variants:
         return Variants(self.params, self.guid)
-
-    # Properties
-
-    @property
-    def id(self) -> str:
-        return self.get("id")  # type: ignore
-
-    @property
-    def guid(self) -> str:
-        return self.get("guid")  # type: ignore
-
-    @property
-    def name(self) -> str:
-        return self.get("name")  # type: ignore
-
-    @property
-    def title(self) -> Optional[str]:
-        return self.get("title")  # type: ignore
-
-    @property
-    def description(self) -> str:
-        return self.get("description")  # type: ignore
-
-    @property
-    def access_type(self) -> str:
-        return self.get("access_type")  # type: ignore
-
-    @property
-    def connection_timeout(self) -> Optional[int]:
-        return self.get("connection_timeout")  # type: ignore
-
-    @property
-    def read_timeout(self) -> Optional[int]:
-        return self.get("read_timeout")  # type: ignore
-
-    @property
-    def init_timeout(self) -> Optional[int]:
-        return self.get("init_timeout")  # type: ignore
-
-    @property
-    def idle_timeout(self) -> Optional[int]:
-        return self.get("idle_timeout")  # type: ignore
-
-    @property
-    def max_processes(self) -> Optional[int]:
-        return self.get("max_processes")  # type: ignore
-
-    @property
-    def min_processes(self) -> Optional[int]:
-        return self.get("min_processes")  # type: ignore
-
-    @property
-    def max_conns_per_process(self) -> Optional[int]:
-        return self.get("max_conns_per_process")  # type: ignore
-
-    @property
-    def load_factor(self) -> Optional[float]:
-        return self.get("load_factor")  # type: ignore
-
-    @property
-    def cpu_request(self) -> Optional[float]:
-        return self.get("cpu_request")  # type: ignore
-
-    @property
-    def cpu_limit(self) -> Optional[float]:
-        return self.get("cpu_limit")  # type: ignore
-
-    @property
-    def memory_request(self) -> Optional[int]:
-        return self.get("memory_request")  # type: ignore
-
-    @property
-    def memory_limit(self) -> Optional[int]:
-        return self.get("memory_limit")  # type: ignore
-
-    @property
-    def amd_gpu_limit(self) -> Optional[int]:
-        return self.get("amd_gpu_limit")  # type: ignore
-
-    @property
-    def nvidia_gpu_limit(self) -> Optional[int]:
-        return self.get("nvidia_gpu_limit")  # type: ignore
-
-    @property
-    def created_time(self) -> str:
-        return self.get("created_time")  # type: ignore
-
-    @property
-    def last_deployed_time(self) -> str:
-        return self.get("last_deployed_time")  # type: ignore
-
-    @property
-    def bundle_id(self) -> Optional[str]:
-        return self.get("bundle_id")  # type: ignore
-
-    @property
-    def app_mode(self) -> str:
-        return self.get("app_mode")  # type: ignore
-
-    @property
-    def content_category(self) -> Optional[str]:
-        return self.get("content_category")  # type: ignore
-
-    @property
-    def parameterized(self) -> bool:
-        return self.get("parameterized")  # type: ignore
-
-    @property
-    def cluster_name(self) -> Optional[str]:
-        return self.get("cluster_name")  # type: ignore
-
-    @property
-    def image_name(self) -> Optional[str]:
-        return self.get("image_name")  # type: ignore
-
-    @property
-    def default_image_name(self) -> Optional[str]:
-        return self.get("default_image_name")  # type: ignore
-
-    @property
-    def default_r_environment_management(self) -> Optional[bool]:
-        return self.get("default_r_environment_management")  # type: ignore
-
-    @property
-    def default_py_environment_management(self) -> Optional[bool]:
-        return self.get("default_py_environment_management")  # type: ignore
-
-    @property
-    def service_account_name(self) -> Optional[str]:
-        return self.get("service_account_name")  # type: ignore
-
-    @property
-    def r_version(self) -> Optional[str]:
-        return self.get("r_version")  # type: ignore
-
-    @property
-    def r_environment_management(self) -> Optional[bool]:
-        return self.get("r_environment_management")  # type: ignore
-
-    @property
-    def py_version(self) -> Optional[str]:
-        return self.get("py_version")  # type: ignore
-
-    @property
-    def py_environment_management(self) -> Optional[bool]:
-        return self.get("py_environment_management")  # type: ignore
-
-    @property
-    def quarto_version(self) -> Optional[str]:
-        return self.get("quarto_version")  # type: ignore
-
-    @property
-    def run_as(self) -> Optional[str]:
-        return self.get("run_as")  # type: ignore
-
-    @property
-    def run_as_current_user(self) -> bool:
-        return self.get("run_as_current_user")  # type: ignore
-
-    @property
-    def owner_guid(self) -> str:
-        return self.get("owner_guid")  # type: ignore
-
-    @property
-    def content_url(self) -> str:
-        return self.get("content_url")  # type: ignore
-
-    @property
-    def dashboard_url(self) -> str:
-        return self.get("dashboard_url")  # type: ignore
-
-    @property
-    def app_role(self) -> str:
-        return self.get("app_role")  # type: ignore
-
-    @property
-    def tags(self) -> List[dict]:
-        return self.get("tags", [])
 
     @property
     def is_interactive(self) -> bool:
@@ -659,8 +371,8 @@ class Content(Resources):
         ContentItem
         """
         path = "v1/content"
-        url = self.url + path
-        response = self.session.post(url, json=kwargs)
+        url = self.params.url + path
+        response = self.params.session.post(url, json=kwargs)
         return ContentItem(self.params, **response.json())
 
     @overload
@@ -723,8 +435,8 @@ class Content(Resources):
         params.update(kwargs)
         params["include"] = include
         path = "v1/content"
-        url = self.url + path
-        response = self.session.get(url, params=params)
+        url = self.params.url + path
+        response = self.params.session.get(url, params=params)
         return [
             ContentItem(
                 self.params,
@@ -803,6 +515,6 @@ class Content(Resources):
         ContentItem
         """
         path = f"v1/content/{guid}"
-        url = self.url + path
-        response = self.session.get(url)
+        url = self.params.url + path
+        response = self.params.session.get(url)
         return ContentItem(self.params, **response.json())

--- a/src/posit/connect/env.py
+++ b/src/posit/connect/env.py
@@ -65,8 +65,8 @@ class EnvVars(Resources, MutableMapping[str, Optional[str]]):
         >>> clear()
         """
         path = f"v1/content/{self.content_guid}/environment"
-        url = self.url + path
-        self.session.put(url, json=[])
+        url = self.params.url + path
+        self.params.session.put(url, json=[])
 
     def create(self, key: str, value: str, /) -> None:
         """Create an environment variable.
@@ -123,8 +123,8 @@ class EnvVars(Resources, MutableMapping[str, Optional[str]]):
         ['DATABASE_URL']
         """
         path = f"v1/content/{self.content_guid}/environment"
-        url = self.url + path
-        response = self.session.get(url)
+        url = self.params.url + path
+        response = self.params.session.get(url)
         return response.json()
 
     def items(self):
@@ -198,5 +198,5 @@ class EnvVars(Resources, MutableMapping[str, Optional[str]]):
 
         body = [{"name": key, "value": value} for key, value in d.items()]
         path = f"v1/content/{self.content_guid}/environment"
-        url = self.url + path
-        self.session.patch(url, json=body)
+        url = self.params.url + path
+        self.params.session.patch(url, json=body)

--- a/src/posit/connect/groups.py
+++ b/src/posit/connect/groups.py
@@ -11,34 +11,11 @@ from .resources import Resource, Resources
 
 
 class Group(Resource):
-    """Group resource.
-
-    Attributes
-    ----------
-    guid : str
-    name: str
-    owner_guid: str
-    """
-
-    @property
-    def guid(self) -> str:
-        return self.get("guid")  # type: ignore
-
-    @property
-    def name(self) -> str:
-        return self.get("name")  # type: ignore
-
-    @property
-    def owner_guid(self) -> str:
-        return self.get("owner_guid")  # type: ignore
-
-    # CRUD Methods
-
     def delete(self) -> None:
         """Delete the group."""
         path = f"v1/groups/{self.guid}"
-        url = self.url + path
-        self.session.delete(url)
+        url = self.params.url + path
+        self.params.session.delete(url)
 
 
 class Groups(Resources):
@@ -83,8 +60,8 @@ class Groups(Resources):
         """
         ...
         path = "v1/groups"
-        url = self.url + path
-        response = self.session.post(url, json=kwargs)
+        url = self.params.url + path
+        response = self.params.session.post(url, json=kwargs)
         return Group(self.params, **response.json())
 
     @overload
@@ -110,8 +87,8 @@ class Groups(Resources):
         List[Group]
         """
         path = "v1/groups"
-        url = self.url + path
-        paginator = Paginator(self.session, url, params=kwargs)
+        url = self.params.url + path
+        paginator = Paginator(self.params.session, url, params=kwargs)
         results = paginator.fetch_results()
         return [
             Group(
@@ -144,8 +121,8 @@ class Groups(Resources):
         Group | None
         """
         path = "v1/groups"
-        url = self.url + path
-        paginator = Paginator(self.session, url, params=kwargs)
+        url = self.params.url + path
+        paginator = Paginator(self.params.session, url, params=kwargs)
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)
         groups = (
@@ -168,8 +145,8 @@ class Groups(Resources):
         -------
         Group
         """
-        url = self.url + f"v1/groups/{guid}"
-        response = self.session.get(url)
+        url = self.params.url + f"v1/groups/{guid}"
+        response = self.params.session.get(url)
         return Group(
             self.params,
             **response.json(),
@@ -183,8 +160,8 @@ class Groups(Resources):
         int
         """
         path = "v1/groups"
-        url = self.url + path
-        response: requests.Response = self.session.get(
+        url = self.params.url + path
+        response: requests.Response = self.params.session.get(
             url, params={"page_size": 1}
         )
         result: dict = response.json()

--- a/src/posit/connect/metrics/shiny_usage.py
+++ b/src/posit/connect/metrics/shiny_usage.py
@@ -107,8 +107,8 @@ class ShinyUsage(Resources):
         params = rename_params(kwargs)
 
         path = "/v1/instrumentation/shiny/usage"
-        url = self.url + path
-        paginator = CursorPaginator(self.session, url, params=params)
+        url = self.params.url + path
+        paginator = CursorPaginator(self.params.session, url, params=params)
         results = paginator.fetch_results()
         return [
             ShinyUsageEvent(
@@ -165,8 +165,8 @@ class ShinyUsage(Resources):
         """
         params = rename_params(kwargs)
         path = "/v1/instrumentation/shiny/usage"
-        url = self.url + path
-        paginator = CursorPaginator(self.session, url, params=params)
+        url = self.params.url + path
+        paginator = CursorPaginator(self.params.session, url, params=params)
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)
         visits = (

--- a/src/posit/connect/metrics/visits.py
+++ b/src/posit/connect/metrics/visits.py
@@ -139,8 +139,8 @@ class Visits(Resources):
         params = rename_params(kwargs)
 
         path = "/v1/instrumentation/content/visits"
-        url = self.url + path
-        paginator = CursorPaginator(self.session, url, params=params)
+        url = self.params.url + path
+        paginator = CursorPaginator(self.params.session, url, params=params)
         results = paginator.fetch_results()
         return [
             VisitEvent(
@@ -197,8 +197,8 @@ class Visits(Resources):
         """
         params = rename_params(kwargs)
         path = "/v1/instrumentation/content/visits"
-        url = self.url + path
-        paginator = CursorPaginator(self.session, url, params=params)
+        url = self.params.url + path
+        paginator = CursorPaginator(self.params.session, url, params=params)
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)
         visits = (

--- a/src/posit/connect/oauth/integrations.py
+++ b/src/posit/connect/oauth/integrations.py
@@ -6,35 +6,13 @@ from ..resources import Resource, Resources
 
 
 class Integration(Resource):
-    """OAuth integration resource.
-
-    Attributes
-    ----------
-    id : str
-        The internal numeric identifier of this OAuth integration.
-    guid : str
-        The unique identifier of this OAuth integration which is used in REST API requests.
-    name : str
-        A descriptive name to identify each OAuth integration.
-    description : Optional[str]
-        A brief text to describe each OAuth integration
-    template : str
-        The template to use to configure this OAuth integration.
-    config : dict
-        The OAuth integration configuration based on the template.
-    created_time : str
-        The timestamp (RFC3339) indicating when this OAuth integration was created.
-    updated_time : str
-        The timestamp (RFC3339) indicating when this OAuth integration was last updated.
-    """
-
-    # CRUD Methods
+    """OAuth integration resource."""
 
     def delete(self) -> None:
         """Delete the OAuth integration."""
-        path = f"v1/oauth/integrations/{self.guid}"
-        url = self.url + path
-        self.session.delete(url)
+        path = f"v1/oauth/integrations/{self['guid']}"
+        url = self.params.url + path
+        self.params.session.delete(url)
 
     @overload
     def update(
@@ -63,43 +41,9 @@ class Integration(Resource):
     def update(self, *args, **kwargs) -> None:
         """Update the OAuth integration."""
         body = dict(*args, **kwargs)
-        url = self.url + f"v1/oauth/integrations/{self.guid}"
-        response = self.session.patch(url, json=body)
+        url = self.params.url + f"v1/oauth/integrations/{self['guid']}"
+        response = self.params.session.patch(url, json=body)
         super().update(**response.json())
-
-    # Properties
-
-    @property
-    def id(self) -> str:
-        return self.get("id")  # type: ignore
-
-    @property
-    def guid(self) -> str:
-        return self.get("guid")  # type: ignore
-
-    @property
-    def name(self) -> str:
-        return self.get("name")  # type: ignore
-
-    @property
-    def description(self) -> Optional[str]:
-        return self.get("description")  # type: ignore
-
-    @property
-    def template(self) -> str:
-        return self.get("template")  # type: ignore
-
-    @property
-    def config(self) -> dict:
-        return self.get("config")  # type: ignore
-
-    @property
-    def created_time(self) -> str:
-        return self.get("created_time")  # type: ignore
-
-    @property
-    def updated_time(self) -> str:
-        return self.get("updated_time")  # type: ignore
 
 
 class Integrations(Resources):
@@ -155,8 +99,8 @@ class Integrations(Resources):
         """
         ...
         path = "v1/oauth/integrations"
-        url = self.url + path
-        response = self.session.post(url, json=kwargs)
+        url = self.params.url + path
+        response = self.params.session.post(url, json=kwargs)
         return Integration(self.params, **response.json())
 
     def find(self) -> List[Integration]:
@@ -167,9 +111,9 @@ class Integrations(Resources):
         List[Integration]
         """
         path = "v1/oauth/integrations"
-        url = self.url + path
+        url = self.params.url + path
 
-        response = self.session.get(url)
+        response = self.params.session.get(url)
         return [
             Integration(
                 self.params,
@@ -190,6 +134,6 @@ class Integrations(Resources):
         Integration
         """
         path = f"v1/oauth/integrations/{guid}"
-        url = self.url + path
-        response = self.session.get(url)
+        url = self.params.url + path
+        response = self.params.session.get(url)
         return Integration(self.params, **response.json())

--- a/src/posit/connect/oauth/oauth.py
+++ b/src/posit/connect/oauth/oauth.py
@@ -32,7 +32,7 @@ class OAuth(Resources):
         if user_session_token:
             data["subject_token"] = user_session_token
 
-        response = self.session.post(url, data=data)
+        response = self.params.session.post(url, data=data)
         return Credentials(**response.json())
 
 

--- a/src/posit/connect/oauth/sessions.py
+++ b/src/posit/connect/oauth/sessions.py
@@ -6,62 +6,12 @@ from ..resources import Resource, Resources
 
 
 class Session(Resource):
-    """OAuth session resource.
-
-    Attributes
-    ----------
-    id : str
-        The internal numeric identifier of this OAuth session.
-    guid : str
-        The unique identifier of this OAuth session which is used in REST API requests.
-    user_guid : str
-        The unique identifier of the user that is associatid with this OAuth session.
-    oauth_integration_guid : str
-        The unique identifier of the OAuth integration that is associated with this OAuth session.
-    has_refresh_token : bool
-        Indicates whether this OAuth session has a refresh token.
-    created_time : str
-        The timestamp (RFC3339) indicating when this OAuth session was created.
-    updated_time : str
-        The timestamp (RFC3339) indicating when this OAuth session was last updated.
-    """
-
-    # Properties
-
-    @property
-    def id(self) -> str:
-        return self.get("id")  # type: ignore
-
-    @property
-    def guid(self) -> str:
-        return self.get("guid")  # type: ignore
-
-    @property
-    def user_guid(self) -> str:
-        return self.get("user_guid")  # type: ignore
-
-    @property
-    def oauth_integration_guid(self) -> str:
-        return self.get("oauth_integration_guid")  # type: ignore
-
-    @property
-    def has_refresh_token(self) -> bool:
-        return self.get("has_refresh_token")  # type: ignore
-
-    @property
-    def created_time(self) -> str:
-        return self.get("created_time")  # type: ignore
-
-    @property
-    def updated_time(self) -> str:
-        return self.get("updated_time")  # type: ignore
-
-    # CRUD Methods
+    """OAuth session resource."""
 
     def delete(self) -> None:
-        path = f"v1/oauth/sessions/{self.guid}"
-        url = self.url + path
-        self.session.delete(url)
+        path = f"v1/oauth/sessions/{self['guid']}"
+        url = self.params.url + path
+        self.params.session.delete(url)
 
 
 class Sessions(Resources):
@@ -77,7 +27,7 @@ class Sessions(Resources):
 
     def find(self, **kwargs) -> List[Session]:
         url = self.params.url + "v1/oauth/sessions"
-        response = self.session.get(url, params=kwargs)
+        response = self.params.session.get(url, params=kwargs)
         results = response.json()
         return [Session(self.params, **result) for result in results]
 
@@ -93,6 +43,6 @@ class Sessions(Resources):
         Session
         """
         path = f"v1/oauth/sessions/{guid}"
-        url = self.url + path
-        response = self.session.get(url)
+        url = self.params.url + path
+        response = self.params.session.get(url)
         return Session(self.params, **response.json())

--- a/src/posit/connect/permissions.py
+++ b/src/posit/connect/permissions.py
@@ -10,31 +10,11 @@ from .resources import Resource, ResourceParameters, Resources
 
 
 class Permission(Resource):
-    @property
-    def id(self) -> str:
-        return self.get("id")  # type: ignore
-
-    @property
-    def content_guid(self) -> str:
-        return self.get("content_guid")  # type: ignore
-
-    @property
-    def principal_guid(self) -> str:
-        return self.get("principal_guid")  # type: ignore
-
-    @property
-    def principal_type(self) -> str:
-        return self.get("principal_type")  # type: ignore
-
-    @property
-    def role(self) -> str:
-        return self.get("role")  # type: ignore
-
     def delete(self) -> None:
         """Delete the permission."""
         path = f"v1/content/{self.content_guid}/permissions/{self.id}"
-        url = self.url + path
-        self.session.delete(url)
+        url = self.params.url + path
+        self.params.session.delete(url)
 
     @overload
     def update(self, *args, role: str, **kwargs) -> None:
@@ -62,8 +42,8 @@ class Permission(Resource):
         body.update(dict(*args))
         body.update(**kwargs)
         path = f"v1/content/{self.content_guid}/permissions/{self.id}"
-        url = self.url + path
-        response = self.session.put(
+        url = self.params.url + path
+        response = self.params.session.put(
             url,
             json=body,
         )
@@ -121,9 +101,9 @@ class Permissions(Resources):
         """
         ...
         path = f"v1/content/{self.content_guid}/permissions"
-        url = self.url + path
-        response = self.session.post(url, json=kwargs)
-        return Permission(self.params, **response.json())
+        url = self.params.url + path
+        response = self.params.session.post(url, json=kwargs)
+        return Permission(params=self.params, **response.json())
 
     def find(self, **kwargs) -> List[Permission]:
         """Find permissions.
@@ -133,8 +113,8 @@ class Permissions(Resources):
         List[Permission]
         """
         path = f"v1/content/{self.content_guid}/permissions"
-        url = self.url + path
-        response = self.session.get(url, json=kwargs)
+        url = self.params.url + path
+        response = self.params.session.get(url, json=kwargs)
         results = response.json()
         return [Permission(self.params, **result) for result in results]
 
@@ -161,6 +141,6 @@ class Permissions(Resources):
         Permission
         """
         path = f"v1/content/{self.content_guid}/permissions/{uid}"
-        url = self.url + path
-        response = self.session.get(url)
+        url = self.params.url + path
+        response = self.params.session.get(url)
         return Permission(self.params, **response.json())

--- a/src/posit/connect/resources.py
+++ b/src/posit/connect/resources.py
@@ -43,5 +43,3 @@ class Resource(dict):
 class Resources:
     def __init__(self, params: ResourceParameters) -> None:
         self.params = params
-        self.session = params.session
-        self.url = params.url

--- a/src/posit/connect/resources.py
+++ b/src/posit/connect/resources.py
@@ -1,6 +1,5 @@
-from abc import ABC
+import warnings
 from dataclasses import dataclass
-from typing import Any
 
 import requests
 
@@ -22,24 +21,26 @@ class ResourceParameters:
     url: Url
 
 
-class Resource(ABC, dict):
-    def __init__(self, params: ResourceParameters, **kwargs):
+class Resource(dict):
+    def __init__(self, /, params: ResourceParameters, **kwargs):
+        self.params = params
         super().__init__(**kwargs)
-        self.params: ResourceParameters
-        super().__setattr__("params", params)
-        self.session: requests.Session
-        super().__setattr__("session", params.session)
-        self.url: Url
-        super().__setattr__("url", params.url)
 
-    def __setattr__(self, name: str, value: Any) -> None:
-        raise AttributeError("cannot set attributes: use update() instead")
+    def __getattr__(self, name):
+        if name in self:
+            warnings.warn(
+                f"Accessing the field '{name}' via attribute is deprecated and will be removed in v1.0.0. "
+                f"Please use __getitem__ (e.g., {self.__class__.__name__.lower()}['{name}']) for field access instead.",
+                DeprecationWarning,
+            )
+            return self[name]
+        return None
 
     def update(self, *args, **kwargs):
         super().update(*args, **kwargs)
 
 
-class Resources(ABC):
+class Resources:
     def __init__(self, params: ResourceParameters) -> None:
         self.params = params
         self.session = params.session

--- a/src/posit/connect/tasks.py
+++ b/src/posit/connect/tasks.py
@@ -2,22 +2,12 @@
 
 from __future__ import annotations
 
-from typing import List, overload
+from typing import overload
 
 from . import resources
 
 
 class Task(resources.Resource):
-    @property
-    def id(self) -> str:
-        """The task identifier.
-
-        Returns
-        -------
-        str
-        """
-        return self["id"]
-
     @property
     def is_finished(self) -> bool:
         """The task state.
@@ -31,18 +21,6 @@ class Task(resources.Resource):
         bool
         """
         return self.get("finished", False)
-
-    @property
-    def output(self) -> List[str]:
-        """Process output.
-
-        The process output produced by the task.
-
-        Returns
-        -------
-        List[str]
-        """
-        return self["output"]
 
     @property
     def error_code(self) -> int | None:
@@ -68,16 +46,6 @@ class Task(resources.Resource):
             Human readable error message, or None on success or not finished.
         """
         return self.get("error") if self.is_finished else None
-
-    @property
-    def result(self) -> dict | None:
-        """The task result.
-
-        Returns
-        -------
-        dict | None
-        """
-        return self.get("result")
 
     # CRUD Methods
 
@@ -125,8 +93,8 @@ class Task(resources.Resource):
         """
         params = dict(*args, **kwargs)
         path = f"v1/tasks/{self.id}"
-        url = self.url + path
-        response = self.session.get(url, params=kwargs)
+        url = self.params.url + path
+        response = self.params.session.get(url, params=kwargs)
         result = response.json()
         super().update(**result)
 
@@ -190,7 +158,7 @@ class Tasks(resources.Resources):
         Task
         """
         path = f"v1/tasks/{uid}"
-        url = self.url + path
-        response = self.session.get(url, params=kwargs)
+        url = self.params.url + path
+        response = self.params.session.get(url, params=kwargs)
         result = response.json()
         return Task(self.params, **result)

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -11,74 +11,9 @@ from .resources import Resource, ResourceParameters, Resources
 
 
 class User(Resource):
-    """User resource.
-
-    Attributes
-    ----------
-    content: Content
-        A content resource scoped to this user.
-    guid : str
-    email : str
-    username : str
-    first_name : str
-    last_name : str
-    user_role : str
-    created_time : str
-    updated_time : str
-    active_time : str
-    confirmed : bool
-        Whether the user has confirmed their email address.
-    locked : bool
-        Whether the user is locked.
-    """
-
     @property
     def content(self) -> Content:
         return Content(self.params, owner_guid=self.guid)
-
-    @property
-    def guid(self) -> str:
-        return self.get("guid")  # type: ignore
-
-    @property
-    def email(self) -> str:
-        return self.get("email")  # type: ignore
-
-    @property
-    def username(self) -> str:
-        return self.get("username")  # type: ignore
-
-    @property
-    def first_name(self) -> str:
-        return self.get("first_name")  # type: ignore
-
-    @property
-    def last_name(self) -> str:
-        return self.get("last_name")  # type: ignore
-
-    @property
-    def user_role(self) -> str:
-        return self.get("user_role")  # type: ignore
-
-    @property
-    def created_time(self) -> str:
-        return self.get("created_time")  # type: ignore
-
-    @property
-    def updated_time(self) -> str:
-        return self.get("updated_time")  # type: ignore
-
-    @property
-    def active_time(self) -> str:
-        return self.get("active_time")  # type: ignore
-
-    @property
-    def confirmed(self) -> bool:
-        return self.get("confirmed")  # type: ignore
-
-    @property
-    def locked(self) -> bool:
-        return self.get("locked")  # type: ignore
 
     def lock(self, *, force: bool = False):
         """
@@ -98,9 +33,9 @@ class User(Resource):
             raise RuntimeError(
                 "You cannot lock your own account. Set force=True to override this behavior."
             )
-        url = self.url + f"v1/users/{self.guid}/lock"
+        url = self.params.url + f"v1/users/{self.guid}/lock"
         body = {"locked": True}
-        self.session.post(url, json=body)
+        self.params.session.post(url, json=body)
         super().update(locked=True)
 
     def unlock(self):
@@ -111,9 +46,9 @@ class User(Resource):
         -------
             None
         """
-        url = self.url + f"v1/users/{self.guid}/lock"
+        url = self.params.url + f"v1/users/{self.guid}/lock"
         body = {"locked": False}
-        self.session.post(url, json=body)
+        self.params.session.post(url, json=body)
         super().update(locked=False)
 
     @overload
@@ -171,8 +106,8 @@ class User(Resource):
             None
         """
         body = dict(*args, **kwargs)
-        url = self.url + f"v1/users/{self.guid}"
-        response = self.session.put(url, json=body)
+        url = self.params.url + f"v1/users/{self.guid}"
+        response = self.params.session.put(url, json=body)
         super().update(**response.json())
 
 
@@ -196,7 +131,7 @@ class Users(Resources):
 
     def find(self, **kwargs) -> List[User]:
         url = self.params.url + "v1/users"
-        paginator = Paginator(self.session, url, params=kwargs)
+        paginator = Paginator(self.params.session, url, params=kwargs)
         results = paginator.fetch_results()
         return [
             User(
@@ -220,7 +155,7 @@ class Users(Resources):
 
     def find_one(self, **kwargs) -> User | None:
         url = self.params.url + "v1/users"
-        paginator = Paginator(self.session, url, params=kwargs)
+        paginator = Paginator(self.params.session, url, params=kwargs)
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)
         users = (
@@ -233,8 +168,8 @@ class Users(Resources):
         return next(users, None)
 
     def get(self, uid: str) -> User:
-        url = self.url + f"v1/users/{uid}"
-        response = self.session.get(url)
+        url = self.params.url + f"v1/users/{uid}"
+        response = self.params.session.get(url)
         return User(
             self.params,
             **response.json(),
@@ -242,6 +177,6 @@ class Users(Resources):
 
     def count(self) -> int:
         url = self.params.url + "v1/users"
-        response = self.session.get(url, params={"page_size": 1})
+        response = self.params.session.get(url, params={"page_size": 1})
         result: dict = response.json()
         return result["total"]

--- a/src/posit/connect/variants.py
+++ b/src/posit/connect/variants.py
@@ -5,18 +5,10 @@ from .tasks import Task
 
 
 class Variant(Resource):
-    @property
-    def id(self) -> str:
-        return self["id"]
-
-    @property
-    def is_default(self) -> bool:
-        return self.get("is_default", False)
-
     def render(self) -> Task:
-        path = f"variants/{self.id}/render"
-        url = self.url + path
-        response = self.session.post(url)
+        path = f"variants/{self['id']}/render"
+        url = self.params.url + path
+        response = self.params.session.post(url)
         return Task(self.params, **response.json())
 
 
@@ -27,7 +19,7 @@ class Variants(Resources):
 
     def find(self) -> List[Variant]:
         path = f"applications/{self.content_guid}/variants"
-        url = self.url + path
-        response = self.session.get(url)
+        url = self.params.url + path
+        response = self.params.session.get(url)
         results = response.json() or []
         return [Variant(self.params, **result) for result in results]

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -180,7 +180,7 @@ class TestContentItemAttributes:
         assert isinstance(self.item.permissions, Permissions)
 
     def test_tags(self):
-        assert self.item.tags == []
+        assert self.item.tags is None
 
 
 class TestContentItemGetContentOwner:

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -313,24 +313,6 @@ class TestUsers:
             carlos.update(first_name="Carlitos")
 
     @responses.activate
-    def test_user_cant_setattr(self):
-        responses.get(
-            "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",
-            json=load_mock(
-                "v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"
-            ),
-        )
-
-        con = Client(api_key="12345", url="https://connect.example/")
-        carlos = con.users.get("20a79ce3-6e87-4522-9faf-be24228800a4")
-
-        with pytest.raises(
-            AttributeError,
-            match=r"cannot set attributes: use update\(\) instead",
-        ):
-            carlos.first_name = "Carlitos"
-
-    @responses.activate
     def test_count(self):
         responses.get(
             "https://connect.example/__api__/v1/users",


### PR DESCRIPTION
Remove all `@property` annotated methods used for direct field access on concrete resources. To maintain backward compatibility, a new `__getattr__` implementation is added to Resource. This implementation invokes `__getitem__` when the key exists in self. A noisy deprecation warning alerts users that this functionality will be removed in v1.0.0.