### PR TITLE
feat: Add `User.groups` and `Group.members`

### DIFF
--- a/integration/tests/posit/connect/test_content_item_permissions.py
+++ b/integration/tests/posit/connect/test_content_item_permissions.py
@@ -1,3 +1,5 @@
+import pytest
+
 from posit import connect
 from posit.connect.content import ContentItem
 
@@ -59,11 +61,9 @@ class TestContentPermissions:
         )
 
         # Remove permissions (and from some that isn't an owner)
-        destroyed_permissions = self.content.permissions.destroy(self.user_aron, self.user_bill)
-        assert_permissions_match_guids(
-            destroyed_permissions,
-            [self.user_aron],
-        )
+        self.content.permissions.destroy(self.user_aron)
+        with pytest.raises(ValueError):
+            self.content.permissions.destroy(self.user_bill)
 
         # Prove they have been removed
         assert_permissions_match_guids(

--- a/integration/tests/posit/connect/test_content_item_permissions.py
+++ b/integration/tests/posit/connect/test_content_item_permissions.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 
 from posit import connect
-from posit.connect.content import ContentItem
+
+if TYPE_CHECKING:
+    from posit.connect.content import ContentItem
+    from posit.connect.permissions import Permission
 
 
 class TestContentPermissions:
@@ -50,7 +57,7 @@ class TestContentPermissions:
             role="owner",
         )
 
-        def assert_permissions_match_guids(permissions, objs_with_guid):
+        def assert_permissions_match_guids(permissions: list[Permission], objs_with_guid):
             for permission, obj_with_guid in zip(permissions, objs_with_guid):
                 assert permission["principal_guid"] == obj_with_guid["guid"]
 
@@ -72,11 +79,7 @@ class TestContentPermissions:
         )
 
         # Remove the last permission
-        destroyed_permissions = self.content.permissions.destroy(self.group_friends)
-        assert_permissions_match_guids(
-            destroyed_permissions,
-            [self.group_friends],
-        )
+        self.content.permissions.destroy(self.group_friends)
 
         # Prove they have been removed
         assert self.content.permissions.find() == []

--- a/integration/tests/posit/connect/test_users.py
+++ b/integration/tests/posit/connect/test_users.py
@@ -47,6 +47,23 @@ class TestUser:
         assert self.client.users.get(self.bill["guid"]) == self.bill
         assert self.client.users.get(self.cole["guid"]) == self.cole
 
+    # Also tests Groups.members
+    def test_groups(self):
+        try:
+            unit_friends = self.client.groups.create(name="UnitFriends")
+            self.client.post(
+                f"/v1/groups/{unit_friends['guid']}/members",
+                json={"user_guid": self.bill["guid"]},
+            )
+            bill_groups = self.bill.groups.find()
+            assert len(bill_groups) == 1
+            assert bill_groups[0]["guid"] == unit_friends["guid"]
+        finally:
+            groups = self.client.groups.find(prefix="UnitFriends")
+            if len(groups) > 0:
+                unit_friends = groups[0]
+                unit_friends.delete()
+
 
 class TestUserContent:
     """Checks behavior of the content attribute."""

--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -156,7 +156,7 @@ class Client(ContextManager):
         session.hooks["response"].append(hooks.handle_errors)
         self.session = session
         self.resource_params = ResourceParameters(session, self.cfg.url)
-        self._ctx = Context(self.session, self.cfg.url)
+        self._ctx = Context(self)
 
     @property
     def version(self) -> str | None:
@@ -180,7 +180,7 @@ class Client(ContextManager):
         User
             The currently authenticated user.
         """
-        return me.get(self.resource_params)
+        return me.get(self._ctx)
 
     @property
     def groups(self) -> Groups:
@@ -191,7 +191,7 @@ class Client(ContextManager):
         Groups
             The groups resource interface.
         """
-        return Groups(self.resource_params)
+        return Groups(self._ctx)
 
     @property
     def tasks(self) -> Tasks:
@@ -215,7 +215,7 @@ class Client(ContextManager):
         Users
             The users resource instance.
         """
-        return Users(self.resource_params)
+        return Users(self._ctx)
 
     @property
     def content(self) -> Content:
@@ -227,7 +227,7 @@ class Client(ContextManager):
         Content
             The content resource instance.
         """
-        return Content(self.resource_params)
+        return Content(self._ctx)
 
     @property
     def metrics(self) -> Metrics:

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -293,8 +293,8 @@ class ContentItem(JobsMixin, PackagesMixin, VanityMixin, Resource):
     def delete(self) -> None:
         """Delete the content item."""
         path = f"v1/content/{self['guid']}"
-        url = self.params.url + path
-        self.params.session.delete(url)
+        url = self._ctx.url + path
+        self._ctx.session.delete(url)
 
     def deploy(self) -> tasks.Task:
         """Deploy the content.
@@ -313,8 +313,8 @@ class ContentItem(JobsMixin, PackagesMixin, VanityMixin, Resource):
         None
         """
         path = f"v1/content/{self['guid']}/deploy"
-        url = self.params.url + path
-        response = self.params.session.post(url, json={"bundle_id": None})
+        url = self._ctx.url + path
+        response = self._ctx.session.post(url, json={"bundle_id": None})
         result = response.json()
         ts = tasks.Tasks(self.params)
         return ts.get(result["task_id"])
@@ -369,8 +369,8 @@ class ContentItem(JobsMixin, PackagesMixin, VanityMixin, Resource):
             self.environment_variables.create(key, unix_epoch_in_seconds)
             self.environment_variables.delete(key)
             # GET via the base Connect URL to force create a new worker thread.
-            url = posixpath.join(dirname(self.params.url), f"content/{self['guid']}")
-            self.params.session.get(url)
+            url = posixpath.join(dirname(self._ctx.url), f"content/{self['guid']}")
+            self._ctx.session.get(url)
             return None
         else:
             raise ValueError(
@@ -440,8 +440,8 @@ class ContentItem(JobsMixin, PackagesMixin, VanityMixin, Resource):
         -------
         None
         """
-        url = self.params.url + f"v1/content/{self['guid']}"
-        response = self.params.session.patch(url, json=attrs)
+        url = self._ctx.url + f"v1/content/{self['guid']}"
+        response = self._ctx.session.patch(url, json=attrs)
         super().update(**response.json())
 
     # Relationships
@@ -597,8 +597,8 @@ class Content(Resources):
         ContentItem
         """
         path = "v1/content"
-        url = self.params.url + path
-        response = self.params.session.post(url, json=attrs)
+        url = self._ctx.url + path
+        response = self._ctx.session.post(url, json=attrs)
         return ContentItem(self._ctx, **response.json())
 
     @overload
@@ -685,8 +685,8 @@ class Content(Resources):
             conditions["owner_guid"] = self.owner_guid
 
         path = "v1/content"
-        url = self.params.url + path
-        response = self.params.session.get(url, params=conditions)
+        url = self._ctx.url + path
+        response = self._ctx.session.get(url, params=conditions)
         return [
             ContentItem(
                 self._ctx,
@@ -858,6 +858,6 @@ class Content(Resources):
         ContentItem
         """
         path = f"v1/content/{guid}"
-        url = self.params.url + path
-        response = self.params.session.get(url)
+        url = self._ctx.url + path
+        response = self._ctx.session.get(url)
         return ContentItem(self._ctx, **response.json())

--- a/src/posit/connect/context.py
+++ b/src/posit/connect/context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import weakref
 from typing import TYPE_CHECKING, Protocol
 
 from packaging.version import Version
@@ -8,6 +9,7 @@ from packaging.version import Version
 if TYPE_CHECKING:
     import requests
 
+    from .client import Client
     from .urls import Url
 
 
@@ -28,9 +30,14 @@ def requires(version: str):
 
 
 class Context:
-    def __init__(self, session: requests.Session, url: Url):
-        self.session = session
-        self.url = url
+    def __init__(self, client: Client):
+        self.session: requests.Session = client.session
+        self.url: Url = client.cfg.url
+        # Since this is a child object of the client, we use a weak reference to avoid circular
+        # references (which would prevent garbage collection)
+        # Note, it might need to be a strong reference, but a `del client` test will need to be
+        # updated
+        self.client: Client = weakref.proxy(client)
 
     @property
     def version(self) -> str | None:

--- a/src/posit/connect/context.py
+++ b/src/posit/connect/context.py
@@ -35,8 +35,6 @@ class Context:
         self.url: Url = client.cfg.url
         # Since this is a child object of the client, we use a weak reference to avoid circular
         # references (which would prevent garbage collection)
-        # Note, it might need to be a strong reference, but a `del client` test will need to be
-        # updated
         self.client: Client = weakref.proxy(client)
 
     @property

--- a/src/posit/connect/groups.py
+++ b/src/posit/connect/groups.py
@@ -108,6 +108,10 @@ class GroupMembers(Resources):
         # Add a user to the group by GUID
         group.members.add(user_guid="USER_GUID_HERE")
         ```
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#post-/v1/groups/-group_guid-/members
         """
         if len(args) > 0:
             from .users import User
@@ -168,6 +172,9 @@ class GroupMembers(Resources):
         group.members.delete(user_guid="USER_GUID_HERE")
         ```
 
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#delete-/v1/groups/-group_guid-/members/-user_guid-
         """
         if len(args) > 0:
             from .users import User
@@ -212,6 +219,10 @@ class GroupMembers(Resources):
         # Find all users in the group
         group_users = group.members.find()
         ```
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#get-/v1/groups/-group_guid-/members
         """
         # Avoid circular import
         from .users import User
@@ -244,6 +255,10 @@ class GroupMembers(Resources):
         # Get count of group members
         group_user_count = group.members.count()
         ```
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#get-/v1/groups/-group_guid-/members
         """
         path = f"v1/groups/{self._group_guid}/members"
         url = self._ctx.url + path
@@ -271,6 +286,10 @@ class Groups(Resources):
         Returns
         -------
         Group
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#post-/v1/groups
         """
 
     @overload
@@ -320,6 +339,10 @@ class Groups(Resources):
         Returns
         -------
         List[Group]
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#get-/v1/groups
         """
         path = "v1/groups"
         url = self._ctx.url + path
@@ -354,6 +377,10 @@ class Groups(Resources):
         Returns
         -------
         Group | None
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#get-/v1/groups
         """
         path = "v1/groups"
         url = self._ctx.url + path
@@ -379,6 +406,10 @@ class Groups(Resources):
         Returns
         -------
         Group
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#get-/v1/groups
         """
         url = self._ctx.url + f"v1/groups/{guid}"
         response = self._ctx.session.get(url)
@@ -393,6 +424,10 @@ class Groups(Resources):
         Returns
         -------
         int
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#get-/v1/groups
         """
         path = "v1/groups"
         url = self._ctx.url + path

--- a/src/posit/connect/groups.py
+++ b/src/posit/connect/groups.py
@@ -74,17 +74,17 @@ class GroupMembers(Resources):
         self._ctx: Context = ctx
 
     @overload
-    def add(self, *args: User) -> None: ...
+    def add(self, user: User, /) -> None: ...
     @overload
-    def add(self, *, user_guid: str) -> None: ...
+    def add(self, /, *, user_guid: str) -> None: ...
 
-    def add(self, *args: User, user_guid: Optional[str] = None) -> None:
+    def add(self, user: Optional[User] = None, /, *, user_guid: Optional[str] = None) -> None:
         """Add a user to the group.
 
         Parameters
         ----------
-        *args : User
-            User objects to add to the group.
+        user : User
+            User object to add to the group. Only one of `user=` or `user_guid=` can be provided.
         user_guid : str
             The user GUID.
 
@@ -103,7 +103,8 @@ class GroupMembers(Resources):
 
         # Add multiple users to the group
         users = client.users.find()
-        group.members.add(*users)
+        for user in users:
+            group.members.add(user)
 
         # Add a user to the group by GUID
         group.members.add(user_guid="USER_GUID_HERE")
@@ -113,19 +114,15 @@ class GroupMembers(Resources):
         --------
         * https://docs.posit.co/connect/api/#post-/v1/groups/-group_guid-/members
         """
-        if len(args) > 0:
+        if user is not None:
             from .users import User
 
             if user_guid:
-                raise ValueError("Only one of `*args` or `user_guid=` should be provided.")
-            for i, user in enumerate(args):
-                if not isinstance(user, User):
-                    raise TypeError(f"args[{i}] is not a `User` object. Received {user}")
+                raise ValueError("Only one of `user=` or `user_guid=` should be provided.")
+            if not isinstance(user, User):
+                raise TypeError(f"`user=` is not a `User` object. Received {user}")
 
-            for user in args:
-                self.add(user_guid=user["guid"])
-
-            return
+            user_guid = user["guid"]
 
         if not isinstance(user_guid, str):
             raise TypeError(f"`user_guid=` should be a string. Received {user_guid}")
@@ -137,17 +134,17 @@ class GroupMembers(Resources):
         self._ctx.session.post(url, json={"user_guid": user_guid})
 
     @overload
-    def delete(self, *args: User) -> None: ...
+    def delete(self, user: User, /) -> None: ...
     @overload
-    def delete(self, *, user_guid: str) -> None: ...
+    def delete(self, /, *, user_guid: str) -> None: ...
 
-    def delete(self, *args: User, user_guid: Optional[str] = None) -> None:
+    def delete(self, user: Optional[User] = None, /, *, user_guid: Optional[str] = None) -> None:
         """Remove a user from the group.
 
         Parameters
         ----------
-        *args : User
-            User objects to remove from the group.
+        user : User
+            User object to add to the group. Only one of `user=` or `user_guid=` can be provided.
         user_guid : str
             The user GUID.
 
@@ -166,7 +163,8 @@ class GroupMembers(Resources):
 
         # Remove multiple users from the group
         group_users = group.members.find()[:2]
-        group.members.delete(*group_users)
+        for group_user in group_users:
+            group.members.delete(group_user)
 
         # Remove a user from the group by GUID
         group.members.delete(user_guid="USER_GUID_HERE")
@@ -176,19 +174,15 @@ class GroupMembers(Resources):
         --------
         * https://docs.posit.co/connect/api/#delete-/v1/groups/-group_guid-/members/-user_guid-
         """
-        if len(args) > 0:
+        if user is not None:
             from .users import User
 
             if user_guid:
-                raise ValueError("Only one of `*args` or `user_guid=` should be provided.")
-            for i, user in enumerate(args):
-                if not isinstance(user, User):
-                    raise TypeError(f"`args[{i}]` is not a `User` object. Received {user}")
+                raise ValueError("Only one of `user=` or `user_guid=` should be provided.")
+            if not isinstance(user, User):
+                raise TypeError(f"`user=` is not a `User` object. Received {user}")
 
-            for user in args:
-                self.delete(user_guid=user["guid"])
-
-            return
+            user_guid = user["guid"]
 
         if not isinstance(user_guid, str):
             raise TypeError(f"`user_guid=` should be a string. Received {user_guid}")

--- a/src/posit/connect/groups.py
+++ b/src/posit/connect/groups.py
@@ -116,7 +116,7 @@ class GroupMembers(Resources):
                 raise ValueError("Only one of `*args` or `user_guid=` should be provided.")
             for i, user in enumerate(args):
                 if not isinstance(user, User):
-                    raise ValueError(f"args[{i}] is not a User object.")
+                    raise TypeError(f"args[{i}] is not a `User` object. Received {user}")
 
             for user in args:
                 self.add(user_guid=user["guid"])
@@ -124,9 +124,9 @@ class GroupMembers(Resources):
             return
 
         if not isinstance(user_guid, str):
-            raise TypeError("`user_guid=` should be a string.")
+            raise TypeError(f"`user_guid=` should be a string. Received {user_guid}")
         if not user_guid:
-            raise ValueError("`user_guid=` should not be empty")
+            raise ValueError("`user_guid=` should not be empty.")
 
         path = f"v1/groups/{self._group_guid}/members"
         url = self._ctx.url + path
@@ -176,7 +176,7 @@ class GroupMembers(Resources):
                 raise ValueError("Only one of `*args` or `user_guid=` should be provided.")
             for i, user in enumerate(args):
                 if not isinstance(user, User):
-                    raise TypeError(f"`args[{i}]` is not a `User` object.")
+                    raise TypeError(f"`args[{i}]` is not a `User` object. Received {user}")
 
             for user in args:
                 self.delete(user_guid=user["guid"])
@@ -184,9 +184,9 @@ class GroupMembers(Resources):
             return
 
         if not isinstance(user_guid, str):
-            raise TypeError("`user_guid=` should be a string.")
+            raise TypeError(f"`user_guid=` should be a string. Received {user_guid}")
         if not user_guid:
-            raise ValueError("`user_guid=` should not be empty")
+            raise ValueError("`user_guid=` should not be empty.")
 
         path = f"v1/groups/{self._group_guid}/members/{user_guid}"
         url = self._ctx.url + path

--- a/src/posit/connect/groups.py
+++ b/src/posit/connect/groups.py
@@ -43,8 +43,8 @@ class Group(Resource):
     def delete(self) -> None:
         """Delete the group."""
         path = f"v1/groups/{self['guid']}"
-        url = self.params.url + path
-        self.params.session.delete(url)
+        url = self._ctx.url + path
+        self._ctx.session.delete(url)
 
 
 class GroupMembers(Resources):
@@ -58,8 +58,8 @@ class GroupMembers(Resources):
         from .users import User
 
         path = f"v1/groups/{self._group_guid}/members"
-        url = self.params.url + path
-        paginator = Paginator(self.params.session, url)
+        url = self._ctx.url + path
+        paginator = Paginator(self._ctx.session, url)
         member_dicts = paginator.fetch_results()
 
         # For each member in the group
@@ -74,8 +74,8 @@ class GroupMembers(Resources):
         int
         """
         path = f"v1/groups/{self._group_guid}/members"
-        url = self.params.url + path
-        response = self.params.session.get(url, params={"page_size": 1})
+        url = self._ctx.url + path
+        response = self._ctx.session.get(url, params={"page_size": 1})
         result = response.json()
         return result["total"]
 
@@ -123,8 +123,8 @@ class Groups(Resources):
         Group
         """
         path = "v1/groups"
-        url = self.params.url + path
-        response = self.params.session.post(url, json=kwargs)
+        url = self._ctx.url + path
+        response = self._ctx.session.post(url, json=kwargs)
         return Group(self._ctx, **response.json())
 
     @overload
@@ -150,8 +150,8 @@ class Groups(Resources):
         List[Group]
         """
         path = "v1/groups"
-        url = self.params.url + path
-        paginator = Paginator(self.params.session, url, params=kwargs)
+        url = self._ctx.url + path
+        paginator = Paginator(self._ctx.session, url, params=kwargs)
         results = paginator.fetch_results()
         return [
             Group(
@@ -184,8 +184,8 @@ class Groups(Resources):
         Group | None
         """
         path = "v1/groups"
-        url = self.params.url + path
-        paginator = Paginator(self.params.session, url, params=kwargs)
+        url = self._ctx.url + path
+        paginator = Paginator(self._ctx.session, url, params=kwargs)
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)
         groups = (
@@ -208,8 +208,8 @@ class Groups(Resources):
         -------
         Group
         """
-        url = self.params.url + f"v1/groups/{guid}"
-        response = self.params.session.get(url)
+        url = self._ctx.url + f"v1/groups/{guid}"
+        response = self._ctx.session.get(url)
         return Group(
             self._ctx,
             **response.json(),
@@ -223,7 +223,7 @@ class Groups(Resources):
         int
         """
         path = "v1/groups"
-        url = self.params.url + path
-        response: requests.Response = self.params.session.get(url, params={"page_size": 1})
+        url = self._ctx.url + path
+        response: requests.Response = self._ctx.session.get(url, params={"page_size": 1})
         result: dict = response.json()
         return result["total"]

--- a/src/posit/connect/me.py
+++ b/src/posit/connect/me.py
@@ -1,9 +1,8 @@
-from posit.connect.resources import ResourceParameters
-
+from .context import Context
 from .users import User
 
 
-def get(params: ResourceParameters) -> User:
+def get(ctx: Context) -> User:
     """
     Gets the current user.
 
@@ -15,6 +14,6 @@ def get(params: ResourceParameters) -> User:
     -------
         User: The current user.
     """
-    url = params.url + "v1/user"
-    response = params.session.get(url)
-    return User(params, **response.json())
+    url = ctx.url + "v1/user"
+    response = ctx.session.get(url)
+    return User(ctx, **response.json())

--- a/src/posit/connect/permissions.py
+++ b/src/posit/connect/permissions.py
@@ -111,8 +111,15 @@ class Permissions(Resources):
         """
         path = f"v1/content/{self.content_guid}/permissions"
         url = self.params.url + path
-        response = self.params.session.get(url, json=kwargs)
+        response = self.params.session.get(url)
+        kwargs_items = kwargs.items()
         results = response.json()
+        if len(kwargs_items) > 0:
+            results = [
+                result
+                for result in results
+                if isinstance(result, dict) and (result.items() >= kwargs_items)
+            ]
         return [Permission(self.params, **result) for result in results]
 
     def find_one(self, **kwargs) -> Permission | None:
@@ -142,24 +149,17 @@ class Permissions(Resources):
         response = self.params.session.get(url)
         return Permission(self.params, **response.json())
 
-    def destroy(self, *permissions: str | Group | User | Permission) -> list[Permission]:
-        """Remove supplied content item permissions.
+    def destroy(self, permission: str | Group | User | Permission, /) -> None:
+        """Remove supplied content item permission.
 
-        Removes all provided permissions from the content item's permissions. If a permission isn't
-        found, it is silently ignored.
+        Removes provided permission from the content item's permissions.
 
         Parameters
         ----------
-        *permissions : str | Group | User | Permission
-            The content item permissions to remove. If a `str` is received, it is compared against
+        permission : str | Group | User | Permission
+            The content item permission to remove. If a `str` is received, it is compared against
             the `Permissions`'s `principal_guid`. If a `Group` or `User` is received, the associated
             `Permission` will be removed.
-
-        Returns
-        -------
-        list[Permission]
-            The removed permissions. If a permission is not found, there is nothing to remove and 
-            it is not included in the returned list.
 
         Examples
         --------
@@ -175,51 +175,46 @@ class Permissions(Resources):
         ############################
 
         client = connect.Client()
+        content_item = client.content.get(content_guid)
 
         # Remove a single permission by principal_guid
-        client.content.get(content_guid).permissions.destroy(principal_guid)
+        content_item.permissions.destroy(principal_guid)
 
         # Remove by user (if principal_guid is a user)
         user = client.users.get(principal_guid)
-        client.content.get(content_guid).permissions.destroy(user)
+        content_item.permissions.destroy(user)
 
         # Remove by group (if principal_guid is a group)
         group = client.groups.get(principal_guid)
-        client.content.get(content_guid).permissions.destroy(group)
+        content_item.permissions.destroy(group)
 
         # Remove all groups with a matching prefix name
         groups = client.groups.find(prefix=group_name_prefix)
-        client.content.get(content_guid).permissions.destroy(*groups)
+        for group in groups:
+            content_item.permissions.destroy(group)
 
         # Confirm new permissions
-        client.content.get(content_guid).permissions.find()
+        content_item.permissions.find()
         ```
         """
         from .groups import Group
         from .users import User
 
-        if len(permissions) == 0:
-            raise ValueError("Expected at least one `permission` to remove")
+        if isinstance(permission, str):
+            permission_obj = self.get(permission)
+        elif isinstance(permission, (Group, User)):
+            principal_guid: str = permission["guid"]
+            permission_obj = self.find_one(
+                principal_guid=principal_guid,
+            )
+            print("Barret!", permission, principal_guid, permission_obj)
+            if permission_obj is None:
+                raise ValueError(f"Permission with principal_guid '{principal_guid}' not found.")
+        elif isinstance(permission, Permission):
+            permission_obj = permission
+        else:
+            raise TypeError(
+                f"destroy() expected `permission=` to have type `str | User | Group | Permission`. Received `{permission}` of type `{type(permission)}`.",
+            )
 
-        principal_guids: set[str] = set()
-
-        for arg in permissions:
-            if isinstance(arg, str):
-                principal_guid = arg
-            elif isinstance(arg, (Group, User)):
-                principal_guid: str = arg["guid"]
-            elif isinstance(arg, Permission):
-                principal_guid: str = arg["principal_guid"]
-            else:
-                raise TypeError(
-                    f"destroy() expected argument type 'str', 'User', 'Group', or 'Permission' but got '{type(arg).__name__}'",
-                )
-            principal_guids.add(principal_guid)
-
-        destroyed_permissions: list[Permission] = []
-        for permission in self.find():
-            if permission["principal_guid"] in principal_guids:
-                permission.destroy()
-                destroyed_permissions.append(permission)
-
-        return destroyed_permissions
+        permission_obj.destroy()

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -50,6 +50,10 @@ class User(Resource):
         Attempt to lock your own account (will raise `RuntimeError` unless `force` is set to `True`):
 
         >>> user.lock(force=True)
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#post-/v1/users/-guid-/lock
         """
         _me = me.get(self._ctx)
         if _me["guid"] == self["guid"] and not force:
@@ -76,6 +80,10 @@ class User(Resource):
         Unlock a user's account:
 
         >>> user.unlock()
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#post-/v1/users/-guid-/lock
         """
         url = self._ctx.url + f"v1/users/{self['guid']}/lock"
         body = {"locked": False}
@@ -124,6 +132,10 @@ class User(Resource):
         Update the user's first and last name:
 
         >>> user.update(first_name="Jane", last_name="Smith")
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#put-/v1/users/-guid-
         """
         url = self._ctx.url + f"v1/users/{self['guid']}"
         response = self._ctx.session.put(url, json=kwargs)
@@ -204,6 +216,10 @@ class UserGroups(Resources):
         # Add the user to a group by GUID
         user.groups.add(group_guid="GROUP_GUID_HERE")
         ```
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#post-/v1/groups/-group_guid-/members
         """
         if len(args) > 0:
             from .groups import Group
@@ -272,6 +288,10 @@ class UserGroups(Resources):
         # Remove the user from a group by GUID
         user.groups.delete(group_guid="GROUP_GUID_HERE")
         ```
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#delete-/v1/groups/-group_guid-/members/-user_guid-
         """
         if len(args) > 0:
             from .groups import Group
@@ -307,9 +327,18 @@ class UserGroups(Resources):
 
         Examples
         --------
-        Retrieve the groups to which the user belongs:
+        ```python
+        from posit.connect import Client
 
-        >>> groups = user.groups()
+        client = Client("https://posit.example.com", "API_KEY")
+
+        user = client.users.get("USER_GUID_HERE")
+        groups = user.groups.find()
+        ```
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#get-/v1/groups/-group_guid-/members
         """
         self_groups: list[Group] = []
         for group in self._ctx.client.groups.find():
@@ -396,6 +425,10 @@ class Users(Resources):
         ...     user_must_set_password=True,
         ...     user_role="viewer",
         ... )
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#post-/v1/users
         """
         # todo - use the 'context' module to inspect the 'authentication' object and route to POST (local) or PUT (remote).
         url = self._ctx.url + "v1/users"
@@ -440,6 +473,10 @@ class Users(Resources):
         Find all users who are locked or licensed:
 
         >>> users = client.find(account_status="locked|licensed")
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#get-/v1/users
         """
         url = self._ctx.url + "v1/users"
         paginator = Paginator(self._ctx.session, url, params={**conditions})
@@ -483,6 +520,10 @@ class Users(Resources):
         Find a user who is locked or licensed:
 
         >>> user = client.find_one(account_status="locked|licensed")
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#get-/v1/users
         """
         url = self._ctx.url + "v1/users"
         paginator = Paginator(self._ctx.session, url, params={**conditions})
@@ -513,6 +554,10 @@ class Users(Resources):
         Examples
         --------
         >>> user = client.get("123e4567-e89b-12d3-a456-426614174000")
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#get-/v1/users
         """
         url = self._ctx.url + f"v1/users/{uid}"
         response = self._ctx.session.get(url)
@@ -528,6 +573,10 @@ class Users(Resources):
         Returns
         -------
         int
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#get-/v1/users
         """
         url = self._ctx.url + "v1/users"
         response = self._ctx.session.get(url, params={"page_size": 1})

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -170,22 +170,19 @@ class UserGroups(Resources):
         self._user_guid: str = user_guid
 
     @overload
-    def add(self, *args: Group) -> None: ...
+    def add(self, group: Group, /) -> None: ...
     @overload
-    def add(self, *, group_guid: str) -> None: ...
+    def add(self, /, *, group_guid: str) -> None: ...
 
-    def add(
-        self,
-        *args: Group,
-        group_guid: Optional[str] = None,
-    ) -> None:
+    def add(self, group: Optional[Group] = None, /, *, group_guid: Optional[str] = None) -> None:
         """
-        Add the user to the specified groups.
+        Add the user to the specified group.
 
         Parameters
         ----------
-        *args : Group
-            The groups to which the user will be added.
+        group : Group
+            The groups to which the user will be added. Only one of `group=` or `group_guid=` can
+            be provided.
         group_guid : str
             The unique identifier (guid) of the group to which the user will be added.
 
@@ -211,7 +208,8 @@ class UserGroups(Resources):
             client.groups.get("GROUP_GUID_1"),
             client.groups.get("GROUP_GUID_2"),
         ]
-        user.groups.add(*groups)
+        for group in groups:
+            user.groups.add(group)
 
         # Add the user to a group by GUID
         user.groups.add(group_guid="GROUP_GUID_HERE")
@@ -221,43 +219,44 @@ class UserGroups(Resources):
         --------
         * https://docs.posit.co/connect/api/#post-/v1/groups/-group_guid-/members
         """
-        if len(args) > 0:
+        if group is not None:
             from .groups import Group
 
             if group_guid:
-                raise ValueError("Only one of `*args` or `group_guid` may be be provided.")
+                raise ValueError("Only one of `group=` or `group_guid` may be be provided.")
 
-            for i, group in enumerate(args):
-                if not isinstance(group, Group):
-                    raise TypeError(
-                        f"`args[{i}]` is not an instance of Group. Received {group}",
-                    )
-            for group in args:
-                group.members.add(user_guid=self._user_guid)
+            if not isinstance(group, Group):
+                raise TypeError(
+                    f"`group=` is not an instance of Group. Received {group}",
+                )
+            group.members.add(user_guid=self._user_guid)
             return
 
         if not group_guid:
-            raise ValueError("Only one of `*args` or `group_guid` may be be provided.")
+            raise ValueError("Only one of `group=` or `group_guid` may be be provided.")
         group = self._ctx.client.groups.get(group_guid)
         group.members.add(user_guid=self._user_guid)
 
     @overload
-    def delete(self, *args: Group) -> None: ...
+    def delete(self, group: Group, /) -> None: ...
     @overload
-    def delete(self, *, group_guid: str) -> None: ...
+    def delete(self, /, *, group_guid: str) -> None: ...
 
     def delete(
         self,
-        *args: Group,
+        group: Optional[Group] = None,
+        /,
+        *,
         group_guid: Optional[str] = None,
     ) -> None:
         """
-        Remove the user from the specified groups.
+        Remove the user from the specified group.
 
         Parameters
         ----------
-        *args : Group
-            The groups from which the user will be removed.
+        group : Group
+            The groups to which the user will be added. Only one of `group=` or `group_guid=` can
+            be provided.
         group_guid : str
             The unique identifier (guid) of the group from which the user will be removed.
 
@@ -283,7 +282,8 @@ class UserGroups(Resources):
             client.groups.get("GROUP_GUID_1"),
             client.groups.get("GROUP_GUID_2"),
         ]
-        user.groups.delete(*groups)
+        for group in groups:
+            user.groups.delete(group)
 
         # Remove the user from a group by GUID
         user.groups.delete(group_guid="GROUP_GUID_HERE")
@@ -293,19 +293,17 @@ class UserGroups(Resources):
         --------
         * https://docs.posit.co/connect/api/#delete-/v1/groups/-group_guid-/members/-user_guid-
         """
-        if len(args) > 0:
+        if group is not None:
             from .groups import Group
 
             if group_guid:
-                raise ValueError("Only one of `*args` or `group_guid=` may be be provided.")
+                raise ValueError("Only one of `group=` or `group_guid=` may be be provided.")
 
-            for i, group in enumerate(args):
-                if not isinstance(group, Group):
-                    raise TypeError(
-                        f"`args[{i}]` is not an instance of Group. Received {group}",
-                    )
-            for group in args:
-                group.members.delete(user_guid=self._user_guid)
+            if not isinstance(group, Group):
+                raise TypeError(
+                    f"`group=` is not an instance of Group. Received {group}",
+                )
+            group.members.delete(user_guid=self._user_guid)
             return
 
         if not isinstance(group_guid, str):

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -56,9 +56,9 @@ class User(Resource):
             raise RuntimeError(
                 "You cannot lock your own account. Set force=True to override this behavior.",
             )
-        url = self.params.url + f"v1/users/{self['guid']}/lock"
+        url = self._ctx.url + f"v1/users/{self['guid']}/lock"
         body = {"locked": True}
-        self.params.session.post(url, json=body)
+        self._ctx.session.post(url, json=body)
         super().update(locked=True)
 
     def unlock(self):
@@ -77,9 +77,9 @@ class User(Resource):
 
         >>> user.unlock()
         """
-        url = self.params.url + f"v1/users/{self['guid']}/lock"
+        url = self._ctx.url + f"v1/users/{self['guid']}/lock"
         body = {"locked": False}
-        self.params.session.post(url, json=body)
+        self._ctx.session.post(url, json=body)
         super().update(locked=False)
 
     class UpdateUser(TypedDict):
@@ -125,8 +125,8 @@ class User(Resource):
 
         >>> user.update(first_name="Jane", last_name="Smith")
         """
-        url = self.params.url + f"v1/users/{self['guid']}"
-        response = self.params.session.put(url, json=kwargs)
+        url = self._ctx.url + f"v1/users/{self['guid']}"
+        response = self._ctx.session.put(url, json=kwargs)
         super().update(**response.json())
 
     @property
@@ -259,8 +259,8 @@ class Users(Resources):
         ... )
         """
         # todo - use the 'context' module to inspect the 'authentication' object and route to POST (local) or PUT (remote).
-        url = self.params.url + "v1/users"
-        response = self.params.session.post(url, json=attributes)
+        url = self._ctx.url + "v1/users"
+        response = self._ctx.session.post(url, json=attributes)
         return User(self._ctx, **response.json())
 
     class FindUser(TypedDict):
@@ -302,8 +302,8 @@ class Users(Resources):
 
         >>> users = client.find(account_status="locked|licensed")
         """
-        url = self.params.url + "v1/users"
-        paginator = Paginator(self.params.session, url, params={**conditions})
+        url = self._ctx.url + "v1/users"
+        paginator = Paginator(self._ctx.session, url, params={**conditions})
         results = paginator.fetch_results()
         return [
             User(
@@ -345,8 +345,8 @@ class Users(Resources):
 
         >>> user = client.find_one(account_status="locked|licensed")
         """
-        url = self.params.url + "v1/users"
-        paginator = Paginator(self.params.session, url, params={**conditions})
+        url = self._ctx.url + "v1/users"
+        paginator = Paginator(self._ctx.session, url, params={**conditions})
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)
         users = (
@@ -375,8 +375,8 @@ class Users(Resources):
         --------
         >>> user = client.get("123e4567-e89b-12d3-a456-426614174000")
         """
-        url = self.params.url + f"v1/users/{uid}"
-        response = self.params.session.get(url)
+        url = self._ctx.url + f"v1/users/{uid}"
+        response = self._ctx.session.get(url)
         return User(
             self._ctx,
             **response.json(),
@@ -390,7 +390,7 @@ class Users(Resources):
         -------
         int
         """
-        url = self.params.url + "v1/users"
-        response = self.params.session.get(url, params={"page_size": 1})
+        url = self._ctx.url + "v1/users"
+        response = self._ctx.session.get(url, params={"page_size": 1})
         result: dict = response.json()
         return result["total"]

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 
 class User(Resource):
-    def __init__(self, ctx: Context, /, **attributes: dict) -> None:
+    def __init__(self, ctx: Context, /, **attributes) -> None:
         super().__init__(ctx.client.resource_params, **attributes)
         self._ctx: Context = ctx
 
@@ -214,7 +214,7 @@ class UserGroups(Resources):
             for i, group in enumerate(args):
                 if not isinstance(group, Group):
                     raise TypeError(
-                        f"`args[{i}]` is not an instance of Group",
+                        f"`args[{i}]` is not an instance of Group. Received {group}",
                     )
             for group in args:
                 group.members.add(user_guid=self._user_guid)
@@ -282,14 +282,14 @@ class UserGroups(Resources):
             for i, group in enumerate(args):
                 if not isinstance(group, Group):
                     raise TypeError(
-                        f"`args[{i}]` is not an instance of Group",
+                        f"`args[{i}]` is not an instance of Group. Received {group}",
                     )
             for group in args:
                 group.members.delete(user_guid=self._user_guid)
             return
 
         if not isinstance(group_guid, str):
-            raise TypeError("`group_guid=` must be a string.")
+            raise TypeError("`group_guid=` must be a string. Received {user}")
         if not group_guid:
             raise ValueError("`group_guid=` must not be empty.")
 

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -129,7 +129,35 @@ class User(Resource):
         response = self.params.session.put(url, json=kwargs)
         super().update(**response.json())
 
-    def groups(self) -> List[Group]:
+    @property
+    def groups(self) -> UserGroups:
+        """
+        Retrieve the groups to which the user belongs.
+
+        Returns
+        -------
+        UserGroups
+            Helper class that returns the groups of which the user is a member.
+
+        Examples
+        --------
+        Retrieve the groups to which the user belongs:
+
+        ```python
+        user = client.users.get("USER_GUID_HERE")
+        groups = user.groups.find()
+        ```
+        """
+        return UserGroups(self._ctx, self["guid"])
+
+
+class UserGroups(Resources):
+    def __init__(self, ctx: Context, user_guid: str) -> None:
+        super().__init__(ctx.client.resource_params)
+        self._ctx: Context = ctx
+        self._user_guid: str = user_guid
+
+    def find(self) -> List[Group]:
         """
         Retrieve the groups to which the user belongs.
 
@@ -148,7 +176,7 @@ class User(Resource):
         for group in self._ctx.client.groups.find():
             group_users = group.members.find()
             for group_user in group_users:
-                if group_user["guid"] == self["guid"]:
+                if group_user["guid"] == self._user_guid:
                     self_groups.append(group)
 
         return self_groups

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -82,7 +82,7 @@ class User(Resource):
         self.params.session.post(url, json=body)
         super().update(locked=False)
 
-    class _UpdateUser(TypedDict):
+    class UpdateUser(TypedDict):
         """Update user request."""
 
         email: NotRequired[str]
@@ -93,7 +93,7 @@ class User(Resource):
 
     def update(
         self,
-        **kwargs: Unpack[_UpdateUser],
+        **kwargs: Unpack[UpdateUser],
     ) -> None:
         """
         Update the user's attributes.
@@ -189,7 +189,7 @@ class Users(Resources):
         super().__init__(ctx.client.resource_params)
         self._ctx: Context = ctx
 
-    class _CreateUser(TypedDict):
+    class CreateUser(TypedDict):
         """Create user request."""
 
         username: Required[str]
@@ -204,7 +204,7 @@ class Users(Resources):
         user_role: NotRequired[Literal["administrator", "publisher", "viewer"]]
         unique_id: NotRequired[str]
 
-    def create(self, **attributes: Unpack[_CreateUser]) -> User:
+    def create(self, **attributes: Unpack[CreateUser]) -> User:
         """
         Create a new user with the specified attributes.
 
@@ -263,14 +263,14 @@ class Users(Resources):
         response = self.params.session.post(url, json=attributes)
         return User(self._ctx, **response.json())
 
-    class _FindUser(TypedDict):
+    class FindUser(TypedDict):
         """Find user request."""
 
         prefix: NotRequired[str]
         user_role: NotRequired[Literal["administrator", "publisher", "viewer"] | str]
         account_status: NotRequired[Literal["locked", "licensed", "inactive"] | str]
 
-    def find(self, **conditions: Unpack[_FindUser]) -> List[User]:
+    def find(self, **conditions: Unpack[FindUser]) -> List[User]:
         """
         Find users matching the specified conditions.
 
@@ -313,7 +313,7 @@ class Users(Resources):
             for user in results
         ]
 
-    def find_one(self, **conditions: Unpack[_FindUser]) -> User | None:
+    def find_one(self, **conditions: Unpack[FindUser]) -> User | None:
         """
         Find a user matching the specified conditions.
 

--- a/tests/posit/connect/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066/permissions.json
+++ b/tests/posit/connect/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066/permissions.json
@@ -1,16 +1,16 @@
 [
-    {
-        "id": 94,
-        "content_guid": "f2f37341-e21d-3d80-c698-a935ad614066",
-        "principal_guid": "78974391-d89f-4f11-916a-ba50cfe993db",
-        "principal_type": "user",
-        "role": "owner"
-    },
-    {
-        "id": 59,
-        "content_guid": "f2f37341-e21d-3d80-c698-a935ad614066",
-        "principal_guid": "75b95fc0-ae02-4d85-8732-79a845143eed",
-        "principal_type": "group",
-        "role": "viewer"
-    }
+  {
+    "id": 94,
+    "content_guid": "f2f37341-e21d-3d80-c698-a935ad614066",
+    "principal_guid": "20a79ce3-6e87-4522-9faf-be24228800a4",
+    "principal_type": "user",
+    "role": "owner"
+  },
+  {
+    "id": 59,
+    "content_guid": "f2f37341-e21d-3d80-c698-a935ad614066",
+    "principal_guid": "6f300623-1e0c-48e6-a473-ddf630c0c0c3",
+    "principal_type": "group",
+    "role": "viewer"
+  }
 ]

--- a/tests/posit/connect/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066/permissions/59.json
+++ b/tests/posit/connect/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066/permissions/59.json
@@ -1,0 +1,7 @@
+{
+  "id": 59,
+  "content_guid": "f2f37341-e21d-3d80-c698-a935ad614066",
+  "principal_guid": "6f300623-1e0c-48e6-a473-ddf630c0c0c3",
+  "principal_type": "group",
+  "role": "viewer"
+}

--- a/tests/posit/connect/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066/permissions/94.json
+++ b/tests/posit/connect/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066/permissions/94.json
@@ -1,7 +1,7 @@
 {
-    "id": 94,
-    "content_guid": "f2f37341-e21d-3d80-c698-a935ad614066",
-    "principal_guid": "78974391-d89f-4f11-916a-ba50cfe993db",
-    "principal_type": "user",
-    "role": "owner"
+  "id": "94",
+  "content_guid": "f2f37341-e21d-3d80-c698-a935ad614066",
+  "principal_guid": "20a79ce3-6e87-4522-9faf-be24228800a4",
+  "principal_type": "user",
+  "role": "owner"
 }

--- a/tests/posit/connect/__api__/v1/groups.json
+++ b/tests/posit/connect/__api__/v1/groups.json
@@ -1,0 +1,16 @@
+{
+  "results": [
+    {
+      "guid": "empty-group-guid",
+      "name": "Empty Friends",
+      "owner_guid": "empty-owner-guid"
+    },
+    {
+      "guid": "6f300623-1e0c-48e6-a473-ddf630c0c0c3",
+      "name": "Friends",
+      "owner_guid": "20a79ce3-6e87-4522-9faf-be24228800a4"
+    }
+  ],
+  "current_page": 1,
+  "total": 2
+}

--- a/tests/posit/connect/__api__/v1/groups/6f300623-1e0c-48e6-a473-ddf630c0c0c3.json
+++ b/tests/posit/connect/__api__/v1/groups/6f300623-1e0c-48e6-a473-ddf630c0c0c3.json
@@ -1,5 +1,5 @@
 {
-    "guid": "6f300623-1e0c-48e6-a473-ddf630c0c0c3",
-    "name": "Friends",
-    "owner_guid": "20a79ce3-6e87-4522-9faf-be24228800a4"
-  }
+  "guid": "6f300623-1e0c-48e6-a473-ddf630c0c0c3",
+  "name": "Friends",
+  "owner_guid": "20a79ce3-6e87-4522-9faf-be24228800a4"
+}

--- a/tests/posit/connect/__api__/v1/groups/6f300623-1e0c-48e6-a473-ddf630c0c0c3/members.json
+++ b/tests/posit/connect/__api__/v1/groups/6f300623-1e0c-48e6-a473-ddf630c0c0c3/members.json
@@ -1,0 +1,32 @@
+{
+  "results": [
+    {
+      "email": "alice@connect.example",
+      "username": "al",
+      "first_name": "Alice",
+      "last_name": "User",
+      "user_role": "publisher",
+      "created_time": "2017-08-08T15:24:32Z",
+      "updated_time": "2023-03-02T20:25:06Z",
+      "active_time": "2018-05-09T16:58:45Z",
+      "confirmed": true,
+      "locked": false,
+      "guid": "a01792e3-2e67-402e-99af-be04a48da074"
+    },
+    {
+      "email": "bob@connect.example",
+      "username": "robert",
+      "first_name": "Bob",
+      "last_name": "Loblaw",
+      "user_role": "publisher",
+      "created_time": "2023-01-06T19:47:29Z",
+      "updated_time": "2023-05-05T19:08:45Z",
+      "active_time": "2023-05-05T20:29:11Z",
+      "confirmed": true,
+      "locked": false,
+      "guid": "87c12c08-11cd-4de1-8da3-12a7579c4998"
+    }
+  ],
+  "current_page": 1,
+  "total": 2
+}

--- a/tests/posit/connect/__api__/v1/groups/empty-group-guid/members.json
+++ b/tests/posit/connect/__api__/v1/groups/empty-group-guid/members.json
@@ -1,0 +1,5 @@
+{
+  "results": [],
+  "current_page": 1,
+  "total": 0
+}

--- a/tests/posit/connect/__api__/v1/groups/groups.json
+++ b/tests/posit/connect/__api__/v1/groups/groups.json
@@ -1,0 +1,16 @@
+{
+  "results": [
+    {
+      "guid": "empty-group-guid",
+      "name": "Empty Friends",
+      "owner_guid": "empty-owner-guid"
+    },
+    {
+      "guid": "6f300623-1e0c-48e6-a473-ddf630c0c0c3",
+      "name": "Friends",
+      "owner_guid": "20a79ce3-6e87-4522-9faf-be24228800a4"
+    }
+  ],
+  "current_page": 1,
+  "total": 2
+}

--- a/tests/posit/connect/test_client.py
+++ b/tests/posit/connect/test_client.py
@@ -84,7 +84,12 @@ class TestClient:
         MockConfig.assert_called_once_with(api_key=api_key, url=url)
         MockSession.assert_called_once()
 
-    def test__del__(self, MockAuth, MockConfig, MockSession):
+    def test__del__(
+        self,
+        MockAuth: MagicMock,
+        MockConfig: MagicMock,
+        MockSession: MagicMock,
+    ):
         api_key = "12345"
         url = "https://connect.example.com"
         client = Client(api_key=api_key, url=url)

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -1,5 +1,4 @@
 import pytest
-import requests
 import responses
 from responses import matchers
 
@@ -7,7 +6,6 @@ from posit.connect.client import Client
 from posit.connect.content import ContentItem, ContentItemRepository
 from posit.connect.context import Context
 from posit.connect.resources import ResourceParameters
-from posit.connect.urls import Url
 
 from .api import load_mock, load_mock_dict
 
@@ -562,15 +560,19 @@ class TestContentRepository:
 
     @property
     def content_item(self):
-        return ContentItem(self.params, guid=self.content_guid)
+        return ContentItem(self.ctx, guid=self.content_guid)
 
     @property
     def endpoint(self):
         return f"{self.base_url}/__api__/v1/content/{self.content_guid}/repository"
 
     @property
+    def client(self):
+        return Client(self.base_url, "12345")
+
+    @property
     def ctx(self):
-        return Context(requests.Session(), Url(self.base_url))
+        return Context(self.client)
 
     @property
     def params(self):

--- a/tests/posit/connect/test_context.py
+++ b/tests/posit/connect/test_context.py
@@ -64,7 +64,7 @@ class TestContextVersion:
             json={},
         )
 
-        ctx = Context(Client("http://connect.example"))
+        ctx = Context(Client("http://connect.example", "12345"))
 
         assert ctx.version is None
 
@@ -75,7 +75,7 @@ class TestContextVersion:
             json={"version": "2024.09.24"},
         )
 
-        ctx = Context(Client("http://connect.example"))
+        ctx = Context(Client("http://connect.example", "12345"))
 
         assert ctx.version == "2024.09.24"
 

--- a/tests/posit/connect/test_context.py
+++ b/tests/posit/connect/test_context.py
@@ -2,11 +2,10 @@ from email.contentmanager import ContentManager
 from unittest.mock import MagicMock, Mock
 
 import pytest
-import requests
 import responses
 
+from posit.connect.client import Client
 from posit.connect.context import Context, requires
-from posit.connect.urls import Url
 
 
 class TestRequires:
@@ -65,9 +64,7 @@ class TestContextVersion:
             json={},
         )
 
-        session = requests.Session()
-        url = Url("http://connect.example")
-        ctx = Context(session, url)
+        ctx = Context(Client("http://connect.example"))
 
         assert ctx.version is None
 
@@ -78,13 +75,11 @@ class TestContextVersion:
             json={"version": "2024.09.24"},
         )
 
-        session = requests.Session()
-        url = Url("http://connect.example")
-        ctx = Context(session, url)
+        ctx = Context(Client("http://connect.example"))
 
         assert ctx.version == "2024.09.24"
 
     def test_setter(self):
-        ctx = Context(Mock(), Mock())
+        ctx = Context(Mock())
         ctx.version = "2024.09.24"
         assert ctx.version == "2024.09.24"

--- a/tests/posit/connect/test_groups.py
+++ b/tests/posit/connect/test_groups.py
@@ -73,7 +73,6 @@ class TestGroupMembers:
 
         user = User(self.client._ctx, guid=user_guid)
         self.group.members.add(user)
-        self.group.members.add(user, user)
         self.group.members.add(user_guid=user["guid"])
 
         with pytest.raises(TypeError):
@@ -102,7 +101,6 @@ class TestGroupMembers:
         user = User(self.client._ctx, guid=user_guid)
 
         self.group.members.delete(user)
-        self.group.members.delete(user, user)
         self.group.members.delete(user_guid=user["guid"])
 
         with pytest.raises(TypeError):

--- a/tests/posit/connect/test_groups.py
+++ b/tests/posit/connect/test_groups.py
@@ -34,7 +34,7 @@ class TestGroupAttributes:
 class TestGroupMembers:
     @classmethod
     def setup_class(cls):
-        cls.client = Client("https://connect.example")
+        cls.client = Client("https://connect.example", "12345")
         guid = "6f300623-1e0c-48e6-a473-ddf630c0c0c3"
         fake_item = load_mock_dict(f"v1/groups/{guid}.json")
         ctx = Context(cls.client)

--- a/tests/posit/connect/test_groups.py
+++ b/tests/posit/connect/test_groups.py
@@ -1,7 +1,12 @@
 from unittest import mock
 from unittest.mock import Mock
 
+import responses
+
+from posit.connect.client import Client
+from posit.connect.context import Context
 from posit.connect.groups import Group
+from posit.connect.users import User
 
 from .api import load_mock_dict
 
@@ -24,3 +29,35 @@ class TestGroupAttributes:
 
     def test_owner_guid(self):
         assert self.item["owner_guid"] == "20a79ce3-6e87-4522-9faf-be24228800a4"
+
+
+class TestGroupMembers:
+    @classmethod
+    def setup_class(cls):
+        cls.client = Client("https://connect.example")
+        guid = "6f300623-1e0c-48e6-a473-ddf630c0c0c3"
+        fake_item = load_mock_dict(f"v1/groups/{guid}.json")
+        ctx = Context(cls.client)
+        cls.group = Group(ctx, **fake_item)
+
+    @responses.activate
+    def test_members_count(self):
+        responses.get(
+            "https://connect.example/__api__/v1/groups/6f300623-1e0c-48e6-a473-ddf630c0c0c3/members",
+            json=load_mock_dict(f"v1/groups/{self.group['guid']}/members.json"),
+        )
+        group_members = self.group.members
+
+        assert group_members.count() == 2
+
+    @responses.activate
+    def test_members_find(self):
+        responses.get(
+            "https://connect.example/__api__/v1/groups/6f300623-1e0c-48e6-a473-ddf630c0c0c3/members",
+            json=load_mock_dict(f"v1/groups/{self.group['guid']}/members.json"),
+        )
+
+        group_users = self.group.members.find()
+        assert len(group_users) == 2
+        for user in group_users:
+            assert isinstance(user, User)

--- a/tests/posit/connect/test_groups.py
+++ b/tests/posit/connect/test_groups.py
@@ -1,6 +1,7 @@
 from unittest import mock
 from unittest.mock import Mock
 
+import pytest
 import responses
 
 from posit.connect.client import Client
@@ -43,7 +44,7 @@ class TestGroupMembers:
     @responses.activate
     def test_members_count(self):
         responses.get(
-            "https://connect.example/__api__/v1/groups/6f300623-1e0c-48e6-a473-ddf630c0c0c3/members",
+            f"https://connect.example/__api__/v1/groups/{self.group['guid']}/members",
             json=load_mock_dict(f"v1/groups/{self.group['guid']}/members.json"),
         )
         group_members = self.group.members
@@ -53,7 +54,7 @@ class TestGroupMembers:
     @responses.activate
     def test_members_find(self):
         responses.get(
-            "https://connect.example/__api__/v1/groups/6f300623-1e0c-48e6-a473-ddf630c0c0c3/members",
+            f"https://connect.example/__api__/v1/groups/{self.group['guid']}/members",
             json=load_mock_dict(f"v1/groups/{self.group['guid']}/members.json"),
         )
 
@@ -61,3 +62,57 @@ class TestGroupMembers:
         assert len(group_users) == 2
         for user in group_users:
             assert isinstance(user, User)
+
+    @responses.activate
+    def test_members_add(self):
+        user_guid = "user-guid"
+        responses.post(
+            f"https://connect.example/__api__/v1/groups/{self.group['guid']}/members",
+            json=[],  # No need to return anything
+        )
+
+        user = User(self.client._ctx, guid=user_guid)
+        self.group.members.add(user)
+        self.group.members.add(user, user)
+        self.group.members.add(user_guid=user["guid"])
+
+        with pytest.raises(TypeError):
+            self.group.members.add(
+                "not-a-user",  # pyright: ignore[reportArgumentType]
+            )
+        with pytest.raises(TypeError):
+            self.group.members.add(group_guid=42)  # pyright: ignore[reportCallIssue]
+        with pytest.raises(ValueError):
+            self.group.members.add(user, user_guid=user["guid"])  # pyright: ignore[reportCallIssue]
+        with pytest.raises(ValueError):
+            self.group.members.add(user_guid="")
+
+    @responses.activate
+    def test_members_delete(self):
+        user_guid = "user-guid"
+        responses.get(
+            f"https://connect.example/__api__/v1/groups/{self.group['guid']}",
+            json=dict(self.group),
+        )
+        responses.delete(
+            f"https://connect.example/__api__/v1/groups/{self.group['guid']}/members/{user_guid}",
+            json=[],  # No need to return anything
+        )
+
+        user = User(self.client._ctx, guid=user_guid)
+
+        self.group.members.delete(user)
+        self.group.members.delete(user, user)
+        self.group.members.delete(user_guid=user["guid"])
+
+        with pytest.raises(TypeError):
+            self.group.members.delete(
+                "not-a-user",  # pyright: ignore[reportArgumentType]
+            )
+        with pytest.raises(TypeError):
+            self.group.members.delete(group_guid=42)  # pyright: ignore[reportCallIssue]
+        with pytest.raises(ValueError):
+            self.group.members.delete(user, user_guid=user["guid"])  # pyright: ignore[reportCallIssue]
+
+        with pytest.raises(ValueError):
+            self.group.members.delete(user_guid="")

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -161,7 +161,7 @@ class TestUserGroups:
                 json=load_mock_dict(f"v1/groups/{guid}/members.json"),
             )
 
-        client = Client("https://connect.example/")
+        client = Client("https://connect.example/", "12345")
         users = client.users.find()
         assert len(users) == 2 + 2
 

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -202,16 +202,10 @@ class TestUserGroups:
         # Add via Group
         user.groups.add(new_group)
         # Add via guid
-        user.groups.add(group_guid=new_group["guid"])
+        user.groups.add(new_group["guid"])
 
-        with pytest.raises(TypeError):
-            user.groups.add(
-                "not a group",  # pyright: ignore[reportArgumentType]
-            )
         with pytest.raises(ValueError):
-            user.groups.add(group_guid="")
-        with pytest.raises(ValueError):
-            user.groups.add(new_group, group_guid=new_group["guid"])  # pyright: ignore[reportCallIssue]
+            user.groups.add("")
 
     @responses.activate
     def test_groups_delete(self):
@@ -234,16 +228,10 @@ class TestUserGroups:
         # Delete via Group
         user.groups.delete(group)
         # Delete via guid
-        user.groups.delete(group_guid=group["guid"])
+        user.groups.delete(group["guid"])
 
-        with pytest.raises(TypeError):
-            user.groups.delete(
-                "not a group",  # pyright: ignore[reportArgumentType]
-            )
         with pytest.raises(ValueError):
-            user.groups.delete(group_guid="")
-        with pytest.raises(ValueError):
-            user.groups.delete(group, group_guid=group["guid"])  # pyright: ignore[reportCallIssue]
+            user.groups.delete("")
 
 
 class TestUsers:

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -166,9 +166,7 @@ class TestUserGroups:
         assert len(users) == 2 + 2
 
         carlos = client.users.get(carlos_guid)
-        print("carlos.guid", carlos["guid"])
         no_groups = carlos.groups.find()
-        print("no_groups", no_groups)
         assert len(no_groups) == 0
 
         user = users[1]

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -6,6 +6,8 @@ import responses
 from responses import matchers
 
 from posit.connect.client import Client
+from posit.connect.groups import Group
+from posit.connect.users import User
 
 from .api import load_mock, load_mock_dict
 
@@ -139,13 +141,18 @@ class TestUserGroups:
     def test_groups(self):
         # Get user
         carlos_guid = "20a79ce3-6e87-4522-9faf-be24228800a4"
+        carlos_empty_group_guid = "empty-group-guid"
         responses.get(
             f"https://connect.example/__api__/v1/users/{carlos_guid}",
             json=load_mock_dict(f"v1/users/{carlos_guid}.json"),
         )
         responses.get(
+            f"https://connect.example/__api__/v1/groups/{carlos_empty_group_guid}/members?page_number=1&page_size=500",
+            json=load_mock_dict(f"v1/groups/{carlos_empty_group_guid}/members.json"),
+        )
+        responses.get(
             "https://connect.example/__api__/v1/users",
-            json=load_mock("v1/users?page_number=1&page_size=500.jsonc"),
+            json=load_mock_dict("v1/users?page_number=1&page_size=500.jsonc"),
         )
         # Get groups
         responses.get(
@@ -154,28 +161,89 @@ class TestUserGroups:
         )
         # Get group members
         group_guid = "6f300623-1e0c-48e6-a473-ddf630c0c0c3"
-        empty_group_guid = "empty-group-guid"
-        for guid in (group_guid, empty_group_guid):
-            responses.get(
-                f"https://connect.example/__api__/v1/groups/{guid}/members",
-                json=load_mock_dict(f"v1/groups/{guid}/members.json"),
-            )
+        responses.get(
+            f"https://connect.example/__api__/v1/groups/{group_guid}/members",
+            json=load_mock_dict(f"v1/groups/{group_guid}/members.json"),
+        )
 
         client = Client("https://connect.example/", "12345")
-        users = client.users.find()
-        assert len(users) == 2 + 2
 
         carlos = client.users.get(carlos_guid)
         no_groups = carlos.groups.find()
         assert len(no_groups) == 0
 
-        user = users[1]
+        user = client.users.find()[1]
         assert user["guid"] == "87c12c08-11cd-4de1-8da3-12a7579c4998"
 
         groups = user.groups.find()
+        assert isinstance(groups, list)
         assert len(groups) == 1
         group = groups[0]
+        assert isinstance(group, Group)
         assert group["name"] == "Friends"
+
+    @responses.activate
+    def test_groups_add(self):
+        group_guid = "new-group-guid"
+        user_guid = "user-guid"
+        responses.get(
+            f"https://connect.example/__api__/v1/groups/{group_guid}",
+            json={"guid": group_guid},
+        )
+        responses.post(
+            f"https://connect.example/__api__/v1/groups/{group_guid}/members",
+            json=[],
+        )
+
+        client = Client("https://connect.example/", "12345")
+
+        user = User(client._ctx, guid=user_guid)
+        new_group = Group(client._ctx, guid=group_guid)
+        # Add via Group
+        user.groups.add(new_group)
+        # Add via guid
+        user.groups.add(group_guid=new_group["guid"])
+
+        with pytest.raises(TypeError):
+            user.groups.add(
+                "not a group",  # pyright: ignore[reportArgumentType]
+            )
+        with pytest.raises(ValueError):
+            user.groups.add(group_guid="")
+        with pytest.raises(ValueError):
+            user.groups.add(new_group, group_guid=new_group["guid"])  # pyright: ignore[reportCallIssue]
+
+    @responses.activate
+    def test_groups_delete(self):
+        group_guid = "new-group-guid"
+        user_guid = "user-guid"
+        responses.get(
+            f"https://connect.example/__api__/v1/groups/{group_guid}",
+            json={"guid": group_guid},
+        )
+        responses.delete(
+            f"https://connect.example/__api__/v1/groups/{group_guid}/members/{user_guid}",
+            json=[],
+        )
+
+        client = Client("https://connect.example/", "12345")
+
+        user = User(client._ctx, guid=user_guid)
+        group = Group(client._ctx, guid=group_guid)
+
+        # Delete via Group
+        user.groups.delete(group)
+        # Delete via guid
+        user.groups.delete(group_guid=group["guid"])
+
+        with pytest.raises(TypeError):
+            user.groups.delete(
+                "not a group",  # pyright: ignore[reportArgumentType]
+            )
+        with pytest.raises(ValueError):
+            user.groups.delete(group_guid="")
+        with pytest.raises(ValueError):
+            user.groups.delete(group, group_guid=group["guid"])  # pyright: ignore[reportCallIssue]
 
 
 class TestUsers:


### PR DESCRIPTION
Fixes #340
Related https://github.com/rstudio/connect/issues/28176


Added
* `Group`
	* `Group.members.find()` - Retrieve all users for a given group
	* `Group.members.add(user)` - Add user to a group
	* `Group.members.delete(user)` - Remove user form a group
* `User`
	* `Users.groups.find()` - Retrieve all groups for a given user
	* `User.groups.add(group)` - Add user to a group
	* `User.groups.delete(group)` - Remove user from a group

#### Other changes

* `Context` class added `self.ctx = weakref.proxy(client)` 
	* A weakref was used as `Client -> Context -> Client` circular dependency is made quickly. By having the `Context -> Client` be weak, then the `Context` will only disappear once the parent `Client` wants to be gc'd.
* Permissions
	* `.destroy(*permissions)` was changed to `.destroy(permission)` to follow pattern of how a single user can be added to a single group. Similarly, destroying multiple permissions in one method is no faster through the API than looping through and destorying single permissions individually.