### PR TITLE
feat: Add client credential oauth integration support + related databricks helpers to SDK

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -107,3 +107,7 @@ quartodoc:
       contents:
         - connect.metrics
         - connect.metrics.usage
+    - title: External Integrations
+      contents:
+        - connect.external.databricks
+        - connect.external.snowflake

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -755,8 +755,8 @@ class Content(Resources):
         -------
         Optional[ContentItem]
 
-        Example
-        -------
+        Examples
+        --------
         >>> find_by(name="example-content-name")
         """
         attr_items = attrs.items()

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -151,7 +151,7 @@ class PositLocalContentCredentialsStrategy(CredentialsStrategy):
     def auth_type(self) -> str:
         return POSIT_LOCAL_CLIENT_CREDENTIALS_AUTH_TYPE 
 
-    def __call__(self) -> CredentialsProvider:
+    def __call__(self, *args, **kwargs) -> CredentialsProvider:
 
         return PositLocalContentCredentialsProvider(
             self._token_endpoint_url, 

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -2,6 +2,7 @@ import abc
 from typing import Callable, Dict, Optional
 
 from ..client import Client
+from ..oauth import Credentials
 from .external import is_local
 
 """
@@ -9,9 +10,10 @@ NOTE: These APIs are provided as a convenience and are subject to breaking chang
 https://github.com/databricks/databricks-sdk-py#interface-stability
 """
 
+POSIT_OAUTH_INTEGRATION_AUTH_TYPE = "posit-oauth-integration"
+
 # The Databricks SDK CredentialsProvider == Databricks SQL HeaderFactory
 CredentialsProvider = Callable[[], Dict[str, str]]
-
 
 class CredentialsStrategy(abc.ABC):
     """Maintain compatibility with the Databricks SQL/SDK client libraries.
@@ -28,20 +30,74 @@ class CredentialsStrategy(abc.ABC):
     def __call__(self, *args, **kwargs) -> CredentialsProvider:
         raise NotImplementedError
 
-# TODO: Refactor common behavior across different cred providers.
+
+def _new_bearer_authorization_header(credentials: Credentials) -> Dict[str, str]:
+    """Helper to transform an Credentials object into the Bearer auth header consumed by databricks.
+
+    Raises
+    ------
+        ValueError: If provided Credentials object does not contain an access token
+
+    Returns
+    -------
+        Dict[str, str]
+    """
+    access_token = credentials.get("access_token")
+    if access_token is None:
+        raise ValueError("Missing value for field 'access_token' in credentials.")
+    return {"Authorization": f"Bearer {access_token}"}
+
+def _get_auth_type(local_auth_type: str) -> str: 
+    """Returns the auth type currently in use.
+
+    The databricks-sdk client uses the configurated auth_type to create
+    a user-agent string which is used for attribution. We should only
+    overwrite the auth_type if we are using the PositCredentialsStrategy (non-local),
+    otherwise, we should return the auth_type of the configured local_strategy instead
+    to avoid breaking someone elses attribution.
+
+    https://github.com/databricks/databricks-sdk-py/blob/v0.29.0/databricks/sdk/config.py#L261-L269
+
+    NOTE: The databricks-sql client does not use auth_type to set the user-agent.
+    https://github.com/databricks/databricks-sql-python/blob/v3.3.0/src/databricks/sql/client.py#L214-L219
+    
+    Returns
+    -------
+        str
+    """
+    if is_local():
+        return local_auth_type
+
+    return POSIT_OAUTH_INTEGRATION_AUTH_TYPE 
+
+
 
 class PositContentCredentialsProvider:
+    """CredentialsProvider implementation which initiates a credential exchange using a content-session-token."""
+
     def __init__(self, client: Client):
         self._client = client
 
     def __call__(self) -> Dict[str, str]:
         credentials = self._client.oauth.get_content_credentials()
-        access_token = credentials.get("access_token")
-        if access_token is None:
-            raise ValueError("Missing value for field 'access_token' in credentials.")
-        return {"Authorization": f"Bearer {access_token}"}
+        return _new_bearer_authorization_header(credentials)
 
-class PositContentCredentialsStrategy:
+
+class PositCredentialsProvider:
+    """CredentialsProvider implementation which initiates a credential exchange using a user-session-token."""
+
+    def __init__(self, client: Client, user_session_token: str):
+        self._client = client
+        self._user_session_token = user_session_token
+
+    def __call__(self) -> Dict[str, str]:
+        credentials = self._client.oauth.get_credentials(self._user_session_token)
+        return _new_bearer_authorization_header(credentials)
+
+
+class PositContentCredentialsStrategy(CredentialsStrategy):
+    """CredentialsStrategy implementation which returns a PositContentCredentialsProvider when called."""
+
     def __init__(
         self,
         local_strategy: CredentialsStrategy,
@@ -51,15 +107,22 @@ class PositContentCredentialsStrategy:
         self._client = client
 
     def sql_credentials_provider(self, *args, **kwargs):
+        """The sql connector attempts to call the credentials provider w/o any args.
+
+        The SQL client's `ExternalAuthProvider` is not compatible w/ the SDK's implementation of
+        `CredentialsProvider`, so create a no-arg lambda that wraps the args defined by the real caller.
+        This way we can pass in a databricks `Config` object required by most of the SDK's `CredentialsProvider`
+        implementations from where `sql.connect` is called.
+
+        https://github.com/databricks/databricks-sql-python/issues/148#issuecomment-2271561365
+        """
         return lambda: self.__call__(*args, **kwargs)
 
     def auth_type(self) -> str:
-        if is_local():
-            return self._local_strategy.auth_type()
-        else:
-            return "posit-oauth-integration"
+        return _get_auth_type(self._local_strategy.auth_type())
 
     def __call__(self, *args, **kwargs) -> CredentialsProvider:
+        # If the content is not running on Connect then fall back to local_strategy
         if is_local():
             return self._local_strategy(*args, **kwargs)
 
@@ -69,20 +132,9 @@ class PositContentCredentialsStrategy:
         return PositContentCredentialsProvider(self._client)
 
 
-class PositCredentialsProvider:
-    def __init__(self, client: Client, user_session_token: str):
-        self._client = client
-        self._user_session_token = user_session_token
-
-    def __call__(self) -> Dict[str, str]:
-        credentials = self._client.oauth.get_credentials(self._user_session_token)
-        access_token = credentials.get("access_token")
-        if access_token is None:
-            raise ValueError("Missing value for field 'access_token' in credentials.")
-        return {"Authorization": f"Bearer {access_token}"}
-
-
 class PositCredentialsStrategy(CredentialsStrategy):
+    """CredentialsStrategy implementation which returns a PositContentCredentialsProvider when called."""
+
     def __init__(
         self,
         local_strategy: CredentialsStrategy,
@@ -106,23 +158,7 @@ class PositCredentialsStrategy(CredentialsStrategy):
         return lambda: self.__call__(*args, **kwargs)
 
     def auth_type(self) -> str:
-        """Returns the auth type currently in use.
-
-        The databricks-sdk client uses the configurated auth_type to create
-        a user-agent string which is used for attribution. We should only
-        overwrite the auth_type if we are using the PositCredentialsStrategy (non-local),
-        otherwise, we should return the auth_type of the configured local_strategy instead
-        to avoid breaking someone elses attribution.
-
-        https://github.com/databricks/databricks-sdk-py/blob/v0.29.0/databricks/sdk/config.py#L261-L269
-
-        NOTE: The databricks-sql client does not use auth_type to set the user-agent.
-        https://github.com/databricks/databricks-sql-python/blob/v3.3.0/src/databricks/sql/client.py#L214-L219
-        """
-        if is_local():
-            return self._local_strategy.auth_type()
-        else:
-            return "posit-oauth-integration"
+        return _get_auth_type(self._local_strategy.auth_type())
 
     def __call__(self, *args, **kwargs) -> CredentialsProvider:
         # If the content is not running on Connect then fall back to local_strategy

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -155,7 +155,7 @@ class PositCredentialsProvider:
         return _new_bearer_authorization_header(credentials)
 
 class PositLocalContentCredentialsStrategy(CredentialsStrategy):
-    """`CredentialsStrategy` implementation which supports local development using OAuth M2M authentication against databricks.
+    """`CredentialsStrategy` implementation which supports local development using OAuth M2M authentication against Databricks.
 
     There is an open issue against the Databricks CLI which prevents it from returning service principal access tokens. 
     https://github.com/databricks/cli/issues/1939
@@ -165,14 +165,12 @@ class PositLocalContentCredentialsStrategy(CredentialsStrategy):
 
     Examples
     --------
-    In the example below, the PositContentCredentialsStrategy can be initialized anywhere that 
+    In the example below, the `PositContentCredentialsStrategy` can be initialized anywhere that 
     the Python process can read environment variables.
 
-    CLIENT_ID and CLIENT_SECRET credentials associated with the Databricks Service Principal.
+    CLIENT_ID and CLIENT_SECRET are credentials associated with the Databricks service principal.
 
     ```python
-    import os
-
     from posit.connect.external.databricks import PositContentCredentialsStrategy, PositLocalContentCredentialsStrategy
 
     import pandas as pd
@@ -189,7 +187,7 @@ class PositLocalContentCredentialsStrategy(CredentialsStrategy):
     CLIENT_SECRET = "<REDACTED>" 
 
     # Rather than relying on the Databricks CLI as a local strategy, we use 
-    # PositLocalContentCredentialsStragtegy as a drop-in replacement.
+    # PositLocalContentCredentialsStrategy as a drop-in replacement.
     # Can be replaced with the Databricks CLI implementation when 
     # https://github.com/databricks/cli/issues/1939 is resolved.
     local_strategy = PositLocalContentCredentialsStrategy(
@@ -249,7 +247,7 @@ class PositContentCredentialsStrategy(CredentialsStrategy):
 
     Examples
     --------
-    NOTE: in the example below, the PositContentCredentialsStrategy can be initialized anywhere that 
+    NOTE: in the example below, the `PositContentCredentialsStrategy` can be initialized anywhere that 
     the Python process can read environment variables.
 
     ```python
@@ -264,7 +262,13 @@ class PositContentCredentialsStrategy(CredentialsStrategy):
     DATABRICKS_HOST_URL = f"https://{DATABRICKS_HOST}"
     SQL_HTTP_PATH = "<REDACTED>"
 
-    # reads `CONNECT_CONTENT_SESSION_TOKEN` environment variable if hosted on Connect 
+    # NOTE: currently the databricks_cli local strategy only supports auth code OAuth flows.
+    # https://github.com/databricks/cli/issues/1939
+    #
+    # This means that the databricks_cli supports local development using the developer's 
+    # databricks credentials, but not the credentials for a service principal. 
+    # To fallback to service principal credentials in local development, use 
+    # `PositLocalContentCredentialsStrategy` as a drop-in replacement.
     posit_strategy = PositContentCredentialsStrategy(local_strategy=databricks_cli)
 
     cfg = Config(host=DATABRICKS_HOST_URL, credentials_strategy=posit_strategy)

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -97,6 +97,8 @@ class PositLocalContentCredentialsProvider:
                 "scope": "all-apis",
             },
         )
+        response.raise_for_status()
+
         credentials = Credentials(**response.json())
         return _new_bearer_authorization_header(credentials)
 

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -125,7 +125,6 @@ class PositContentCredentialsStrategy(CredentialsStrategy):
 
     Examples
     --------
-
     NOTE: in the example below, the PositContentCredentialsStrategy can be initialized anywhere that 
     the Python process can read environment variables.
 
@@ -204,7 +203,6 @@ class PositCredentialsStrategy(CredentialsStrategy):
 
     Examples
     --------
-    
     NOTE: In the example below, the PositCredentialsProvider *must* be initialized within the context of the 
     shiny `server` function, which provides access to the HTTP session headers.
 

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -152,7 +152,6 @@ class PositLocalContentCredentialsStrategy(CredentialsStrategy):
         return POSIT_LOCAL_CLIENT_CREDENTIALS_AUTH_TYPE 
 
     def __call__(self, *args, **kwargs) -> CredentialsProvider:
-
         return PositLocalContentCredentialsProvider(
             self._token_endpoint_url, 
             self._client_id, 

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -50,7 +50,7 @@ def _new_bearer_authorization_header(credentials: Credentials) -> Dict[str, str]
 def _get_auth_type(local_auth_type: str) -> str: 
     """Returns the auth type currently in use.
 
-    The databricks-sdk client uses the configurated auth_type to create
+    The databricks-sdk client uses the configured auth_type to create
     a user-agent string which is used for attribution. We should only
     overwrite the auth_type if we are using the PositCredentialsStrategy (non-local),
     otherwise, we should return the auth_type of the configured local_strategy instead

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -15,11 +15,14 @@ POSIT_OAUTH_INTEGRATION_AUTH_TYPE = "posit-oauth-integration"
 # The Databricks SDK CredentialsProvider == Databricks SQL HeaderFactory
 CredentialsProvider = Callable[[], Dict[str, str]]
 
+
 class CredentialsStrategy(abc.ABC):
     """Maintain compatibility with the Databricks SQL/SDK client libraries.
 
-    https://github.com/databricks/databricks-sql-python/blob/v3.3.0/src/databricks/sql/auth/authenticators.py#L19-L33
-    https://github.com/databricks/databricks-sdk-py/blob/v0.29.0/databricks/sdk/credentials_provider.py#L44-L54
+    See Also
+    --------
+    * https://github.com/databricks/databricks-sql-python/blob/v3.3.0/src/databricks/sql/auth/authenticators.py#L19-L33
+    * https://github.com/databricks/databricks-sdk-py/blob/v0.29.0/databricks/sdk/credentials_provider.py#L44-L54
     """
 
     @abc.abstractmethod
@@ -47,7 +50,8 @@ def _new_bearer_authorization_header(credentials: Credentials) -> Dict[str, str]
         raise ValueError("Missing value for field 'access_token' in credentials.")
     return {"Authorization": f"Bearer {access_token}"}
 
-def _get_auth_type(local_auth_type: str) -> str: 
+
+def _get_auth_type(local_auth_type: str) -> str:
     """Returns the auth type currently in use.
 
     The databricks-sdk client uses the configured auth_type to create
@@ -62,7 +66,7 @@ def _get_auth_type(local_auth_type: str) -> str:
     See Also
     --------
     * https://github.com/databricks/databricks-sdk-py/blob/v0.29.0/databricks/sdk/config.py#L261-L269
-    
+
     Returns
     -------
         str
@@ -70,8 +74,7 @@ def _get_auth_type(local_auth_type: str) -> str:
     if is_local():
         return local_auth_type
 
-    return POSIT_OAUTH_INTEGRATION_AUTH_TYPE 
-
+    return POSIT_OAUTH_INTEGRATION_AUTH_TYPE
 
 
 class PositContentCredentialsProvider:
@@ -117,7 +120,7 @@ class PositCredentialsProvider:
 class PositContentCredentialsStrategy(CredentialsStrategy):
     """`CredentialsStrategy` implementation which supports interacting with Service Account OAuth integrations on Connect.
 
-    This strategy callable class returns a `PositContentCredentialsProvider` when hosted on Connect, and 
+    This strategy callable class returns a `PositContentCredentialsProvider` when hosted on Connect, and
     its `local_strategy` strategy otherwise.
 
     Examples
@@ -130,7 +133,6 @@ class PositContentCredentialsStrategy(CredentialsStrategy):
     from posit.connect.external.databricks import PositContentCredentialsStrategy
 
     import pandas as pd
-    
     from databricks import sql
     from databricks.sdk.core import ApiClient, Config, databricks_cli
     from databricks.sdk.service.iam import CurrentUserAPI
@@ -197,7 +199,7 @@ class PositContentCredentialsStrategy(CredentialsStrategy):
 class PositCredentialsStrategy(CredentialsStrategy):
     """`CredentialsStrategy` implementation which supports interacting with Viewer OAuth integrations on Connect.
 
-    This strategy callable class returns a `PositCredentialsProvider` when hosted on Connect, and 
+    This strategy callable class returns a `PositCredentialsProvider` when hosted on Connect, and
     its `local_strategy` strategy otherwise.
 
     Examples
@@ -221,6 +223,7 @@ class PositCredentialsStrategy(CredentialsStrategy):
     SQL_HTTP_PATH = "<REDACTED>"
 
     app_ui = ui.page_fluid(ui.output_text("text"), ui.output_data_frame("result"))
+
 
     def server(i: Inputs, o: Outputs, session: Session):
 
@@ -250,7 +253,8 @@ class PositCredentialsStrategy(CredentialsStrategy):
         def text():
             databricks_user_info = CurrentUserAPI(ApiClient(cfg)).me()
             return f"Hello, {databricks_user_info.display_name}!"
-    
+
+
     app = App(app_ui, server)
     ```
     """

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -78,7 +78,7 @@ def _get_auth_type(local_auth_type: str) -> str:
 
 
 class PositContentCredentialsProvider:
-    """CredentialsProvider implementation which initiates a credential exchange using a content-session-token.
+    """`CredentialsProvider` implementation which initiates a credential exchange using a content-session-token.
 
     The content-session-token is provided by Connect through the environment variable `CONNECT_CONTENT_SESSION_TOKEN`.
 
@@ -97,7 +97,7 @@ class PositContentCredentialsProvider:
 
 
 class PositCredentialsProvider:
-    """CredentialsProvider implementation which initiates a credential exchange using a user-session-token.
+    """`CredentialsProvider` implementation which initiates a credential exchange using a user-session-token.
     
     The user-session-token is provided by Connect through the HTTP session header 
     `Posit-Connect-User-Session-Token`.

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -56,10 +56,12 @@ def _get_auth_type(local_auth_type: str) -> str:
     otherwise, we should return the auth_type of the configured local_strategy instead
     to avoid breaking someone elses attribution.
 
-    https://github.com/databricks/databricks-sdk-py/blob/v0.29.0/databricks/sdk/config.py#L261-L269
-
     NOTE: The databricks-sql client does not use auth_type to set the user-agent.
     https://github.com/databricks/databricks-sql-python/blob/v3.3.0/src/databricks/sql/client.py#L214-L219
+
+    See Also
+    --------
+    * https://github.com/databricks/databricks-sdk-py/blob/v0.29.0/databricks/sdk/config.py#L261-L269
     
     Returns
     -------

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -1,14 +1,16 @@
+"""
+Databricks SDK credentials implementations which support interacting with Posit OAuth integrations on Connect.
+
+NOTE: These APIs are provided as a convenience and are subject to breaking changes:
+https://github.com/databricks/databricks-sdk-py#interface-stability
+"""
+
 import abc
 from typing import Callable, Dict, Optional
 
 from ..client import Client
 from ..oauth import Credentials
 from .external import is_local
-
-"""
-NOTE: These APIs are provided as a convenience and are subject to breaking changes:
-https://github.com/databricks/databricks-sdk-py#interface-stability
-"""
 
 POSIT_OAUTH_INTEGRATION_AUTH_TYPE = "posit-oauth-integration"
 

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -153,7 +153,9 @@ class PositCredentialsStrategy(CredentialsStrategy):
         This way we can pass in a databricks `Config` object required by most of the SDK's `CredentialsProvider`
         implementations from where `sql.connect` is called.
 
-        https://github.com/databricks/databricks-sql-python/issues/148#issuecomment-2271561365
+        See Also
+        --------
+        * https://github.com/databricks/databricks-sql-python/issues/148#issuecomment-2271561365
         """
         return lambda: self.__call__(*args, **kwargs)
 

--- a/src/posit/connect/external/snowflake.py
+++ b/src/posit/connect/external/snowflake.py
@@ -1,14 +1,65 @@
+"""Snowflake SDK credentials implementations which support interacting with Posit OAuth integrations on Connect.
+
+NOTE: The APIs in this module are provided as a convenience and are subject to breaking changes.
+"""
+
 from typing import Optional
 
 from ..client import Client
 from .external import is_local
 
-"""
-NOTE: The APIs in this module are provided as a convenience and are subject to breaking changes.
-"""
-
 
 class PositAuthenticator:
+    """
+    Authenticator for Snowflake SDK which supports Posit OAuth integrations on Connect.
+
+    Examples
+    --------
+    ```python
+    import os
+
+    import pandas as pd
+    import snowflake.connector
+    import streamlit as st
+
+    from posit.connect.external.snowflake import PositAuthenticator
+
+    ACCOUNT = os.getenv("SNOWFLAKE_ACCOUNT")
+    WAREHOUSE = os.getenv("SNOWFLAKE_WAREHOUSE")
+
+    # USER is only required when running the example locally with external browser auth
+    USER = os.getenv("SNOWFLAKE_USER")
+
+    # https://docs.snowflake.com/en/user-guide/sample-data-using
+    DATABASE = os.getenv("SNOWFLAKE_DATABASE", "snowflake_sample_data")
+    SCHEMA = os.getenv("SNOWFLAKE_SCHEMA", "tpch_sf1")
+    TABLE = os.getenv("SNOWFLAKE_TABLE", "lineitem")
+
+    session_token = st.context.headers.get("Posit-Connect-User-Session-Token")
+    auth = PositAuthenticator(
+        local_authenticator="EXTERNALBROWSER", user_session_token=session_token
+    )
+
+    con = snowflake.connector.connect(
+        user=USER,
+        account=ACCOUNT,
+        warehouse=WAREHOUSE,
+        database=DATABASE,
+        schema=SCHEMA,
+        authenticator=auth.authenticator,
+        token=auth.token,
+    )
+
+    snowflake_user = con.cursor().execute("SELECT CURRENT_USER()").fetchone()
+    st.write(f"Hello, {snowflake_user[0]}!")
+
+    with st.spinner("Loading data from Snowflake..."):
+        df = pd.read_sql_query(f"SELECT * FROM {TABLE} LIMIT 10", con)
+
+    st.dataframe(df)
+    ```
+    """
+
     def __init__(
         self,
         local_authenticator: Optional[str] = None,

--- a/src/posit/connect/oauth/__init__.py
+++ b/src/posit/connect/oauth/__init__.py
@@ -1,1 +1,2 @@
+from .oauth import Credentials as Credentials
 from .oauth import OAuth as OAuth

--- a/src/posit/connect/oauth/oauth.py
+++ b/src/posit/connect/oauth/oauth.py
@@ -13,6 +13,7 @@ GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
 USER_SESSION_TOKEN_TYPE = "urn:posit:connect:user-session-token"
 CONTENT_SESSION_TOKEN_TYPE = "urn:posit:connect:content-session-token"
 
+
 def _get_content_session_token() -> str:
     """Return the content session token.
 
@@ -28,15 +29,18 @@ def _get_content_session_token() -> str:
     """
     value = os.environ.get("CONNECT_CONTENT_SESSION_TOKEN")
     if not value:
-        raise ValueError("Invalid value for 'CONNECT_CONTENT_SESSION_TOKEN': Must be a non-empty string.")
+        raise ValueError(
+            "Invalid value for 'CONNECT_CONTENT_SESSION_TOKEN': Must be a non-empty string."
+        )
     return value
+
 
 class OAuth(Resources):
     def __init__(self, params: ResourceParameters, api_key: str) -> None:
         super().__init__(params)
         self.api_key = api_key
 
-    def _get_credentials_url(self) -> str: 
+    def _get_credentials_url(self) -> str:
         return self.params.url + "v1/oauth/integrations/credentials"
 
     @property
@@ -65,10 +69,11 @@ class OAuth(Resources):
         data = {}
         data["grant_type"] = GRANT_TYPE
         data["subject_token_type"] = CONTENT_SESSION_TOKEN_TYPE
-        data["subject_token"] = content_session_token or _get_content_session_token() 
+        data["subject_token"] = content_session_token or _get_content_session_token()
 
         response = self.params.session.post(self._get_credentials_url(), data=data)
         return Credentials(**response.json())
+
 
 class Credentials(TypedDict, total=False):
     access_token: str

--- a/src/posit/connect/oauth/oauth.py
+++ b/src/posit/connect/oauth/oauth.py
@@ -36,6 +36,9 @@ class OAuth(Resources):
         super().__init__(params)
         self.api_key = api_key
 
+    def _get_credentials_url(self) -> str: 
+        return self.params.url + "v1/oauth/integrations/credentials"
+
     @property
     def integrations(self):
         return Integrations(self.params)
@@ -45,7 +48,7 @@ class OAuth(Resources):
         return Sessions(self.params)
 
     def get_credentials(self, user_session_token: Optional[str] = None) -> Credentials:
-        url = self.params.url + "v1/oauth/integrations/credentials"
+        """Perform an oauth credential exchange for a viewer's access token."""
 
         # craft a credential exchange request
         data = {}
@@ -54,19 +57,19 @@ class OAuth(Resources):
         if user_session_token:
             data["subject_token"] = user_session_token
 
-        response = self.params.session.post(url, data=data)
+        response = self.params.session.post(self._get_credentials_url(), data=data)
         return Credentials(**response.json())
 
     def get_content_credentials(self, content_session_token: Optional[str] = None) -> Credentials:
-        url = self.params.url + "v1/oauth/integrations/credentials"
-
+        """Perform an oauth credential exchange for a service account's access token."""
+        
         # craft a credential exchange request
         data = {}
         data["grant_type"] = GRANT_TYPE
         data["subject_token_type"] = CONTENT_SESSION_TOKEN_TYPE
         data["subject_token"] = content_session_token or _get_content_session_token() 
 
-        response = self.params.session.post(url, data=data)
+        response = self.params.session.post(self._get_credentials_url(), data=data)
         return Credentials(**response.json())
 
 class Credentials(TypedDict, total=False):

--- a/src/posit/connect/oauth/oauth.py
+++ b/src/posit/connect/oauth/oauth.py
@@ -48,8 +48,7 @@ class OAuth(Resources):
         return Sessions(self.params)
 
     def get_credentials(self, user_session_token: Optional[str] = None) -> Credentials:
-        """Perform an oauth credential exchange for a viewer's access token."""
-
+        """Perform an oauth credential exchange with a user-session-token."""
         # craft a credential exchange request
         data = {}
         data["grant_type"] = GRANT_TYPE
@@ -61,8 +60,7 @@ class OAuth(Resources):
         return Credentials(**response.json())
 
     def get_content_credentials(self, content_session_token: Optional[str] = None) -> Credentials:
-        """Perform an oauth credential exchange for a service account's access token."""
-        
+        """Perform an oauth credential exchange with a content-session-token."""
         # craft a credential exchange request
         data = {}
         data["grant_type"] = GRANT_TYPE

--- a/src/posit/connect/oauth/oauth.py
+++ b/src/posit/connect/oauth/oauth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import Optional
 
 from typing_extensions import TypedDict
@@ -8,6 +9,27 @@ from ..resources import ResourceParameters, Resources
 from .integrations import Integrations
 from .sessions import Sessions
 
+GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
+USER_SESSION_TOKEN_TYPE = "urn:posit:connect:user-session-token"
+CONTENT_SESSION_TOKEN_TYPE = "urn:posit:connect:content-session-token"
+
+def _get_content_session_token() -> str:
+    """Return the content session token.
+
+    Reads the environment variable 'CONNECT_CONTENT_SESSION_TOKEN'.
+
+    Raises
+    ------
+        ValueError: If CONNECT_CONTENT_SESSION_TOKEN is not set or invalid
+
+    Returns
+    -------
+        str
+    """
+    value = os.environ.get("CONNECT_CONTENT_SESSION_TOKEN")
+    if not value:
+        raise ValueError("Invalid value for 'CONNECT_CONTENT_SESSION_TOKEN': Must be a non-empty string.")
+    return value
 
 class OAuth(Resources):
     def __init__(self, params: ResourceParameters, api_key: str) -> None:
@@ -27,14 +49,25 @@ class OAuth(Resources):
 
         # craft a credential exchange request
         data = {}
-        data["grant_type"] = "urn:ietf:params:oauth:grant-type:token-exchange"
-        data["subject_token_type"] = "urn:posit:connect:user-session-token"
+        data["grant_type"] = GRANT_TYPE
+        data["subject_token_type"] = USER_SESSION_TOKEN_TYPE
         if user_session_token:
             data["subject_token"] = user_session_token
 
         response = self.params.session.post(url, data=data)
         return Credentials(**response.json())
 
+    def get_content_credentials(self, content_session_token: Optional[str] = None) -> Credentials:
+        url = self.params.url + "v1/oauth/integrations/credentials"
+
+        # craft a credential exchange request
+        data = {}
+        data["grant_type"] = GRANT_TYPE
+        data["subject_token_type"] = CONTENT_SESSION_TOKEN_TYPE
+        data["subject_token"] = content_session_token or _get_content_session_token() 
+
+        response = self.params.session.post(url, data=data)
+        return Credentials(**response.json())
 
 class Credentials(TypedDict, total=False):
     access_token: str

--- a/tests/posit/connect/external/test_databricks.py
+++ b/tests/posit/connect/external/test_databricks.py
@@ -1,5 +1,4 @@
 import base64
-
 from typing import Dict
 from unittest.mock import patch
 
@@ -72,10 +71,7 @@ def register_mocks():
     )
 
 
-
-
 class TestPositCredentialsHelpers:
-
     def test_new_bearer_authorization_header(self):
         credential = Credentials()
         credential["token_type"] = "token_type"
@@ -91,19 +87,17 @@ class TestPositCredentialsHelpers:
     def test_get_auth_type_local(self):
         assert _get_auth_type("local-auth") == "local-auth"
 
-
     @patch.dict("os.environ", {"RSTUDIO_PRODUCT": "CONNECT"})
     def test_get_auth_type_connect(self):
         assert _get_auth_type("local-auth") == POSIT_OAUTH_INTEGRATION_AUTH_TYPE
 
     @responses.activate
     def test_local_content_credentials_provider(self):
-
         token_url = "https://my-token/url"
         client_id = "client_id"
         client_secret = "client_secret_123"
         basic_auth = f"{client_id}:{client_secret}"
-        b64_basic_auth = base64.b64encode(basic_auth.encode('utf-8')).decode('utf-8')
+        b64_basic_auth = base64.b64encode(basic_auth.encode("utf-8")).decode("utf-8")
 
         responses.post(
             token_url,
@@ -114,7 +108,7 @@ class TestPositCredentialsHelpers:
                         "scope": "all-apis",
                     },
                 ),
-                responses.matchers.header_matcher({"Authorization": f"Basic {b64_basic_auth}"})
+                responses.matchers.header_matcher({"Authorization": f"Basic {b64_basic_auth}"}),
             ],
             json={
                 "access_token": "oauth2-m2m-access-token",
@@ -145,16 +139,13 @@ class TestPositCredentialsHelpers:
         cp = PositCredentialsProvider(client=client, user_session_token="cit")
         assert cp() == {"Authorization": "Bearer dynamic-viewer-access-token"}
 
-
     @responses.activate
     def test_local_content_credentials_strategy(self):
-
         token_url = "https://my-token/url"
         client_id = "client_id"
         client_secret = "client_secret_123"
         basic_auth = f"{client_id}:{client_secret}"
-        b64_basic_auth = base64.b64encode(basic_auth.encode('utf-8')).decode('utf-8')
-
+        b64_basic_auth = base64.b64encode(basic_auth.encode("utf-8")).decode("utf-8")
 
         responses.post(
             token_url,
@@ -165,7 +156,7 @@ class TestPositCredentialsHelpers:
                         "scope": "all-apis",
                     },
                 ),
-                responses.matchers.header_matcher({"Authorization": f"Basic {b64_basic_auth}"})
+                responses.matchers.header_matcher({"Authorization": f"Basic {b64_basic_auth}"}),
             ],
             json={
                 "access_token": "oauth2-m2m-access-token",
@@ -183,8 +174,6 @@ class TestPositCredentialsHelpers:
         assert cs.auth_type() == "posit-local-client-credentials"
         assert cp() == {"Authorization": "Bearer oauth2-m2m-access-token"}
 
-
-
     @patch.dict("os.environ", {"CONNECT_CONTENT_SESSION_TOKEN": "cit"})
     @responses.activate
     @patch.dict("os.environ", {"RSTUDIO_PRODUCT": "CONNECT"})
@@ -200,7 +189,6 @@ class TestPositCredentialsHelpers:
         cp = cs()
         assert cs.auth_type() == "posit-oauth-integration"
         assert cp() == {"Authorization": "Bearer content-access-token"}
-
 
     @responses.activate
     @patch.dict("os.environ", {"RSTUDIO_PRODUCT": "CONNECT"})

--- a/tests/posit/connect/external/test_databricks.py
+++ b/tests/posit/connect/external/test_databricks.py
@@ -1,15 +1,22 @@
 from typing import Dict
 from unittest.mock import patch
 
+import pytest
 import responses
 
 from posit.connect import Client
 from posit.connect.external.databricks import (
+    POSIT_OAUTH_INTEGRATION_AUTH_TYPE,
     CredentialsProvider,
     CredentialsStrategy,
+    PositContentCredentialsProvider,
+    PositContentCredentialsStrategy,
     PositCredentialsProvider,
     PositCredentialsStrategy,
+    _get_auth_type,
+    _new_bearer_authorization_header,
 )
+from posit.connect.oauth import Credentials
 
 
 class mock_strategy(CredentialsStrategy):
@@ -42,8 +49,59 @@ def register_mocks():
         },
     )
 
+    responses.post(
+        "https://connect.example/__api__/v1/oauth/integrations/credentials",
+        match=[
+            responses.matchers.urlencoded_params_matcher(
+                {
+                    "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                    "subject_token_type": "urn:posit:connect:content-session-token",
+                    "subject_token": "cit",
+                },
+            ),
+        ],
+        json={
+            "access_token": "content-access-token",
+            "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+            "token_type": "Bearer",
+        },
+    )
+
+
+
 
 class TestPositCredentialsHelpers:
+
+    def test_new_bearer_authorization_header(self):
+        credential = Credentials()
+        credential["token_type"] = "token_type"
+        credential["issued_token_type"] = "issued_token_type"
+
+        with pytest.raises(ValueError):
+            _new_bearer_authorization_header(credential)
+
+        credential["access_token"] = "access_token"
+        result = _new_bearer_authorization_header(credential)
+        assert result == {"Authorization": "Bearer access_token"}
+
+    def test_get_auth_type_local(self):
+        assert _get_auth_type("local-auth") == "local-auth"
+
+
+    @patch.dict("os.environ", {"RSTUDIO_PRODUCT": "CONNECT"})
+    def test_get_auth_type_connect(self):
+        assert _get_auth_type("local-auth") == POSIT_OAUTH_INTEGRATION_AUTH_TYPE
+
+    @patch.dict("os.environ", {"CONNECT_CONTENT_SESSION_TOKEN": "cit"})
+    @responses.activate
+    def test_posit_content_credentials_provider(self):
+        register_mocks()
+
+        client = Client(api_key="12345", url="https://connect.example/")
+        client._ctx.version = None
+        cp = PositContentCredentialsProvider(client=client)
+        assert cp() == {"Authorization": "Bearer content-access-token"}
+
     @responses.activate
     def test_posit_credentials_provider(self):
         register_mocks()
@@ -52,6 +110,23 @@ class TestPositCredentialsHelpers:
         client._ctx.version = None
         cp = PositCredentialsProvider(client=client, user_session_token="cit")
         assert cp() == {"Authorization": "Bearer dynamic-viewer-access-token"}
+
+    @patch.dict("os.environ", {"CONNECT_CONTENT_SESSION_TOKEN": "cit"})
+    @responses.activate
+    @patch.dict("os.environ", {"RSTUDIO_PRODUCT": "CONNECT"})
+    def test_posit_content_credentials_strategy(self):
+        register_mocks()
+
+        client = Client(api_key="12345", url="https://connect.example/")
+        client._ctx.version = None
+        cs = PositContentCredentialsStrategy(
+            local_strategy=mock_strategy(),
+            client=client,
+        )
+        cp = cs()
+        assert cs.auth_type() == "posit-oauth-integration"
+        assert cp() == {"Authorization": "Bearer content-access-token"}
+
 
     @responses.activate
     @patch.dict("os.environ", {"RSTUDIO_PRODUCT": "CONNECT"})
@@ -68,6 +143,17 @@ class TestPositCredentialsHelpers:
         cp = cs()
         assert cs.auth_type() == "posit-oauth-integration"
         assert cp() == {"Authorization": "Bearer dynamic-viewer-access-token"}
+
+    def test_posit_content_credentials_strategy_fallback(self):
+        # local_strategy is used when the content is running locally
+        client = Client(api_key="12345", url="https://connect.example/")
+        cs = PositContentCredentialsStrategy(
+            local_strategy=mock_strategy(),
+            client=client,
+        )
+        cp = cs()
+        assert cs.auth_type() == "local"
+        assert cp() == {"Authorization": "Bearer static-pat-token"}
 
     def test_posit_credentials_strategy_fallback(self):
         # local_strategy is used when the content is running locally

--- a/tests/posit/connect/oauth/test_oauth.py
+++ b/tests/posit/connect/oauth/test_oauth.py
@@ -1,9 +1,22 @@
+from unittest.mock import patch
+
+import pytest
 import responses
 
 from posit.connect import Client
+from posit.connect.oauth.oauth import _get_content_session_token
 
 
 class TestOAuthIntegrations:
+
+    @patch.dict("os.environ", {"CONNECT_CONTENT_SESSION_TOKEN": "cit"})
+    def test_get_content_session_token_success(self): 
+        assert _get_content_session_token() == "cit"
+
+    def test_get_content_session_token_failure(self):
+        with pytest.raises(ValueError):
+            _get_content_session_token()
+
     @responses.activate
     def test_get_credentials(self):
         responses.post(
@@ -28,3 +41,54 @@ class TestOAuthIntegrations:
         creds = c.oauth.get_credentials("cit")
         assert "access_token" in creds
         assert creds["access_token"] == "viewer-token"
+
+    @responses.activate
+    def test_get_content_credentials(self):
+        responses.post(
+            "https://connect.example/__api__/v1/oauth/integrations/credentials",
+            match=[
+                responses.matchers.urlencoded_params_matcher(
+                    {
+                        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                        "subject_token_type": "urn:posit:connect:content-session-token",
+                        "subject_token": "cit",
+                    },
+                ),
+            ],
+            json={
+                "access_token": "content-token",
+                "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+                "token_type": "Bearer",
+            },
+        )
+        c = Client(api_key="12345", url="https://connect.example/")
+        c._ctx.version = None
+        creds = c.oauth.get_content_credentials("cit")
+        assert "access_token" in creds
+        assert creds["access_token"] == "content-token"
+
+    @patch.dict("os.environ", {"CONNECT_CONTENT_SESSION_TOKEN": "cit"})
+    @responses.activate
+    def test_get_content_credentials_env_var(self):
+        responses.post(
+            "https://connect.example/__api__/v1/oauth/integrations/credentials",
+            match=[
+                responses.matchers.urlencoded_params_matcher(
+                    {
+                        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                        "subject_token_type": "urn:posit:connect:content-session-token",
+                        "subject_token": "cit",
+                    },
+                ),
+            ],
+            json={
+                "access_token": "content-token",
+                "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+                "token_type": "Bearer",
+            },
+        )
+        c = Client(api_key="12345", url="https://connect.example/")
+        c._ctx.version = None
+        creds = c.oauth.get_content_credentials()
+        assert "access_token" in creds
+        assert creds["access_token"] == "content-token"

--- a/tests/posit/connect/oauth/test_oauth.py
+++ b/tests/posit/connect/oauth/test_oauth.py
@@ -8,9 +8,8 @@ from posit.connect.oauth.oauth import _get_content_session_token
 
 
 class TestOAuthIntegrations:
-
     @patch.dict("os.environ", {"CONNECT_CONTENT_SESSION_TOKEN": "cit"})
-    def test_get_content_session_token_success(self): 
+    def test_get_content_session_token_success(self):
         assert _get_content_session_token() == "cit"
 
     def test_get_content_session_token_failure(self):


### PR DESCRIPTION
This PR adds a new function to the oauth tooling. It knows how to craft a request against the credential exchange endpoint that can interface with client credential flows. This supports service-account-like oauth interactions. 

Connect sets an environment variable called `CONNECT_CONTENT_SESSION_TOKEN` which can be used by the executing content when making the request. This means that the syntax for using this new credential exchange function is slightly different. 

This PR also adds the databricks extensions needed to use this new oauth exchange flow when interfacing with databricks resources. 

This feature won't land in Connect until the upcoming release gets published - I don't know how we typically queue up work like this in sync with product releases. 