### PR TITLE
fix: raise AttributeError instead of returning None on __getattr__

### DIFF
--- a/src/posit/connect/resources.py
+++ b/src/posit/connect/resources.py
@@ -40,7 +40,7 @@ class Resource(dict):
                 stacklevel=2,
             )
             return self[name]
-        return None
+        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
 
     def update(self, *args, **kwargs):
         super().update(*args, **kwargs)


### PR DESCRIPTION
The` __getattr__` method should always raise an `AttributeError` if the value does not exist instead of returning `None`. The existing implementation causes issues when converting to a Pandas `DataFrame`.

This error was introduced in the 0.5.0 release.