### PR TITLE
feat: add create local user support

### DIFF
--- a/integration/Makefile
+++ b/integration/Makefile
@@ -134,4 +134,4 @@ help:
 test:
 	mkdir -p logs
 	set -o pipefail; \
-		CONNECT_VERSION=${CONNECT_VERSION} CONNECT_API_KEY="$(shell rsconnect bootstrap -i -s http://connect:3939 --raw)" $(PYTHON) -m pytest -s --junit-xml=./reports/$(CONNECT_VERSION).xml | tee ./logs/$(CONNECT_VERSION).log;
+		CONNECT_VERSION=${CONNECT_VERSION} CONNECT_API_KEY="$(shell rsconnect bootstrap -i -s http://connect:3939 --raw)" $(PYTHON) -m pytest -s --junit-xml=./reports/$(CONNECT_VERSION).xml ./tests/posit/connect/test_users.py | tee ./logs/$(CONNECT_VERSION).log;

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -134,4 +134,4 @@ help:
 test:
 	mkdir -p logs
 	set -o pipefail; \
-		CONNECT_VERSION=${CONNECT_VERSION} CONNECT_API_KEY="$(shell rsconnect bootstrap -i -s http://connect:3939 --raw)" $(PYTHON) -m pytest -s --junit-xml=./reports/$(CONNECT_VERSION).xml ./tests/posit/connect/test_users.py | tee ./logs/$(CONNECT_VERSION).log;
+		CONNECT_VERSION=${CONNECT_VERSION} CONNECT_API_KEY="$(shell rsconnect bootstrap -i -s http://connect:3939 --raw)" $(PYTHON) -m pytest -s --junit-xml=./reports/$(CONNECT_VERSION).xml | tee ./logs/$(CONNECT_VERSION).log;

--- a/integration/tests/posit/connect/test_users.py
+++ b/integration/tests/posit/connect/test_users.py
@@ -1,14 +1,55 @@
 from posit import connect
 
 
-class TestAttributeContent:
+class TestUser:
+    @classmethod
+    def setup_class(cls):
+        cls.client = client = connect.Client()
+        cls.aron = client.users.create(
+            username="aron", email="aron@example.com", password="s3cur3p@ssword"
+        )
+        cls.bill = client.users.create(
+            username="bill", email="bill@example.com", password="s3cur3p@ssword"
+        )
+        cls.cole = client.users.create(
+            username="cole", email="cole@example.com", password="s3cur3p@ssword"
+        )
+
+    def test_lock(self):
+        for user in (self.aron, self.bill, self.cole):
+            user.lock()
+            assert len(self.client.users.find(account_status="locked")) == 1
+            user.unlock()
+        assert len(self.client.users.find(account_status="locked")) == 0
+
+    def test_count(self):
+        # aron, bill, cole, and me
+        assert self.client.users.count() == 4
+
+    def test_find(self):
+        assert self.client.users.find(prefix="aron") == [self.aron]
+        assert self.client.users.find(prefix="bill") == [self.bill]
+        assert self.client.users.find(prefix="cole") == [self.cole]
+
+    def test_find_one(self):
+        assert self.client.users.find_one(prefix="aron") == self.aron
+        assert self.client.users.find_one(prefix="bill") == self.bill
+        assert self.client.users.find_one(prefix="cole") == self.cole
+
+    def test_get(self):
+        assert self.client.users.get(self.aron["guid"]) == self.aron
+        assert self.client.users.get(self.bill["guid"]) == self.bill
+        assert self.client.users.get(self.cole["guid"]) == self.cole
+
+
+class TestUserContent:
     """Checks behavior of the content attribute."""
 
     @classmethod
     def setup_class(cls):
-        cls.client = connect.Client()
-        cls.user = cls.client.me
-        cls.user.content.create(
+        cls.client = client = connect.Client()
+        cls.me = me = client.me
+        cls.content = me.content.create(
             name="Sample",
             description="Simple sample content for testing",
             access_type="acl",
@@ -16,14 +57,23 @@ class TestAttributeContent:
 
     @classmethod
     def teardown_class(cls):
-        assert cls.user.content.find_one().delete() is None
-        assert cls.user.content.count() == 0
+        assert cls.content.delete() is None
+        assert cls.me.content.count() == 0
 
     def test_count(self):
-        assert self.user.content.count() == 1
+        assert self.me.content.count() == 1
 
     def test_find(self):
-        assert self.user.content.find()
+        assert self.me.content.find()
 
     def test_find_one(self):
-        assert self.user.content.find_one()
+        assert self.me.content.find_one()
+
+    def test_multiple_users(self):
+        user = self.client.users.create(
+            username="example", email="example@example.com", password="s3cur3p@ssword"
+        )
+        # assert filtering limits to the provided user.
+        assert self.me.content.find_one() == self.content
+        assert user.content.find_one() is None
+        user.lock()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "requests>=2.31.0,<3",
-    "packaging"
+    "packaging",
+    "typing-extensions"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.32.2
 packaging==24.1
+typing-extensions==4.12.2

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -367,7 +367,7 @@ class Content(Resources):
             Content title. Default is None.
         description : str, optional
             Content description. Default is None.
-        access_type : Literal['all', 'acl', 'logged_in', optional
+        access_type : Literal['all', 'acl', 'logged_in'], optional
             How content manages viewers. Default is 'acl'. Options: 'all', 'logged_in', 'acl'.
         connection_timeout : int, optional
             Max seconds without data exchange. Default is None. Falls back to server setting 'Scheduler.ConnectionTimeout'.

--- a/src/posit/connect/paginator.py
+++ b/src/posit/connect/paginator.py
@@ -38,7 +38,7 @@ class Paginator:
         url (str): The URL of the paginated API endpoint.
     """
 
-    def __init__(self, session: requests.Session, url: str, params: dict = {}) -> None:
+    def __init__(self, session: requests.Session, url: str, params = {}) -> None:
         self.session = session
         self.url = url
         self.params = params

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, overload
+from typing import List, Literal, Optional, overload
 
 from . import me
 from .content import Content
@@ -13,40 +13,60 @@ from .resources import Resource, ResourceParameters, Resources
 class User(Resource):
     @property
     def content(self) -> Content:
-        return Content(self.params, owner_guid=self.guid)
+        return Content(self.params, owner_guid=self["guid"])
 
     def lock(self, *, force: bool = False):
         """
-        Locks the user account.
+        Lock the user account.
 
-        .. warning:: You cannot unlock your own account. Once an account is locked, only an admin can unlock it.
+        You cannot unlock your own account unless you have administrative privileges. Once an account is locked, only an admin can unlock it.
 
-        Args:
-            force (bool, optional): If set to True, overrides lock protection allowing a user to lock their own account. Defaults to False.
+        Parameters
+        ----------
+        force : bool, optional
+            If `True`, overrides lock protection allowing a user to lock their own account. Default is `False`.
 
         Returns
         -------
-            None
+        None
+
+        Examples
+        --------
+        Lock another user's account:
+
+        >>> user.lock()
+
+        Attempt to lock your own account (will raise `RuntimeError` unless `force` is set to `True`):
+
+        >>> user.lock(force=True)
         """
         _me = me.get(self.params)
-        if _me.guid == self.guid and not force:
+        if _me.guid == self["guid"] and not force:
             raise RuntimeError(
                 "You cannot lock your own account. Set force=True to override this behavior."
             )
-        url = self.params.url + f"v1/users/{self.guid}/lock"
+        url = self.params.url + f"v1/users/{self['guid']}/lock"
         body = {"locked": True}
         self.params.session.post(url, json=body)
         super().update(locked=True)
 
     def unlock(self):
         """
-        Unlocks the user account.
+        Unlock the user account.
+
+        This method unlocks the specified user's account. You must have administrative privileges to unlock accounts other than your own.
 
         Returns
         -------
-            None
+        None
+
+        Examples
+        --------
+        Unlock a user's account:
+
+        >>> user.unlock()
         """
-        url = self.params.url + f"v1/users/{self.guid}/lock"
+        url = self.params.url + f"v1/users/{self['guid']}/lock"
         body = {"locked": False}
         self.params.session.post(url, json=body)
         super().update(locked=False)
@@ -55,26 +75,42 @@ class User(Resource):
     def update(
         self,
         *args,
-        email: str = ...,
-        username: str = ...,
-        first_name: str = ...,
-        last_name: str = ...,
-        user_role: str = ...,
+        email: Optional[str] = None,
+        username: Optional[str] = None,
+        first_name: Optional[str] = None,
+        last_name: Optional[str] = None,
+        user_role: Optional[Literal["administrator", "publisher", "viewer"]] = None,
         **kwargs,
     ) -> None:
         """
-        Update the user.
+        Update the user's attributes.
 
-        Args:
-            email (str): The email address for the user.
-            username (str): The username for the user.
-            first_name (str): The first name for the user.
-            last_name (str): The last name for the user.
-            user_role (str): The role for the user.
+        Parameters
+        ----------
+        email : str, optional
+            The new email address for the user. Default is `None`.
+        username : str, optional
+            The new username for the user. Default is `None`.
+        first_name : str, optional
+            The new first name for the user. Default is `None`.
+        last_name : str, optional
+            The new last name for the user. Default is `None`.
+        user_role : Literal["administrator", "publisher", "viewer"], optional
+            The new role for the user. Options are `'administrator'`, `'publisher'`, `'viewer'`. Default is `None`.
 
         Returns
         -------
-            None
+        None
+
+        Examples
+        --------
+        Update the user's email and role:
+
+        >>> user.update(email="newemail@example.com", user_role="publisher")
+
+        Update the user's first and last name:
+
+        >>> user.update(first_name="Jane", last_name="Smith")
         """
         ...
 
@@ -83,13 +119,16 @@ class User(Resource):
         """
         Update the user.
 
-        Args:
-            *args
-            **kwargs
+        Parameters
+        ----------
+        *args
+            Variable length argument list.
+        **kwargs
+            Arbitrary keyword arguments.
 
         Returns
         -------
-            None
+        None
         """
         ...
 
@@ -97,16 +136,19 @@ class User(Resource):
         """
         Update the user.
 
-        Args:
-            *args
-            **kwargs
+        Parameters
+        ----------
+        *args
+            Variable length argument list.
+        **kwargs
+            Arbitrary keyword arguments.
 
         Returns
         -------
-            None
+        None
         """
         body = dict(*args, **kwargs)
-        url = self.params.url + f"v1/users/{self.guid}"
+        url = self.params.url + f"v1/users/{self['guid']}"
         response = self.params.session.put(url, json=body)
         super().update(**response.json())
 
@@ -118,20 +160,187 @@ class Users(Resources):
         super().__init__(params)
 
     @overload
+    def create(
+        self,
+        *,
+        # Required arguments
+        username: str,
+        # Authentication Information
+        password: Optional[str] = None,
+        user_must_set_password: bool = False,
+        # Profile Information
+        email: Optional[str] = None,
+        first_name: Optional[str] = None,
+        last_name: Optional[str] = None,
+        # Role and Permissions
+        user_role: Optional[Literal["administrator", "publisher", "viewer"]] = None,
+        unique_id: Optional[str] = None,
+    ) -> User:
+        """
+        Create a new user with the specified attributes.
+
+        Applies when server setting 'Authentication.Provider' is set to 'ldap', 'oauth2', 'pam', 'password', 'proxy', or 'saml'.
+
+        Parameters
+        ----------
+        username : str
+            The user's desired username.
+        password : str, optional
+            Applies when server setting 'Authentication.Provider="password"'. Cannot be set when `user_must_set_password` is `True`. Default is `None`.
+        user_must_set_password : bool, optional
+            If `True`, the user is prompted to set their password on first login. When `False`, the `password` parameter is used. Default is `False`. Applies when server setting 'Authentication.Provider="password"'.
+        email : str, optional
+            The user's email address. Default is `None`.
+        first_name : str, optional
+            The user's first name. Default is `None`.
+        last_name : str, optional
+            The user's last name. Default is `None`.
+        user_role : Literal["administrator", "publisher", "viewer"], optional
+            The user role. Default is `None`. Options are `'administrator'`, `'publisher'`, `'viewer'`. Falls back to server setting 'Authorization.DefaultUserRole'.
+        unique_id : str, optional
+            Default is `None`. Required when server is configured with SAML or OAuth2 (non-Google) authentication. Applies when server setting `ProxyAuth.UniqueIdHeader` is set.
+
+        Returns
+        -------
+        User
+            The newly created user.
+
+        Examples
+        --------
+        Create a user with a predefined password:
+
+        >>> user = client.create(
+        ...     username="jdoe",
+        ...     email="jdoe@example.com",
+        ...     first_name="John",
+        ...     last_name="Doe",
+        ...     password="s3cur3p@ssword",
+        ...     user_role="viewer",
+        ... )
+
+        Create a user who must set their own password:
+
+        >>> user = client.create(
+        ...     username="jdoe",
+        ...     email="jdoe@example.com",
+        ...     first_name="John",
+        ...     last_name="Doe",
+        ...     user_must_set_password=True,
+        ...     user_role="viewer",
+        ... )
+        """
+        ...
+
+    @overload
+    def create(self, **attributes) -> User:
+        """
+        Create a user with the specified attributes.
+
+        Parameters
+        ----------
+        **attributes
+            Arbitrary keyword arguments representing user attributes.
+
+        Returns
+        -------
+        User
+            The newly created user.
+        """
+        ...
+
+    def create(self, **attributes) -> User:
+        """
+        Create a user.
+
+        Parameters
+        ----------
+        **attributes
+            Arbitrary keyword arguments representing user attributes.
+
+        Returns
+        -------
+        User
+            The newly created user.
+        """
+        # todo - use the 'context' module to inspect the 'authentication' object and route to POST (local) or PUT (remote).
+        url = self.params.url + "v1/users"
+        response = self.params.session.post(url, json=attributes)
+        return User(self.params, **response.json())
+
+    @overload
     def find(
         self,
         *,
-        prefix: str = ...,
-        user_role: str = ...,
-        account_status: str = ...,
-    ) -> List[User]: ...
+        prefix: Optional[str] = None,
+        user_role: Optional[Literal["administrator", "publisher", "viewer"] | str] = None,
+        account_status: Optional[Literal["locked", "licensed", "inactive"] | str] = None,
+    ) -> List[User]:
+        """
+        Find users matching the specified conditions.
+
+        Parameters
+        ----------
+        prefix : str, optional
+            Filter users by prefix (username, first name, or last name). The filter is case-insensitive. Default is `None`.
+        user_role : Literal["administrator", "publisher", "viewer"], optional
+            Filter by user role. Options are `'administrator'`, `'publisher'`, `'viewer'`. Use `'|'` to represent logical OR (e.g., `'viewer|publisher'`). Default is `None`.
+        account_status : Literal["locked", "licensed", "inactive"], optional
+            Filter by account status. Options are `'locked'`, `'licensed'`, `'inactive'`. Use `'|'` to represent logical OR. For example, `'locked|licensed'` includes users who are either locked or licensed. Default is `None`.
+
+        Returns
+        -------
+        List[User]
+            A list of users matching the specified conditions.
+
+        Examples
+        --------
+        Find all users with a username, first name, or last name starting with 'jo':
+
+        >>> users = client.find(prefix="jo")
+
+        Find all users who are either viewers or publishers:
+
+        >>> users = client.find(user_role="viewer|publisher")
+
+        Find all users who are locked or licensed:
+
+        >>> users = client.find(account_status="locked|licensed")
+        """
+        ...
 
     @overload
-    def find(self, **kwargs) -> List[User]: ...
+    def find(self, **conditions) -> List[User]:
+        """
+        Find users matching the specified conditions.
 
-    def find(self, **kwargs) -> List[User]:
+        Parameters
+        ----------
+        **conditions
+            Arbitrary keyword arguments representing search conditions.
+
+        Returns
+        -------
+        List[User]
+            A list of users matching the specified conditions.
+        """
+        ...
+
+    def find(self, **conditions) -> List[User]:
+        """
+        Find users matching the specified conditions.
+
+        Parameters
+        ----------
+        **conditions
+            Arbitrary keyword arguments representing search conditions.
+
+        Returns
+        -------
+        List[User]
+            A list of users matching the specified conditions.
+        """
         url = self.params.url + "v1/users"
-        paginator = Paginator(self.params.session, url, params=kwargs)
+        paginator = Paginator(self.params.session, url, params=conditions)
         results = paginator.fetch_results()
         return [
             User(
@@ -145,17 +354,76 @@ class Users(Resources):
     def find_one(
         self,
         *,
-        prefix: str = ...,
-        user_role: str = ...,
-        account_status: str = ...,
-    ) -> User | None: ...
+        prefix: Optional[str] = None,
+        user_role: Optional[Literal["administrator", "publisher", "viewer"] | str] = None,
+        account_status: Optional[Literal["locked", "licensed", "inactive"] | str] = None,
+    ) -> User | None:
+        """
+        Find a user matching the specified conditions.
+
+        Parameters
+        ----------
+        prefix : str, optional
+            Filter users by prefix (username, first name, or last name). The filter is case-insensitive. Default is `None`.
+        user_role : Literal["administrator", "publisher", "viewer"], optional
+            Filter by user role. Options are `'administrator'`, `'publisher'`, `'viewer'`. Use `'|'` to represent logical OR (e.g., `'viewer|publisher'`). Default is `None`.
+        account_status : Literal["locked", "licensed", "inactive"], optional
+            Filter by account status. Options are `'locked'`, `'licensed'`, `'inactive'`. Use `'|'` to represent logical OR. For example, `'locked|licensed'` includes users who are either locked or licensed. Default is `None`.
+
+        Returns
+        -------
+        User or None
+            The first user matching the specified conditions, or `None` if no user is found.
+
+        Examples
+        --------
+        Find a user with a username, first name, or last name starting with 'jo':
+
+        >>> user = client.find_one(prefix="jo")
+
+        Find a user who is either a viewer or publisher:
+
+        >>> user = client.find_one(user_role="viewer|publisher")
+
+        Find a user who is locked or licensed:
+
+        >>> user = client.find_one(account_status="locked|licensed")
+        """
+        ...
 
     @overload
-    def find_one(self, **kwargs) -> User | None: ...
+    def find_one(self, **conditions) -> User | None:
+        """
+        Find a user matching the specified conditions.
 
-    def find_one(self, **kwargs) -> User | None:
+        Parameters
+        ----------
+        **conditions
+            Arbitrary keyword arguments representing search conditions.
+
+        Returns
+        -------
+        User or None
+            The first user matching the specified conditions, or `None` if no user is found.
+        """
+        ...
+
+    def find_one(self, **conditions) -> User | None:
+        """
+        Find a user matching the specified conditions.
+
+        Parameters
+        ----------
+        **conditions
+            Arbitrary keyword arguments representing search conditions.
+
+        Returns
+        -------
+        User or None
+            The first user matching the specified conditions, or `None` if no user is found.
+        """
         url = self.params.url + "v1/users"
-        paginator = Paginator(self.params.session, url, params=kwargs)
+        paginator = Paginator(self.params.session, url, params=conditions)
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)
         users = (
@@ -168,6 +436,22 @@ class Users(Resources):
         return next(users, None)
 
     def get(self, uid: str) -> User:
+        """
+        Retrieve a user by their unique identifier (guid).
+
+        Parameters
+        ----------
+        uid : str
+            The unique identifier (guid) of the user to retrieve.
+
+        Returns
+        -------
+        User
+
+        Examples
+        --------
+        >>> user = client.get("123e4567-e89b-12d3-a456-426614174000")
+        """
         url = self.params.url + f"v1/users/{uid}"
         response = self.params.session.get(url)
         return User(
@@ -176,6 +460,13 @@ class Users(Resources):
         )
 
     def count(self) -> int:
+        """
+        Return the total number of users.
+
+        Returns
+        -------
+        int
+        """
         url = self.params.url + "v1/users"
         response = self.params.session.get(url, params={"page_size": 1})
         result: dict = response.json()


### PR DESCRIPTION
Adds create user support for local authentication providers (e.g., 'ldap', 'oauth2', 'pam', 'password', 'proxy', or 'saml').

Closes #113
Closes #225 