### PR TITLE
build: change default to latest

### DIFF
--- a/integration/Makefile
+++ b/integration/Makefile
@@ -8,7 +8,7 @@ DOCKER_PROJECT_IMAGE_TAG ?= $(PROJECT_NAME):latest
 # Connect settings
 CONNECT_BOOTSTRAP_SECRETKEY ?= $(shell head -c 32 /dev/random | base64)
 
-.DEFAULT_GOAL := all
+.DEFAULT_GOAL := latest
 
 .PHONY: $(CONNECT_VERSIONS) \
 		all \


### PR DESCRIPTION
This changes the behavior of the `make it` command from "./Makefile".

The `make it` command is only used for convenience. Otherwise, the "./integration/Makefile" is used directly for integration testing.