### PR TITLE
feat: drops support for Python 3.8 and adds support for Python 3.13.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,11 +26,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ The `posit-sdk` is a software development kit (SDK) for working with Posit's pro
 
 Before contributing to the `posit-sdk`, ensure that the following prerequisites are met:
 
-- Python >=3.8
+- Python >=3.9
 
 > [!INFO]
 > We require using virtual environments to maintain a clean and consistent development environment.

--- a/docs/installation.qmd
+++ b/docs/installation.qmd
@@ -8,7 +8,7 @@ toc-depth: 2
 
 ## Python version
 
-We recommend using the latest version of Python available to you. The Posit SDK supports Python 3.8 and newer.
+We recommend using the latest version of Python available to you. The Posit SDK supports Python 3.9 and newer.
 
 ## Dependencies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "posit-sdk"
 description = "Posit SDK for Python"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { file = "LICENSE" }
 keywords = ["posit", "sdk"]
 classifiers = [


### PR DESCRIPTION
Python 3.8 is no longer recieving updates. All users should migrate to Python 3.9 or later at this time.