### PR TITLE
docs: host production site on github pages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,16 +20,8 @@ jobs:
         check-latest: true
         cache: 'pip'
     - uses: actions/setup-node@v4
-    - uses: quarto-dev/quarto-actions/setup@v2
     - run: make deps
     - run: make build
     - run: make install
-    - run: make docs
     - id: release
       uses: pypa/gh-action-pypi-publish@release/v1
-    - id: site
-      working-directory: docs
-      env:
-        ENV: prod
-        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-      run: make deploy

--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -1,13 +1,48 @@
 name: Site
+
 on:
-  - pull_request
+  push:
+    tags:
+      - "v*.*.*"
+  pull_request:
+
+env:
+  UV_SYSTEM_PYTHON: true
+
+permissions:
+  id-token: write
+  pages: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-env:
-  UV_SYSTEM_PYTHON: true
+
 jobs:
+  site:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+          check-latest: true
+          cache: 'pip'
+      - run: make deps
+      - run: make build
+      - run: make install
+      - uses: quarto-dev/quarto-actions/setup@v2
+      - run: make docs
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: "./docs/_site"
+      - uses: actions/deploy-pages@v2
+
   preview:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +61,7 @@ jobs:
       - id: preview
         working-directory: docs
         env:
-            NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         run: |
           preview_url=$(make deploy | jq '.deploy_url' | tail -n 1 | tr -d '"')
           echo "# 🚀 Site Preview" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Host the production documentation site on GitHub pages instead of Netlify.