### PR TITLE
fix: use correct mypy syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ it:
 	$(MAKE) -C ./integration
 
 lint:
-	$(PYTHON) -m mypy --install-types --non-interactive **/*.py
+	$(PYTHON) -m mypy --install-types --non-interactive .
 	$(PYTHON) -m ruff check **/*.py
 
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = ["requests>=2.31.0,<3"]
 Source = "https://github.com/posit-dev/posit-sdk-py"
 Issues = "https://github.com/posit-dev/posit-sdk-py/issues"
 
+[tool.mypy]
+exclude = "integration/resources"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = ["--import-mode=importlib"]


### PR DESCRIPTION
The **/*.py syntax is evaluated incorrectly and fails silently.