### PR TITLE
build: use pyright as static type checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ it:
 	$(MAKE) -C ./integration
 
 lint:
-	$(PYTHON) -m mypy --install-types --non-interactive .
+	$(PYTHON) -m pyright
 	$(PYTHON) -m ruff check
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build:
 clean:
 	$(MAKE) -C ./docs $@
 	$(MAKE) -C ./integration $@
-	rm -rf .coverage .mypy_cache .pytest_cache .ruff_cache *.egg-info build coverage.xml dist htmlcov coverage.xml
+	rm -rf .coverage .pytest_cache .ruff_cache *.egg-info build coverage.xml dist htmlcov coverage.xml
 	find src -name "_version.py" -exec rm -rf {} +
 	find . -name "*.egg-info" -exec rm -rf {} +
 	find . -name "*.pyc" -exec rm -f {} +

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ Issues = "https://github.com/posit-dev/posit-sdk-py/issues"
 [tool.mypy]
 exclude = "integration/resources"
 
+[tool.pyright]
+include = ["src"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = ["--import-mode=importlib"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,6 @@ dependencies = ["requests>=2.31.0,<3"]
 Source = "https://github.com/posit-dev/posit-sdk-py"
 Issues = "https://github.com/posit-dev/posit-sdk-py/issues"
 
-[tool.mypy]
-exclude = "integration/resources"
-
 [tool.pyright]
 include = ["src"]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 build
 coverage
-mypy
 pandas
 pre-commit
 pyjson5
+pyright
 pytest
 responses
 rsconnect-python

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -195,15 +195,15 @@ class ContentItem(Resource):
 
     @property
     def bundles(self) -> Bundles:
-        return Bundles(self.params, self.guid)
+        return Bundles(self.params, self["guid"])
 
     @property
     def environment_variables(self) -> EnvVars:
-        return EnvVars(self.params, self.guid)
+        return EnvVars(self.params, self["guid"])
 
     @property
     def permissions(self) -> Permissions:
-        return Permissions(self.params, self.guid)
+        return Permissions(self.params, self["guid"])
 
     @property
     def owner(self) -> dict:
@@ -213,12 +213,12 @@ class ContentItem(Resource):
             # If it's not included, we can retrieve the information by `owner_guid`
             from .users import Users
 
-            self["owner"] = Users(self.params).get(self.owner_guid)
+            self["owner"] = Users(self.params).get(self["owner_guid"])
         return self["owner"]
 
     @property
     def _variants(self) -> Variants:
-        return Variants(self.params, self.guid)
+        return Variants(self.params, self["guid"])
 
     @property
     def is_interactive(self) -> bool:

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -35,9 +35,14 @@ class PositCredentialsProvider:
         self._user_session_token = user_session_token
 
     def __call__(self) -> Dict[str, str]:
-        access_token = self._client.oauth.get_credentials(
+        credentials = self._client.oauth.get_credentials(
             self._user_session_token
-        )["access_token"]
+        )
+        access_token = credentials.get("access_token")
+        if access_token is None:
+            raise ValueError(
+                "Missing value for field 'access_token' in credentials."
+            )
         return {"Authorization": f"Bearer {access_token}"}
 
 

--- a/src/posit/connect/external/snowflake.py
+++ b/src/posit/connect/external/snowflake.py
@@ -40,7 +40,7 @@ class PositAuthenticator:
         if self._client is None:
             self._client = Client()
 
-        access_token = self._client.oauth.get_credentials(
+        credentials = self._client.oauth.get_credentials(
             self._user_session_token
-        )["access_token"]
-        return access_token
+        )
+        return credentials.get("access_token")


### PR DESCRIPTION
When analyzing overload definitions, Pyright does a better job at understanding the conventions we have established. This is due to how Pyright has decided to interpret PEP-484. Additional details are available here: https://github.com/microsoft/pyright/blob/main/docs/type-concepts-advanced.md#overloads

Additionally, Pyright discovered a few issues with types, which are addressed in this change.