### PR TITLE
build: set make shell to bash.

### DIFF
--- a/integration/Makefile
+++ b/integration/Makefile
@@ -125,4 +125,5 @@ help:
 # on local network.
 test:
 	mkdir -p logs
-	CONNECT_VERSION=${CONNECT_VERSION} CONNECT_API_KEY="$(shell rsconnect bootstrap -i -s http://connect:3939 --raw)" $(PYTHON) -m pytest -s --junit-xml=./reports/$(CONNECT_VERSION).xml | tee ./logs/$(CONNECT_VERSION).log
+	set -o pipefail; \
+		CONNECT_VERSION=${CONNECT_VERSION} CONNECT_API_KEY="$(shell rsconnect bootstrap -i -s http://connect:3939 --raw)" $(PYTHON) -m pytest -s --junit-xml=./reports/$(CONNECT_VERSION).xml | tee ./logs/$(CONNECT_VERSION).log;

--- a/vars.mk
+++ b/vars.mk
@@ -40,6 +40,8 @@ else
 PIP := pip3
 endif
 
+SHELL := /bin/bash
+
 QUARTO ?= quarto
 
 QUARTODOC ?= quartodoc


### PR DESCRIPTION
pipefail is required to capture the pytest exit code