### PR TITLE
chore: report D418 analysis and remove redundant rules

### DIFF
--- a/examples/connect/databricks/dash/app.py
+++ b/examples/connect/databricks/dash/app.py
@@ -66,9 +66,7 @@ def update_page(_):
                 with connection.cursor() as cursor:
                     cursor.execute(query)
                     rows = cursor.fetchall()
-                    df = pd.DataFrame(
-                        rows, columns=[col[0] for col in cursor.description]
-                    )
+                    df = pd.DataFrame(rows, columns=[col[0] for col in cursor.description])
 
         table = dash_table.DataTable(
             id="table",

--- a/examples/connect/databricks/dash/app.py
+++ b/examples/connect/databricks/dash/app.py
@@ -36,9 +36,7 @@ def update_page(_):
     Dash example application that shows user information and
     the first few rows from a table hosted in Databricks.
     """
-    session_token = flask.request.headers.get(
-        "Posit-Connect-User-Session-Token"
-    )
+    session_token = flask.request.headers.get("Posit-Connect-User-Session-Token")
     posit_strategy = PositCredentialsStrategy(
         local_strategy=databricks_cli, user_session_token=session_token
     )
@@ -63,9 +61,7 @@ def update_page(_):
                 server_hostname=DATABRICKS_HOST,
                 http_path=SQL_HTTP_PATH,
                 # https://github.com/databricks/databricks-sql-python/issues/148#issuecomment-2271561365
-                credentials_provider=posit_strategy.sql_credentials_provider(
-                    cfg
-                ),
+                credentials_provider=posit_strategy.sql_credentials_provider(cfg),
             ) as connection:
                 with connection.cursor() as cursor:
                     cursor.execute(query)

--- a/examples/connect/databricks/shiny/app.py
+++ b/examples/connect/databricks/shiny/app.py
@@ -22,9 +22,7 @@ def server(i: Inputs, o: Outputs, session: Session):
     Shiny for Python example application that shows user information and
     the first few rows from a table hosted in Databricks.
     """
-    session_token = session.http_conn.headers.get(
-        "Posit-Connect-User-Session-Token"
-    )
+    session_token = session.http_conn.headers.get("Posit-Connect-User-Session-Token")
     posit_strategy = PositCredentialsStrategy(
         local_strategy=databricks_cli, user_session_token=session_token
     )
@@ -48,9 +46,7 @@ def server(i: Inputs, o: Outputs, session: Session):
             with connection.cursor() as cursor:
                 cursor.execute(query)
                 rows = cursor.fetchall()
-                df = pd.DataFrame(
-                    rows, columns=[col[0] for col in cursor.description]
-                )
+                df = pd.DataFrame(rows, columns=[col[0] for col in cursor.description])
                 return df
 
     @render.text

--- a/examples/connect/snowflake/streamlit/app.py
+++ b/examples/connect/snowflake/streamlit/app.py
@@ -20,9 +20,7 @@ SCHEMA = os.getenv("SNOWFLAKE_SCHEMA", "tpch_sf1")
 TABLE = os.getenv("SNOWFLAKE_TABLE", "lineitem")
 
 session_token = st.context.headers.get("Posit-Connect-User-Session-Token")
-auth = PositAuthenticator(
-    local_authenticator="EXTERNALBROWSER", user_session_token=session_token
-)
+auth = PositAuthenticator(local_authenticator="EXTERNALBROWSER", user_session_token=session_token)
 
 con = snowflake.connector.connect(
     user=USER,

--- a/integration/tests/posit/connect/oauth/test_associations.py
+++ b/integration/tests/posit/connect/oauth/test_associations.py
@@ -73,10 +73,7 @@ class TestAssociations:
     def test_find_by_integration(self):
         associations = self.integration.associations.find()
         assert len(associations) == 1
-        assert (
-            associations[0]["oauth_integration_guid"]
-            == self.integration["guid"]
-        )
+        assert associations[0]["oauth_integration_guid"] == self.integration["guid"]
 
         no_associations = self.another_integration.associations.find()
         assert len(no_associations) == 0
@@ -85,15 +82,10 @@ class TestAssociations:
         associations = self.content.oauth.associations.find()
         assert len(associations) == 1
         assert associations[0]["app_guid"] == self.content["guid"]
-        assert (
-            associations[0]["oauth_integration_guid"]
-            == self.integration["guid"]
-        )
+        assert associations[0]["oauth_integration_guid"] == self.integration["guid"]
 
         # update content association to another_integration
-        self.content.oauth.associations.update(
-            self.another_integration["guid"]
-        )
+        self.content.oauth.associations.update(self.another_integration["guid"])
         updated_associations = self.content.oauth.associations.find()
         assert len(updated_associations) == 1
         assert updated_associations[0]["app_guid"] == self.content["guid"]

--- a/integration/tests/posit/connect/oauth/test_associations.py
+++ b/integration/tests/posit/connect/oauth/test_associations.py
@@ -50,9 +50,7 @@ class TestAssociations:
         # requires full bundle deployment to produce an interactive content type
         cls.content = cls.client.content.create(name="example-flask-minimal")
         # create bundle
-        path = Path(
-            "../../../../resources/connect/bundles/example-flask-minimal/bundle.tar.gz"
-        )
+        path = Path("../../../../resources/connect/bundles/example-flask-minimal/bundle.tar.gz")
         path = (Path(__file__).parent / path).resolve()
         bundle = cls.content.bundles.create(str(path))
         # deploy bundle
@@ -89,10 +87,7 @@ class TestAssociations:
         updated_associations = self.content.oauth.associations.find()
         assert len(updated_associations) == 1
         assert updated_associations[0]["app_guid"] == self.content["guid"]
-        assert (
-            updated_associations[0]["oauth_integration_guid"]
-            == self.another_integration.guid
-        )
+        assert updated_associations[0]["oauth_integration_guid"] == self.another_integration.guid
 
         # unset content association
         self.content.oauth.associations.delete()

--- a/integration/tests/posit/connect/test_content.py
+++ b/integration/tests/posit/connect/test_content.py
@@ -49,9 +49,7 @@ class TestContent:
         # create content
         content = self.client.content.create(name="example-flask-minimal")
         # create bundle
-        path = Path(
-            "../../../resources/connect/bundles/example-flask-minimal/bundle.tar.gz"
-        )
+        path = Path("../../../resources/connect/bundles/example-flask-minimal/bundle.tar.gz")
         path = (Path(__file__).parent / path).resolve()
         bundle = content.bundles.create(str(path))
         # deploy bundle
@@ -70,9 +68,7 @@ class TestContent:
         # create content
         content = self.client.content.create(name="example-quarto-minimal")
         # create bundle
-        path = Path(
-            "../../../resources/connect/bundles/example-quarto-minimal/bundle.tar.gz"
-        )
+        path = Path("../../../resources/connect/bundles/example-quarto-minimal/bundle.tar.gz")
         path = (Path(__file__).parent / path).resolve()
         bundle = content.bundles.create(str(path))
         # deploy bundle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,20 +80,11 @@ ignore = [
     'D103', # TODO(#135) implement docstring for public functions
     'D104', # TODO(#135) implement docstring for public package
     'D105', # TODO(#135) implement docstring for magic methods
-    'D107',
-    'D203',
-    'D212',
-    'D213',
     'D100', # TODO(#135) implement docstring for public modules
     'D102', # TODO(#135) implement docstring for public methods
     'D401', # TODO(#135) fix imperative mood warnings
-    'D402',
-    'D413',
-    'D415',
-    'D416',
-    'D417',
-    'D418', # The Python Language Server can accomodate documentation for individual methods.
-            # TODO(#135) resarch D418 and determine if we should continue ignoring it.
+
+    'D418', # D418 contradicts the overload convention used in this project to describe different endpoints across Connect versions.
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ version_file = "src/posit/_version.py"
 
 [tool.ruff]
 extend-exclude = ["integration/resources"]
+line-length = 99
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ version_file = "src/posit/_version.py"
 
 [tool.ruff]
 extend-exclude = ["integration/resources"]
-line-length = 79
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -140,11 +140,7 @@ class Client:
         url = None
         if len(args) == 1 and isinstance(args[0], str):
             url = args[0]
-        elif (
-            len(args) == 2
-            and isinstance(args[0], str)
-            and isinstance(args[1], str)
-        ):
+        elif len(args) == 2 and isinstance(args[0], str) and isinstance(args[1], str):
             url = args[0]
             api_key = args[1]
         else:

--- a/src/posit/connect/config.py
+++ b/src/posit/connect/config.py
@@ -21,9 +21,7 @@ def _get_api_key() -> str:
     """
     value = os.environ.get("CONNECT_API_KEY")
     if not value:
-        raise ValueError(
-            "Invalid value for 'CONNECT_API_KEY': Must be a non-empty string."
-        )
+        raise ValueError("Invalid value for 'CONNECT_API_KEY': Must be a non-empty string.")
     return value
 
 
@@ -42,17 +40,13 @@ def _get_url() -> str:
     """
     value = os.environ.get("CONNECT_SERVER")
     if not value:
-        raise ValueError(
-            "Invalid value for 'CONNECT_SERVER': Must be a non-empty string."
-        )
+        raise ValueError("Invalid value for 'CONNECT_SERVER': Must be a non-empty string.")
     return value
 
 
 class Config:
     """Configuration object."""
 
-    def __init__(
-        self, api_key: Optional[str] = None, url: Optional[str] = None
-    ) -> None:
+    def __init__(self, api_key: Optional[str] = None, url: Optional[str] = None) -> None:
         self.api_key = api_key or _get_api_key()
         self.url = urls.Url(url or _get_url())

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -414,9 +414,7 @@ class Content(Resources):
         ...
 
     @overload
-    def find(
-        self, *args, include: Optional[str] = "owner,tags", **kwargs
-    ) -> List[ContentItem]:
+    def find(self, *args, include: Optional[str] = "owner,tags", **kwargs) -> List[ContentItem]:
         """Find content items.
 
         Parameters
@@ -430,9 +428,7 @@ class Content(Resources):
         """
         ...
 
-    def find(
-        self, *args, include: Optional[str] = "owner,tags", **kwargs
-    ) -> List[ContentItem]:
+    def find(self, *args, include: Optional[str] = "owner,tags", **kwargs) -> List[ContentItem]:
         """Find content items.
 
         Parameters

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -25,9 +25,7 @@ class ContentItemOAuth(Resource):
 
     @property
     def associations(self) -> ContentItemAssociations:
-        return ContentItemAssociations(
-            self.params, content_guid=self.content_guid
-        )
+        return ContentItemAssociations(self.params, content_guid=self.content_guid)
 
 
 class ContentItemOwner(Resource):
@@ -124,9 +122,7 @@ class ContentItem(Resource):
             self.environment_variables.create(key, unix_epoch_in_seconds)
             self.environment_variables.delete(key)
             # GET via the base Connect URL to force create a new worker thread.
-            url = posixpath.join(
-                dirname(self.params.url), f"content/{self.guid}"
-            )
+            url = posixpath.join(dirname(self.params.url), f"content/{self.guid}")
             self.params.session.get(url)
             return None
         else:

--- a/src/posit/connect/cursors.py
+++ b/src/posit/connect/cursors.py
@@ -16,9 +16,7 @@ class CursorPage:
 
 
 class CursorPaginator:
-    def __init__(
-        self, session: requests.Session, url: str, params: dict = {}
-    ) -> None:
+    def __init__(self, session: requests.Session, url: str, params: dict = {}) -> None:
         self.session = session
         self.url = url
         self.params = params

--- a/src/posit/connect/env.py
+++ b/src/posit/connect/env.py
@@ -51,9 +51,7 @@ class EnvVars(Resources, MutableMapping[str, Optional[str]]):
         Examples
         --------
         >>> vars = EnvVars(params, content_guid)
-        >>> vars["DATABASE_URL"] = (
-        ...     "postgres://user:password@localhost:5432/database"
-        ... )
+        >>> vars["DATABASE_URL"] = "postgres://user:password@localhost:5432/database"
         """
         self.update({key: value})
 
@@ -153,9 +151,7 @@ class EnvVars(Resources, MutableMapping[str, Optional[str]]):
         Examples
         --------
         Update using keyword arguments:
-        >>> update(
-        ...     DATABASE_URL="postgres://user:password@localhost:5432/database"
-        ... )
+        >>> update(DATABASE_URL="postgres://user:password@localhost:5432/database")
 
         Update using multiple keyword arguments:
         >>> update(

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -92,9 +92,7 @@ class PositCredentialsStrategy(CredentialsStrategy):
         # If the user-session-token wasn't provided and we're running on Connect then we raise an exception.
         # user_session_token is required to impersonate the viewer.
         if self._user_session_token is None:
-            raise ValueError(
-                "The user-session-token is required for viewer authentication."
-            )
+            raise ValueError("The user-session-token is required for viewer authentication.")
 
         if self._client is None:
             self._client = Client()

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -35,14 +35,10 @@ class PositCredentialsProvider:
         self._user_session_token = user_session_token
 
     def __call__(self) -> Dict[str, str]:
-        credentials = self._client.oauth.get_credentials(
-            self._user_session_token
-        )
+        credentials = self._client.oauth.get_credentials(self._user_session_token)
         access_token = credentials.get("access_token")
         if access_token is None:
-            raise ValueError(
-                "Missing value for field 'access_token' in credentials."
-            )
+            raise ValueError("Missing value for field 'access_token' in credentials.")
         return {"Authorization": f"Bearer {access_token}"}
 
 

--- a/src/posit/connect/external/snowflake.py
+++ b/src/posit/connect/external/snowflake.py
@@ -40,7 +40,5 @@ class PositAuthenticator:
         if self._client is None:
             self._client = Client()
 
-        credentials = self._client.oauth.get_credentials(
-            self._user_session_token
-        )
+        credentials = self._client.oauth.get_credentials(self._user_session_token)
         return credentials.get("access_token")

--- a/src/posit/connect/external/snowflake.py
+++ b/src/posit/connect/external/snowflake.py
@@ -33,9 +33,7 @@ class PositAuthenticator:
         # If the user-session-token wasn't provided and we're running on Connect then we raise an exception.
         # user_session_token is required to impersonate the viewer.
         if self._user_session_token is None:
-            raise ValueError(
-                "The user-session-token is required for viewer authentication."
-            )
+            raise ValueError("The user-session-token is required for viewer authentication.")
 
         if self._client is None:
             self._client = Client()

--- a/src/posit/connect/groups.py
+++ b/src/posit/connect/groups.py
@@ -161,8 +161,6 @@ class Groups(Resources):
         """
         path = "v1/groups"
         url = self.params.url + path
-        response: requests.Response = self.params.session.get(
-            url, params={"page_size": 1}
-        )
+        response: requests.Response = self.params.session.get(url, params={"page_size": 1})
         result: dict = response.json()
         return result["total"]

--- a/src/posit/connect/hooks.py
+++ b/src/posit/connect/hooks.py
@@ -24,9 +24,7 @@ def handle_errors(response: Response, *args, **kwargs) -> Response:
     return response
 
 
-def check_for_deprecation_header(
-    response: Response, *args, **kwargs
-) -> Response:
+def check_for_deprecation_header(response: Response, *args, **kwargs) -> Response:
     """
     Check for deprecation warnings from the server.
 

--- a/src/posit/connect/hooks.py
+++ b/src/posit/connect/hooks.py
@@ -15,9 +15,7 @@ def handle_errors(response: Response, *args, **kwargs) -> Response:
             payload = data.get("payload")
             http_status = response.status_code
             http_status_message = responses[http_status]
-            raise ClientError(
-                error_code, message, http_status, http_status_message, payload
-            )
+            raise ClientError(error_code, message, http_status, http_status_message, payload)
         except JSONDecodeError:
             # No JSON error message from Connect, so just raise
             response.raise_for_status()

--- a/src/posit/connect/oauth/associations.py
+++ b/src/posit/connect/oauth/associations.py
@@ -12,9 +12,7 @@ class Association(Resource):
 class IntegrationAssociations(Resources):
     """IntegrationAssociations resource."""
 
-    def __init__(
-        self, params: ResourceParameters, integration_guid: str
-    ) -> None:
+    def __init__(self, params: ResourceParameters, integration_guid: str) -> None:
         super().__init__(params)
         self.integration_guid = integration_guid
 
@@ -52,9 +50,7 @@ class ContentItemAssociations(Resources):
         -------
         List[Association]
         """
-        path = (
-            f"v1/content/{self.content_guid}/oauth/integrations/associations"
-        )
+        path = f"v1/content/{self.content_guid}/oauth/integrations/associations"
         url = self.params.url + path
         response = self.params.session.get(url)
         return [
@@ -69,9 +65,7 @@ class ContentItemAssociations(Resources):
         """Delete integration associations."""
         data = []
 
-        path = (
-            f"v1/content/{self.content_guid}/oauth/integrations/associations"
-        )
+        path = f"v1/content/{self.content_guid}/oauth/integrations/associations"
         url = self.params.url + path
         self.params.session.put(url, json=data)
 
@@ -79,8 +73,6 @@ class ContentItemAssociations(Resources):
         """Set integration associations."""
         data = [{"oauth_integration_guid": integration_guid}]
 
-        path = (
-            f"v1/content/{self.content_guid}/oauth/integrations/associations"
-        )
+        path = f"v1/content/{self.content_guid}/oauth/integrations/associations"
         url = self.params.url + path
         self.params.session.put(url, json=data)

--- a/src/posit/connect/oauth/integrations.py
+++ b/src/posit/connect/oauth/integrations.py
@@ -12,9 +12,7 @@ class Integration(Resource):
 
     @property
     def associations(self) -> IntegrationAssociations:
-        return IntegrationAssociations(
-            self.params, integration_guid=self["guid"]
-        )
+        return IntegrationAssociations(self.params, integration_guid=self["guid"])
 
     def delete(self) -> None:
         """Delete the OAuth integration."""

--- a/src/posit/connect/oauth/oauth.py
+++ b/src/posit/connect/oauth/oauth.py
@@ -20,9 +20,7 @@ class OAuth(Resources):
     def sessions(self):
         return Sessions(self.params)
 
-    def get_credentials(
-        self, user_session_token: Optional[str] = None
-    ) -> Credentials:
+    def get_credentials(self, user_session_token: Optional[str] = None) -> Credentials:
         url = self.params.url + "v1/oauth/integrations/credentials"
 
         # craft a credential exchange request

--- a/src/posit/connect/paginator.py
+++ b/src/posit/connect/paginator.py
@@ -38,9 +38,7 @@ class Paginator:
         url (str): The URL of the paginated API endpoint.
     """
 
-    def __init__(
-        self, session: requests.Session, url: str, params: dict = {}
-    ) -> None:
+    def __init__(self, session: requests.Session, url: str, params: dict = {}) -> None:
         self.session = session
         self.url = url
         self.params = params

--- a/src/posit/connect/permissions.py
+++ b/src/posit/connect/permissions.py
@@ -65,9 +65,7 @@ class Permissions(Resources):
         return len(self.find())
 
     @overload
-    def create(
-        self, *, principal_guid: str, principal_type: str, role: str
-    ) -> Permission:
+    def create(self, *, principal_guid: str, principal_type: str, role: str) -> Permission:
         """Create a permission.
 
         Parameters

--- a/src/posit/connect/urls.py
+++ b/src/posit/connect/urls.py
@@ -77,13 +77,9 @@ def _create(url: str) -> str:
     """
     split = urlsplit(url, allow_fragments=False)
     if not split.scheme:
-        raise ValueError(
-            f"URL must specify a scheme (e.g., http://example.com/__api__): {url}"
-        )
+        raise ValueError(f"URL must specify a scheme (e.g., http://example.com/__api__): {url}")
     if not split.netloc:
-        raise ValueError(
-            f"URL must be absolute (e.g., http://example.com/__api__): {url}"
-        )
+        raise ValueError(f"URL must be absolute (e.g., http://example.com/__api__): {url}")
 
     url = url.rstrip("/")
     if "/__api__" not in url:

--- a/src/posit/connect/urls.py
+++ b/src/posit/connect/urls.py
@@ -116,6 +116,4 @@ def _append(url: str, path) -> str:
     path = str(path).strip("/")
     split = urlsplit(url, allow_fragments=False)
     new_path = posixpath.join(split.path, path)
-    return urlunsplit(
-        (split.scheme, split.netloc, new_path, split.query, None)
-    )
+    return urlunsplit((split.scheme, split.netloc, new_path, split.query, None))

--- a/tests/posit/connect/metrics/test_shiny_usage.py
+++ b/tests/posit/connect/metrics/test_shiny_usage.py
@@ -52,9 +52,7 @@ class TestShinyUsageFind:
 
         mock_get[1] = responses.get(
             f"https://connect.example/__api__/v1/instrumentation/shiny/usage",
-            json=load_mock(
-                "v1/instrumentation/shiny/usage?limit=500&next=23948901087.json"
-            ),
+            json=load_mock("v1/instrumentation/shiny/usage?limit=500&next=23948901087.json"),
             match=[
                 matchers.query_param_matcher(
                     {
@@ -66,9 +64,7 @@ class TestShinyUsageFind:
         )
 
         # setup
-        params = ResourceParameters(
-            requests.Session(), "https://connect.example/__api__"
-        )
+        params = ResourceParameters(requests.Session(), "https://connect.example/__api__")
 
         # invoke
         events = shiny_usage.ShinyUsage(params).find()
@@ -98,9 +94,7 @@ class TestShinyUsageFindOne:
 
         mock_get[1] = responses.get(
             f"https://connect.example/__api__/v1/instrumentation/shiny/usage",
-            json=load_mock(
-                "v1/instrumentation/shiny/usage?limit=500&next=23948901087.json"
-            ),
+            json=load_mock("v1/instrumentation/shiny/usage?limit=500&next=23948901087.json"),
             match=[
                 matchers.query_param_matcher(
                     {
@@ -112,9 +106,7 @@ class TestShinyUsageFindOne:
         )
 
         # setup
-        params = ResourceParameters(
-            requests.Session(), "https://connect.example/__api__"
-        )
+        params = ResourceParameters(requests.Session(), "https://connect.example/__api__")
 
         # invoke
         event = shiny_usage.ShinyUsage(params).find_one()

--- a/tests/posit/connect/metrics/test_shiny_usage.py
+++ b/tests/posit/connect/metrics/test_shiny_usage.py
@@ -14,15 +14,11 @@ class TestShinyUsageEventAttributes:
     def setup_class(cls):
         cls.event = shiny_usage.ShinyUsageEvent(
             mock.Mock(),
-            **load_mock("v1/instrumentation/shiny/usage?limit=500.json")[
-                "results"
-            ][0],
+            **load_mock("v1/instrumentation/shiny/usage?limit=500.json")["results"][0],
         )
 
     def test_content_guid(self):
-        assert (
-            self.event.content_guid == "bd1d2285-6c80-49af-8a83-a200effe3cb3"
-        )
+        assert self.event.content_guid == "bd1d2285-6c80-49af-8a83-a200effe3cb3"
 
     def test_user_guid(self):
         assert self.event.user_guid == "08e3a41d-1f8e-47f2-8855-f05ea3b0d4b2"

--- a/tests/posit/connect/metrics/test_usage.py
+++ b/tests/posit/connect/metrics/test_usage.py
@@ -20,9 +20,7 @@ class TestUsageEventFromVisitEvent:
     def setup_class(cls):
         visit_event = visits.VisitEvent(
             mock.Mock(),
-            **load_mock("v1/instrumentation/content/visits?limit=500.json")["results"][
-                0
-            ],
+            **load_mock("v1/instrumentation/content/visits?limit=500.json")["results"][0],
         )
         cls.view_event = usage.UsageEvent.from_visit_event(visit_event)
 
@@ -110,9 +108,7 @@ class TestUsageFind:
 
         mock_get[1] = responses.get(
             f"https://connect.example/__api__/v1/instrumentation/content/visits",
-            json=load_mock(
-                "v1/instrumentation/content/visits?limit=500&next=23948901087.json"
-            ),
+            json=load_mock("v1/instrumentation/content/visits?limit=500&next=23948901087.json"),
             match=[
                 matchers.query_param_matcher(
                     {
@@ -137,9 +133,7 @@ class TestUsageFind:
 
         mock_get[3] = responses.get(
             f"https://connect.example/__api__/v1/instrumentation/shiny/usage",
-            json=load_mock(
-                "v1/instrumentation/shiny/usage?limit=500&next=23948901087.json"
-            ),
+            json=load_mock("v1/instrumentation/shiny/usage?limit=500&next=23948901087.json"),
             match=[
                 matchers.query_param_matcher(
                     {
@@ -184,9 +178,7 @@ class TestUsageFindOne:
 
         mock_get[1] = responses.get(
             f"https://connect.example/__api__/v1/instrumentation/content/visits",
-            json=load_mock(
-                "v1/instrumentation/content/visits?limit=500&next=23948901087.json"
-            ),
+            json=load_mock("v1/instrumentation/content/visits?limit=500&next=23948901087.json"),
             match=[
                 matchers.query_param_matcher(
                     {
@@ -211,9 +203,7 @@ class TestUsageFindOne:
 
         mock_get[3] = responses.get(
             f"https://connect.example/__api__/v1/instrumentation/shiny/usage",
-            json=load_mock(
-                "v1/instrumentation/shiny/usage?limit=500&next=23948901087.json"
-            ),
+            json=load_mock("v1/instrumentation/shiny/usage?limit=500&next=23948901087.json"),
             match=[
                 matchers.query_param_matcher(
                     {
@@ -246,16 +236,12 @@ class TestUsageFindOne:
         # return an empty result set to push through the iterator
         mock_get[0] = responses.get(
             f"https://connect.example/__api__/v1/instrumentation/content/visits",
-            json=load_mock(
-                "v1/instrumentation/content/visits?limit=500&next=23948901087.json"
-            ),
+            json=load_mock("v1/instrumentation/content/visits?limit=500&next=23948901087.json"),
         )
 
         mock_get[1] = responses.get(
             f"https://connect.example/__api__/v1/instrumentation/shiny/usage",
-            json=load_mock(
-                "v1/instrumentation/shiny/usage?limit=500&next=23948901087.json"
-            ),
+            json=load_mock("v1/instrumentation/shiny/usage?limit=500&next=23948901087.json"),
         )
 
         # setup

--- a/tests/posit/connect/metrics/test_usage.py
+++ b/tests/posit/connect/metrics/test_usage.py
@@ -20,22 +20,17 @@ class TestUsageEventFromVisitEvent:
     def setup_class(cls):
         visit_event = visits.VisitEvent(
             mock.Mock(),
-            **load_mock("v1/instrumentation/content/visits?limit=500.json")[
-                "results"
-            ][0],
+            **load_mock("v1/instrumentation/content/visits?limit=500.json")["results"][
+                0
+            ],
         )
         cls.view_event = usage.UsageEvent.from_visit_event(visit_event)
 
     def test_content_guid(self):
-        assert (
-            self.view_event.content_guid
-            == "bd1d2285-6c80-49af-8a83-a200effe3cb3"
-        )
+        assert self.view_event.content_guid == "bd1d2285-6c80-49af-8a83-a200effe3cb3"
 
     def test_user_guid(self):
-        assert (
-            self.view_event.user_guid == "08e3a41d-1f8e-47f2-8855-f05ea3b0d4b2"
-        )
+        assert self.view_event.user_guid == "08e3a41d-1f8e-47f2-8855-f05ea3b0d4b2"
 
     def test_variant_key(self):
         assert self.view_event.variant_key == "HidI2Kwq"
@@ -63,22 +58,15 @@ class TestUsageEventFromShinyUsageEvent:
     def setup_class(cls):
         visit_event = shiny_usage.ShinyUsageEvent(
             mock.Mock(),
-            **load_mock("v1/instrumentation/shiny/usage?limit=500.json")[
-                "results"
-            ][0],
+            **load_mock("v1/instrumentation/shiny/usage?limit=500.json")["results"][0],
         )
         cls.view_event = usage.UsageEvent.from_shiny_usage_event(visit_event)
 
     def test_content_guid(self):
-        assert (
-            self.view_event.content_guid
-            == "bd1d2285-6c80-49af-8a83-a200effe3cb3"
-        )
+        assert self.view_event.content_guid == "bd1d2285-6c80-49af-8a83-a200effe3cb3"
 
     def test_user_guid(self):
-        assert (
-            self.view_event.user_guid == "08e3a41d-1f8e-47f2-8855-f05ea3b0d4b2"
-        )
+        assert self.view_event.user_guid == "08e3a41d-1f8e-47f2-8855-f05ea3b0d4b2"
 
     def test_variant_key(self):
         assert self.view_event.variant_key is None
@@ -248,9 +236,7 @@ class TestUsageFindOne:
         assert mock_get[2].call_count == 0
         assert mock_get[3].call_count == 0
         assert view_event
-        assert (
-            view_event.content_guid == "bd1d2285-6c80-49af-8a83-a200effe3cb3"
-        )
+        assert view_event.content_guid == "bd1d2285-6c80-49af-8a83-a200effe3cb3"
 
     @responses.activate
     def test_none(self):

--- a/tests/posit/connect/metrics/test_visits.py
+++ b/tests/posit/connect/metrics/test_visits.py
@@ -14,9 +14,7 @@ class TestVisitAttributes:
     def setup_class(cls):
         cls.visit = visits.VisitEvent(
             mock.Mock(),
-            **load_mock("v1/instrumentation/content/visits?limit=500.json")["results"][
-                0
-            ],
+            **load_mock("v1/instrumentation/content/visits?limit=500.json")["results"][0],
         )
 
     def test_content_guid(self):
@@ -63,9 +61,7 @@ class TestVisitsFind:
 
         mock_get[1] = responses.get(
             f"https://connect.example/__api__/v1/instrumentation/content/visits",
-            json=load_mock(
-                "v1/instrumentation/content/visits?limit=500&next=23948901087.json"
-            ),
+            json=load_mock("v1/instrumentation/content/visits?limit=500&next=23948901087.json"),
             match=[
                 matchers.query_param_matcher(
                     {
@@ -77,9 +73,7 @@ class TestVisitsFind:
         )
 
         # setup
-        params = ResourceParameters(
-            requests.Session(), "https://connect.example/__api__"
-        )
+        params = ResourceParameters(requests.Session(), "https://connect.example/__api__")
 
         # invoke
         events = visits.Visits(params).find()
@@ -109,9 +103,7 @@ class TestVisitsFindOne:
 
         mock_get[1] = responses.get(
             f"https://connect.example/__api__/v1/instrumentation/content/visits",
-            json=load_mock(
-                "v1/instrumentation/content/visits?limit=500&next=23948901087.json"
-            ),
+            json=load_mock("v1/instrumentation/content/visits?limit=500&next=23948901087.json"),
             match=[
                 matchers.query_param_matcher(
                     {
@@ -123,9 +115,7 @@ class TestVisitsFindOne:
         )
 
         # setup
-        params = ResourceParameters(
-            requests.Session(), "https://connect.example/__api__"
-        )
+        params = ResourceParameters(requests.Session(), "https://connect.example/__api__")
 
         # invoke
         event = visits.Visits(params).find_one()

--- a/tests/posit/connect/metrics/test_visits.py
+++ b/tests/posit/connect/metrics/test_visits.py
@@ -14,15 +14,13 @@ class TestVisitAttributes:
     def setup_class(cls):
         cls.visit = visits.VisitEvent(
             mock.Mock(),
-            **load_mock("v1/instrumentation/content/visits?limit=500.json")[
-                "results"
-            ][0],
+            **load_mock("v1/instrumentation/content/visits?limit=500.json")["results"][
+                0
+            ],
         )
 
     def test_content_guid(self):
-        assert (
-            self.visit.content_guid == "bd1d2285-6c80-49af-8a83-a200effe3cb3"
-        )
+        assert self.visit.content_guid == "bd1d2285-6c80-49af-8a83-a200effe3cb3"
 
     def test_user_guid(self):
         assert self.visit.user_guid == "08e3a41d-1f8e-47f2-8855-f05ea3b0d4b2"

--- a/tests/posit/connect/oauth/test_associations.py
+++ b/tests/posit/connect/oauth/test_associations.py
@@ -23,10 +23,7 @@ class TestAssociationAttributes:
         assert self.item["app_guid"] == "f2f37341-e21d-3d80-c698-a935ad614066"
 
     def test_oauth_integration_guid(self):
-        assert (
-            self.item["oauth_integration_guid"]
-            == "22644575-a27b-4118-ad06-e24459b05126"
-        )
+        assert self.item["oauth_integration_guid"] == "22644575-a27b-4118-ad06-e24459b05126"
 
     def test_oauth_integration_name(self):
         assert self.item["oauth_integration_name"] == "keycloak integration"

--- a/tests/posit/connect/oauth/test_associations.py
+++ b/tests/posit/connect/oauth/test_associations.py
@@ -12,9 +12,7 @@ class TestAssociationAttributes:
     @classmethod
     def setup_class(cls):
         guid = "22644575-a27b-4118-ad06-e24459b05126"
-        fake_items = load_mock(
-            f"v1/oauth/integrations/{guid}/associations.json"
-        )
+        fake_items = load_mock(f"v1/oauth/integrations/{guid}/associations.json")
 
         assert len(fake_items) == 1
         fake_item = fake_items[0]
@@ -34,10 +32,7 @@ class TestAssociationAttributes:
         assert self.item["oauth_integration_name"] == "keycloak integration"
 
     def test_oauth_integration_description(self):
-        assert (
-            self.item["oauth_integration_description"]
-            == "integration description"
-        )
+        assert self.item["oauth_integration_description"] == "integration description"
 
     def test_oauth_integration_template(self):
         assert self.item["oauth_integration_template"] == "custom"
@@ -86,9 +81,7 @@ class TestContentAssociationsFind:
         )
         mock_get_association = responses.get(
             f"https://connect.example/__api__/v1/content/{guid}/oauth/integrations/associations",
-            json=load_mock(
-                f"v1/content/{guid}/oauth/integrations/associations.json"
-            ),
+            json=load_mock(f"v1/content/{guid}/oauth/integrations/associations.json"),
         )
 
         # setup

--- a/tests/posit/connect/oauth/test_integrations.py
+++ b/tests/posit/connect/oauth/test_integrations.py
@@ -40,10 +40,7 @@ class TestIntegrationAttributes:
         )
         assert self.item.config["client_id"] == "rsconnect-oidc"
         assert self.item.config["scopes"] == "email"
-        assert (
-            self.item.config["token_endpoint_auth_method"]
-            == "client_secret_basic"
-        )
+        assert self.item.config["token_endpoint_auth_method"] == "client_secret_basic"
         assert (
             self.item.config["token_uri"]
             == "http://keycloak:8080/realms/rsconnect/protocol/openid-connect/token"

--- a/tests/posit/connect/oauth/test_oauth.py
+++ b/tests/posit/connect/oauth/test_oauth.py
@@ -24,6 +24,4 @@ class TestOAuthIntegrations:
             },
         )
         con = Client(api_key="12345", url="https://connect.example/")
-        assert (
-            con.oauth.get_credentials("cit")["access_token"] == "viewer-token"
-        )
+        assert con.oauth.get_credentials("cit")["access_token"] == "viewer-token"

--- a/tests/posit/connect/oauth/test_sessions.py
+++ b/tests/posit/connect/oauth/test_sessions.py
@@ -26,9 +26,7 @@ class TestOAuthSessionAttributes:
         assert self.item.user_guid == "217be1f2-6a32-46b9-af78-e3f4b89f2e74"
 
     def test_oauth_integration_guid(self):
-        assert (
-            self.item.oauth_integration_guid == "967f0ad3-3e3b-4491-8539-1a193b35a415"
-        )
+        assert self.item.oauth_integration_guid == "967f0ad3-3e3b-4491-8539-1a193b35a415"
 
     def test_has_refresh_token(self):
         assert self.item.has_refresh_token
@@ -51,9 +49,7 @@ class TestSessionDelete:
             json=load_mock(f"v1/oauth/sessions/{guid}.json"),
         )
 
-        mock_delete = responses.delete(
-            f"https://connect.example/__api__/v1/oauth/sessions/{guid}"
-        )
+        mock_delete = responses.delete(f"https://connect.example/__api__/v1/oauth/sessions/{guid}")
 
         # setup
         c = Client("https://connect.example", "12345")

--- a/tests/posit/connect/oauth/test_sessions.py
+++ b/tests/posit/connect/oauth/test_sessions.py
@@ -27,8 +27,7 @@ class TestOAuthSessionAttributes:
 
     def test_oauth_integration_guid(self):
         assert (
-            self.item.oauth_integration_guid
-            == "967f0ad3-3e3b-4491-8539-1a193b35a415"
+            self.item.oauth_integration_guid == "967f0ad3-3e3b-4491-8539-1a193b35a415"
         )
 
     def test_has_refresh_token(self):

--- a/tests/posit/connect/test_bundles.py
+++ b/tests/posit/connect/test_bundles.py
@@ -24,9 +24,7 @@ class TestBundleProperties:
         assert self.bundle.id == "101"
 
     def test_content_guid(self):
-        assert (
-            self.bundle.content_guid == "f2f37341-e21d-3d80-c698-a935ad614066"
-        )
+        assert self.bundle.content_guid == "f2f37341-e21d-3d80-c698-a935ad614066"
 
     def test_created_time(self):
         assert self.bundle.created_time == "2006-01-02T15:04:05Z07:00"
@@ -71,10 +69,7 @@ class TestBundleProperties:
         assert self.bundle.metadata.source_commit == "string"
 
     def test_metadata_archive_md5(self):
-        assert (
-            self.bundle.metadata.archive_md5
-            == "37324238a80595c453c706b22adb83d3"
-        )
+        assert self.bundle.metadata.archive_md5 == "37324238a80595c453c706b22adb83d3"
 
     def test_metadata_archive_sha1(self):
         assert (
@@ -97,9 +92,7 @@ class TestBundleDelete:
 
         mock_bundle_get = responses.get(
             f"https://connect.example/__api__/v1/content/{content_guid}/bundles/{bundle_id}",
-            json=load_mock(
-                f"v1/content/{content_guid}/bundles/{bundle_id}.json"
-            ),
+            json=load_mock(f"v1/content/{content_guid}/bundles/{bundle_id}.json"),
         )
 
         mock_bundle_delete = responses.delete(
@@ -134,9 +127,7 @@ class TestBundleDeploy:
 
         mock_bundle_get = responses.get(
             f"https://connect.example/__api__/v1/content/{content_guid}/bundles/{bundle_id}",
-            json=load_mock(
-                f"v1/content/{content_guid}/bundles/{bundle_id}.json"
-            ),
+            json=load_mock(f"v1/content/{content_guid}/bundles/{bundle_id}.json"),
         )
 
         mock_bundle_deploy = responses.post(
@@ -183,9 +174,7 @@ class TestBundleDownload:
 
         mock_bundle_get = responses.get(
             f"https://connect.example/__api__/v1/content/{content_guid}/bundles/{bundle_id}",
-            json=load_mock(
-                f"v1/content/{content_guid}/bundles/{bundle_id}.json"
-            ),
+            json=load_mock(f"v1/content/{content_guid}/bundles/{bundle_id}.json"),
         )
 
         mock_bundle_download = responses.get(
@@ -222,9 +211,7 @@ class TestBundleDownload:
 
         mock_bundle_get = responses.get(
             f"https://connect.example/__api__/v1/content/{content_guid}/bundles/{bundle_id}",
-            json=load_mock(
-                f"v1/content/{content_guid}/bundles/{bundle_id}.json"
-            ),
+            json=load_mock(f"v1/content/{content_guid}/bundles/{bundle_id}.json"),
         )
 
         mock_bundle_download = responses.get(
@@ -264,9 +251,7 @@ class TestBundleDownload:
 
         mock_bundle_get = responses.get(
             f"https://connect.example/__api__/v1/content/{content_guid}/bundles/{bundle_id}",
-            json=load_mock(
-                f"v1/content/{content_guid}/bundles/{bundle_id}.json"
-            ),
+            json=load_mock(f"v1/content/{content_guid}/bundles/{bundle_id}.json"),
         )
 
         mock_bundle_download = responses.get(
@@ -304,9 +289,7 @@ class TestBundlesCreate:
 
         mock_bundle_post = responses.post(
             f"https://connect.example/__api__/v1/content/{content_guid}/bundles",
-            json=load_mock(
-                f"v1/content/{content_guid}/bundles/{bundle_id}.json"
-            ),
+            json=load_mock(f"v1/content/{content_guid}/bundles/{bundle_id}.json"),
         )
 
         # setup
@@ -338,9 +321,7 @@ class TestBundlesCreate:
 
         mock_bundle_post = responses.post(
             f"https://connect.example/__api__/v1/content/{content_guid}/bundles",
-            json=load_mock(
-                f"v1/content/{content_guid}/bundles/{bundle_id}.json"
-            ),
+            json=load_mock(f"v1/content/{content_guid}/bundles/{bundle_id}.json"),
         )
 
         # setup
@@ -446,9 +427,7 @@ class TestBundlesGet:
 
         mock_bundle_get = responses.get(
             f"https://connect.example/__api__/v1/content/{content_guid}/bundles/{bundle_id}",
-            json=load_mock(
-                f"v1/content/{content_guid}/bundles/{bundle_id}.json"
-            ),
+            json=load_mock(f"v1/content/{content_guid}/bundles/{bundle_id}.json"),
         )
 
         # setup

--- a/tests/posit/connect/test_bundles.py
+++ b/tests/posit/connect/test_bundles.py
@@ -15,9 +15,7 @@ class TestBundleProperties:
     def setup_class(cls):
         cls.bundle = Bundle(
             mock.Mock(),
-            **load_mock(
-                f"v1/content/f2f37341-e21d-3d80-c698-a935ad614066/bundles/101.json"
-            ),
+            **load_mock(f"v1/content/f2f37341-e21d-3d80-c698-a935ad614066/bundles/101.json"),
         )
 
     def test_id(self):
@@ -72,10 +70,7 @@ class TestBundleProperties:
         assert self.bundle.metadata.archive_md5 == "37324238a80595c453c706b22adb83d3"
 
     def test_metadata_archive_sha1(self):
-        assert (
-            self.bundle.metadata.archive_sha1
-            == "a2f7d13d87657df599aeeabdb70194d508cfa92f"
-        )
+        assert self.bundle.metadata.archive_sha1 == "a2f7d13d87657df599aeeabdb70194d508cfa92f"
 
 
 class TestBundleDelete:
@@ -162,9 +157,7 @@ class TestBundleDownload:
     def test_output_as_str(self, mock_file: mock.MagicMock):
         content_guid = "f2f37341-e21d-3d80-c698-a935ad614066"
         bundle_id = "101"
-        path = get_path(
-            f"v1/content/{content_guid}/bundles/{bundle_id}/download/bundle.tar.gz"
-        )
+        path = get_path(f"v1/content/{content_guid}/bundles/{bundle_id}/download/bundle.tar.gz")
 
         # behavior
         mock_content_get = responses.get(
@@ -199,9 +192,7 @@ class TestBundleDownload:
     def test_output_as_io(self):
         content_guid = "f2f37341-e21d-3d80-c698-a935ad614066"
         bundle_id = "101"
-        path = get_path(
-            f"v1/content/{content_guid}/bundles/{bundle_id}/download/bundle.tar.gz"
-        )
+        path = get_path(f"v1/content/{content_guid}/bundles/{bundle_id}/download/bundle.tar.gz")
 
         # behavior
         mock_content_get = responses.get(
@@ -239,9 +230,7 @@ class TestBundleDownload:
     def test_invalid_arguments(self):
         content_guid = "f2f37341-e21d-3d80-c698-a935ad614066"
         bundle_id = "101"
-        path = get_path(
-            f"v1/content/{content_guid}/bundles/{bundle_id}/download/bundle.tar.gz"
-        )
+        path = get_path(f"v1/content/{content_guid}/bundles/{bundle_id}/download/bundle.tar.gz")
 
         # behavior
         mock_content_get = responses.get(

--- a/tests/posit/connect/test_client.py
+++ b/tests/posit/connect/test_client.py
@@ -143,42 +143,32 @@ class TestClient:
         url = "https://connect.example.com"
         client = Client(api_key=api_key, url=url)
         client.get("/foo")
-        client.session.get.assert_called_once_with(
-            "https://connect.example.com/__api__/foo"
-        )
+        client.session.get.assert_called_once_with("https://connect.example.com/__api__/foo")
 
     def test_post(self, MockSession):
         api_key = "12345"
         url = "https://connect.example.com"
         client = Client(api_key=api_key, url=url)
         client.post("/foo")
-        client.session.post.assert_called_once_with(
-            "https://connect.example.com/__api__/foo"
-        )
+        client.session.post.assert_called_once_with("https://connect.example.com/__api__/foo")
 
     def test_put(self, MockSession):
         api_key = "12345"
         url = "https://connect.example.com"
         client = Client(api_key=api_key, url=url)
         client.put("/foo")
-        client.session.put.assert_called_once_with(
-            "https://connect.example.com/__api__/foo"
-        )
+        client.session.put.assert_called_once_with("https://connect.example.com/__api__/foo")
 
     def test_patch(self, MockSession):
         api_key = "12345"
         url = "https://connect.example.com"
         client = Client(api_key=api_key, url=url)
         client.patch("/foo")
-        client.session.patch.assert_called_once_with(
-            "https://connect.example.com/__api__/foo"
-        )
+        client.session.patch.assert_called_once_with("https://connect.example.com/__api__/foo")
 
     def test_delete(self, MockSession):
         api_key = "12345"
         url = "https://connect.example.com"
         client = Client(api_key=api_key, url=url)
         client.delete("/foo")
-        client.session.delete.assert_called_once_with(
-            "https://connect.example.com/__api__/foo"
-        )
+        client.session.delete.assert_called_once_with("https://connect.example.com/__api__/foo")

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -230,9 +230,7 @@ class TestContentItemDelete:
             json=load_mock(f"v1/content/{guid}.json"),
         )
 
-        mock_delete = responses.delete(
-            f"https://connect.example/__api__/v1/content/{guid}"
-        )
+        mock_delete = responses.delete(f"https://connect.example/__api__/v1/content/{guid}")
 
         # setup
         c = Client("https://connect.example", "12345")
@@ -421,9 +419,7 @@ class TestContentsFindOne:
             "https://connect.example/__api__/v1/content",
             json=load_mock("v1/content.json"),
             match=[
-                matchers.query_param_matcher(
-                    {"owner_guid": owner_guid, "include": "owner,tags"}
-                )
+                matchers.query_param_matcher({"owner_guid": owner_guid, "include": "owner,tags"})
             ],
         )
 
@@ -447,9 +443,7 @@ class TestContentsFindOne:
         mock_get = responses.get(
             "https://connect.example/__api__/v1/content",
             json=load_mock("v1/content.json"),
-            match=[
-                matchers.query_param_matcher({"name": name, "include": "owner,tags"})
-            ],
+            match=[matchers.query_param_matcher({"name": name, "include": "owner,tags"})],
         )
 
         # setup

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -188,9 +188,7 @@ class TestContentItemAttributes:
         assert isinstance(self.item.oauth, ContentItemOAuth)
 
     def test_oauth_associations(self):
-        assert isinstance(
-            self.item.oauth.associations, ContentItemAssociations
-        )
+        assert isinstance(self.item.oauth.associations, ContentItemAssociations)
 
     def test_tags(self):
         assert self.item.tags is None
@@ -199,9 +197,7 @@ class TestContentItemAttributes:
 class TestContentItemGetContentOwner:
     @responses.activate
     def test_owner(self):
-        mock_content = load_mock(
-            "v1/content/f2f37341-e21d-3d80-c698-a935ad614066.json"
-        )
+        mock_content = load_mock("v1/content/f2f37341-e21d-3d80-c698-a935ad614066.json")
         responses.get(
             "https://connect.example/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066",
             json=mock_content,
@@ -209,9 +205,7 @@ class TestContentItemGetContentOwner:
 
         mock_user_get = responses.get(
             f"https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",
-            json=load_mock(
-                f"v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"
-            ),
+            json=load_mock(f"v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
         )
 
         c = Client("https://connect.example", "12345")
@@ -324,11 +318,7 @@ class TestContentCreate:
         responses.post(
             f"https://connect.example/__api__/v1/content",
             json=load_mock(f"v1/content/{guid}.json"),
-            match=[
-                matchers.json_params_matcher(
-                    {"name": fake_content_item["name"]}
-                )
-            ],
+            match=[matchers.json_params_matcher({"name": fake_content_item["name"]})],
         )
 
         # setup
@@ -458,9 +448,7 @@ class TestContentsFindOne:
             "https://connect.example/__api__/v1/content",
             json=load_mock("v1/content.json"),
             match=[
-                matchers.query_param_matcher(
-                    {"name": name, "include": "owner,tags"}
-                )
+                matchers.query_param_matcher({"name": name, "include": "owner,tags"})
             ],
         )
 
@@ -517,9 +505,7 @@ class TestContentsGet:
     def test(self):
         responses.get(
             "https://connect.example/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066",
-            json=load_mock(
-                "v1/content/f2f37341-e21d-3d80-c698-a935ad614066.json"
-            ),
+            json=load_mock("v1/content/f2f37341-e21d-3d80-c698-a935ad614066.json"),
         )
         con = Client("https://connect.example", "12345")
         get_one = con.content.get("f2f37341-e21d-3d80-c698-a935ad614066")
@@ -609,16 +595,12 @@ class TestRender:
     def test_missing_default(self):
         responses.get(
             "https://connect.example.com/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066",
-            json=load_mock(
-                "v1/content/f2f37341-e21d-3d80-c698-a935ad614066.json"
-            ),
+            json=load_mock("v1/content/f2f37341-e21d-3d80-c698-a935ad614066.json"),
         )
 
         responses.patch(
             "https://connect.example.com/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066",
-            json=load_mock(
-                "v1/content/f2f37341-e21d-3d80-c698-a935ad614066.json"
-            ),
+            json=load_mock("v1/content/f2f37341-e21d-3d80-c698-a935ad614066.json"),
         )
 
         responses.get(

--- a/tests/posit/connect/test_permissions.py
+++ b/tests/posit/connect/test_permissions.py
@@ -25,9 +25,7 @@ class TestPermissionDelete:
         )
 
         # setup
-        params = ResourceParameters(
-            requests.Session(), Url("https://connect.example/__api__")
-        )
+        params = ResourceParameters(requests.Session(), Url("https://connect.example/__api__"))
         fake_permission = load_mock(f"v1/content/{content_guid}/permissions/{uid}.json")
         permission = Permission(params, **fake_permission)
 
@@ -71,9 +69,7 @@ class TestPermissionUpdate:
         )
 
         # setup
-        params = ResourceParameters(
-            requests.Session(), Url("https://connect.example/__api__")
-        )
+        params = ResourceParameters(requests.Session(), Url("https://connect.example/__api__"))
         permission = Permission(
             params,
             id=uid,
@@ -116,12 +112,8 @@ class TestPermissionUpdate:
         )
 
         # setup
-        params = ResourceParameters(
-            requests.Session(), Url("https://connect.example/__api__")
-        )
-        permission = Permission(
-            params, id=uid, content_guid=content_guid, role=old_role
-        )
+        params = ResourceParameters(requests.Session(), Url("https://connect.example/__api__"))
+        permission = Permission(params, id=uid, content_guid=content_guid, role=old_role)
 
         # assert role change with respect to api response
         assert permission.role == old_role
@@ -143,9 +135,7 @@ class TestPermissionsCount:
         )
 
         # setup
-        params = ResourceParameters(
-            requests.Session(), Url("https://connect.example/__api__")
-        )
+        params = ResourceParameters(requests.Session(), Url("https://connect.example/__api__"))
         permissions = Permissions(params, content_guid=content_guid)
 
         # invoke
@@ -187,9 +177,7 @@ class TestPermissionsCreate:
         )
 
         # setup
-        params = ResourceParameters(
-            requests.Session(), Url("https://connect.example/__api__")
-        )
+        params = ResourceParameters(requests.Session(), Url("https://connect.example/__api__"))
         permissions = Permissions(params, content_guid=content_guid)
 
         # invoke
@@ -217,9 +205,7 @@ class TestPermissionsFind:
         )
 
         # setup
-        params = ResourceParameters(
-            requests.Session(), Url("https://connect.example/__api__")
-        )
+        params = ResourceParameters(requests.Session(), Url("https://connect.example/__api__"))
         permissions = Permissions(params, content_guid=content_guid)
 
         # invoke
@@ -243,9 +229,7 @@ class TestPermissionsFindOne:
         )
 
         # setup
-        params = ResourceParameters(
-            requests.Session(), Url("https://connect.example/__api__")
-        )
+        params = ResourceParameters(requests.Session(), Url("https://connect.example/__api__"))
         permissions = Permissions(params, content_guid=content_guid)
 
         # invoke
@@ -270,9 +254,7 @@ class TestPermissionsGet:
         )
 
         # setup
-        params = ResourceParameters(
-            requests.Session(), Url("https://connect.example/__api__")
-        )
+        params = ResourceParameters(requests.Session(), Url("https://connect.example/__api__"))
         permissions = Permissions(params, content_guid=content_guid)
 
         # invoke

--- a/tests/posit/connect/test_permissions.py
+++ b/tests/posit/connect/test_permissions.py
@@ -28,9 +28,7 @@ class TestPermissionDelete:
         params = ResourceParameters(
             requests.Session(), Url("https://connect.example/__api__")
         )
-        fake_permission = load_mock(
-            f"v1/content/{content_guid}/permissions/{uid}.json"
-        )
+        fake_permission = load_mock(f"v1/content/{content_guid}/permissions/{uid}.json")
         permission = Permission(params, **fake_permission)
 
         # invoke
@@ -97,9 +95,7 @@ class TestPermissionUpdate:
 
         uid = "94"
         content_guid = "f2f37341-e21d-3d80-c698-a935ad614066"
-        fake_permission = load_mock(
-            f"v1/content/{content_guid}/permissions/{uid}.json"
-        )
+        fake_permission = load_mock(f"v1/content/{content_guid}/permissions/{uid}.json")
         fake_permission.update(role=new_role)
 
         # define api behavior
@@ -138,9 +134,7 @@ class TestPermissionsCount:
     def test(self):
         # test data
         content_guid = "f2f37341-e21d-3d80-c698-a935ad614066"
-        fake_permissions = load_mock(
-            f"v1/content/{content_guid}/permissions.json"
-        )
+        fake_permissions = load_mock(f"v1/content/{content_guid}/permissions.json")
 
         # define api behavior
         responses.get(
@@ -214,9 +208,7 @@ class TestPermissionsFind:
     def test(self):
         # test data
         content_guid = "f2f37341-e21d-3d80-c698-a935ad614066"
-        fake_permissions = load_mock(
-            f"v1/content/{content_guid}/permissions.json"
-        )
+        fake_permissions = load_mock(f"v1/content/{content_guid}/permissions.json")
 
         # define api behavior
         responses.get(
@@ -242,9 +234,7 @@ class TestPermissionsFindOne:
     def test(self):
         # test data
         content_guid = "f2f37341-e21d-3d80-c698-a935ad614066"
-        fake_permissions = load_mock(
-            f"v1/content/{content_guid}/permissions.json"
-        )
+        fake_permissions = load_mock(f"v1/content/{content_guid}/permissions.json")
 
         # define api behavior
         responses.get(
@@ -271,9 +261,7 @@ class TestPermissionsGet:
         # data
         uid = "94"
         content_guid = "f2f37341-e21d-3d80-c698-a935ad614066"
-        fake_permission = load_mock(
-            f"v1/content/{content_guid}/permissions/{uid}.json"
-        )
+        fake_permission = load_mock(f"v1/content/{content_guid}/permissions/{uid}.json")
 
         # behavior
         responses.get(

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -108,9 +108,7 @@ class TestUserContent:
 
         mock_get_content = responses.get(
             "https://connect.example/__api__/v1/content",
-            json=load_mock(
-                "v1/content?owner_guid=20a79ce3-6e87-4522-9faf-be24228800a4.json"
-            ),
+            json=load_mock("v1/content?owner_guid=20a79ce3-6e87-4522-9faf-be24228800a4.json"),
             match=[
                 matchers.query_param_matcher(
                     {"owner_guid": "20a79ce3-6e87-4522-9faf-be24228800a4"},
@@ -350,20 +348,12 @@ class TestUsersFind:
         # validate response body is parsed and returned
         responses.get(
             "https://connect.example/__api__/v1/users",
-            match=[
-                responses.matchers.query_param_matcher(
-                    {"page_size": 500, "page_number": 1}
-                )
-            ],
+            match=[responses.matchers.query_param_matcher({"page_size": 500, "page_number": 1})],
             json=load_mock("v1/users?page_number=1&page_size=500.jsonc"),
         )
         responses.get(
             "https://connect.example/__api__/v1/users",
-            match=[
-                responses.matchers.query_param_matcher(
-                    {"page_size": 500, "page_number": 2}
-                )
-            ],
+            match=[responses.matchers.query_param_matcher({"page_size": 500, "page_number": 2})],
             json=load_mock("v1/users?page_number=2&page_size=500.jsonc"),
         )
         con = Client(api_key="12345", url="https://connect.example/")

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -103,9 +103,7 @@ class TestUserContent:
         # behavior
         mock_get_user = responses.get(
             "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",
-            json=load_mock(
-                "v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"
-            ),
+            json=load_mock("v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
         )
 
         mock_get_content = responses.get(
@@ -139,9 +137,7 @@ class TestUserLock:
     def test_lock(self):
         responses.get(
             "https://connect.example/__api__/v1/users/a1b2c3d4-e5f6-g7h8-i9j0-k1l2m3n4o5p6",
-            json=load_mock(
-                "v1/users/a1b2c3d4-e5f6-g7h8-i9j0-k1l2m3n4o5p6.json"
-            ),
+            json=load_mock("v1/users/a1b2c3d4-e5f6-g7h8-i9j0-k1l2m3n4o5p6.json"),
         )
         c = Client(api_key="12345", url="https://connect.example/")
         user = c.users.get("a1b2c3d4-e5f6-g7h8-i9j0-k1l2m3n4o5p6")
@@ -149,9 +145,7 @@ class TestUserLock:
 
         responses.get(
             "https://connect.example/__api__/v1/user",
-            json=load_mock(
-                "v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"
-            ),
+            json=load_mock("v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
         )
         responses.post(
             "https://connect.example/__api__/v1/users/a1b2c3d4-e5f6-g7h8-i9j0-k1l2m3n4o5p6/lock",
@@ -164,9 +158,7 @@ class TestUserLock:
     def test_lock_self_true(self):
         responses.get(
             "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",
-            json=load_mock(
-                "v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"
-            ),
+            json=load_mock("v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
         )
         c = Client(api_key="12345", url="https://connect.example/")
         user = c.users.get("20a79ce3-6e87-4522-9faf-be24228800a4")
@@ -174,9 +166,7 @@ class TestUserLock:
 
         responses.get(
             "https://connect.example/__api__/v1/user",
-            json=load_mock(
-                "v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"
-            ),
+            json=load_mock("v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
         )
         responses.post(
             "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4/lock",
@@ -189,9 +179,7 @@ class TestUserLock:
     def test_lock_self_false(self):
         responses.get(
             "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",
-            json=load_mock(
-                "v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"
-            ),
+            json=load_mock("v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
         )
         c = Client(api_key="12345", url="https://connect.example/")
         user = c.users.get("20a79ce3-6e87-4522-9faf-be24228800a4")
@@ -199,9 +187,7 @@ class TestUserLock:
 
         responses.get(
             "https://connect.example/__api__/v1/user",
-            json=load_mock(
-                "v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"
-            ),
+            json=load_mock("v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
         )
         responses.post(
             "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4/lock",
@@ -217,9 +203,7 @@ class TestUserUnlock:
     def test_unlock(self):
         responses.get(
             "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",
-            json=load_mock(
-                "v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"
-            ),
+            json=load_mock("v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
         )
         c = Client(api_key="12345", url="https://connect.example/")
         user = c.users.get("20a79ce3-6e87-4522-9faf-be24228800a4")
@@ -238,9 +222,7 @@ class TestUsers:
     def test_users_get(self):
         responses.get(
             "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",
-            json=load_mock(
-                "v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"
-            ),
+            json=load_mock("v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
         )
 
         con = Client(api_key="12345", url="https://connect.example/")
@@ -269,17 +251,11 @@ class TestUsers:
     def test_user_update(self):
         responses.get(
             "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",
-            json=load_mock(
-                "v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"
-            ),
+            json=load_mock("v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
         )
         patch_request = responses.put(
             "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",
-            match=[
-                responses.matchers.json_params_matcher(
-                    {"first_name": "Carlitos"}
-                )
-            ],
+            match=[responses.matchers.json_params_matcher({"first_name": "Carlitos"})],
             json={"first_name": "Carlitos"},
         )
 
@@ -298,9 +274,7 @@ class TestUsers:
     def test_user_update_server_error(self):
         responses.get(
             "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",
-            json=load_mock(
-                "v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"
-            ),
+            json=load_mock("v1/users/20a79ce3-6e87-4522-9faf-be24228800a4.json"),
         )
         responses.put(
             "https://connect.example/__api__/v1/users/20a79ce3-6e87-4522-9faf-be24228800a4",


### PR DESCRIPTION
Based on my research, the D418 rule was introduced to accommodate an existing bug in pydocstyle (https://github.com/PyCQA/pydocstyle/commit/7921a6db337774d85c16c73010ca91e0ce1953f0). I'm unable to find any newer information on why to continue using this rule. The Ruff documentation (https://docs.astral.sh/ruff/rules/overload-with-docstring/#references) links to PEP-257, which was written before overload methods were introduced.

Additionally, In my environment, Pylance supports introspecting the docstring of overload methods.

The other removed rules are redundant to: https://github.com/posit-dev/posit-sdk-py/blob/ba6096aa27e977a28986964500a740d136b25d4a/pyproject.toml#L96