### PR TITLE
build: fix ruff config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ensure-uv:
 
 fmt:
 	$(PYTHON) -m ruff check --fix
-	$(PYTHON) -m ruff format .
+	$(PYTHON) -m ruff format
 
 install: ensure-uv
 	$(UV) pip install dist/*.whl
@@ -55,7 +55,7 @@ it:
 
 lint:
 	$(PYTHON) -m mypy --install-types --non-interactive .
-	$(PYTHON) -m ruff check **/*.py
+	$(PYTHON) -m ruff check
 
 test:
 	$(PYTHON) -m coverage run --source=src -m pytest tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ addopts = ["--import-mode=importlib"]
 version_file = "src/posit/_version.py"
 
 [tool.ruff]
+extend-exclude = ["integration/resources"]
 line-length = 79
 
 [tool.ruff.format]


### PR DESCRIPTION
Remove glob expressions from Ruff calls. These expressions are inconsistent between shells and cause unexpected behavior.


Update the Ruff configuration in pyproject.toml to also exclude the integration/resources directory, which includes additional Python projects used for testing bundles.