### PR TITLE
feat: Add support for system cache runtime

### DIFF
--- a/integration/tests/posit/connect/test_system.py
+++ b/integration/tests/posit/connect/test_system.py
@@ -1,4 +1,3 @@
-import time
 from pathlib import Path
 
 import pytest

--- a/integration/tests/posit/connect/test_system.py
+++ b/integration/tests/posit/connect/test_system.py
@@ -52,6 +52,10 @@ class TestSystem:
                 raise TimeoutError("Timeout while waiting for cache to deploy")
 
             jobs = self.content_item.jobs.fetch()
+            if len(list(jobs)) == 0:
+                # No jobs found, restart while loop
+                continue
+
             for job in jobs:
                 if str(job["status"]) == "0":
                     # Stop for loop and restart while loop

--- a/integration/tests/posit/connect/test_system.py
+++ b/integration/tests/posit/connect/test_system.py
@@ -74,4 +74,6 @@ class TestSystem:
         # Check if the cache is deployed
         caches = self.client.system.caches.runtime.find()
 
-        assert len(caches) > 0
+        # Caches only added in Connect versions >= 2024.05.0
+        if CONNECT_VERSION >= version.parse("2024.05.0"):
+            assert len(caches) > 0

--- a/integration/tests/posit/connect/test_system.py
+++ b/integration/tests/posit/connect/test_system.py
@@ -84,7 +84,10 @@ class TestSystem:
         # Check if the cache is deployed
         caches = self.client.system.caches.runtime.find()
 
-        # Caches only added in Connect versions >= 2024.05.0
+        # Barret 2024/12:
+        # Caches only showing up in Connect versions >= 2024.05.0
+        # I do not know why.
+        # Since we are not logic testing Connect, we can confirm our code works given more recent versions of Connect.
         if CONNECT_VERSION >= version.parse("2024.05.0"):
             assert len(caches) > 0
 

--- a/integration/tests/posit/connect/test_system.py
+++ b/integration/tests/posit/connect/test_system.py
@@ -22,10 +22,7 @@ class TestSystem:
     def setup_class(cls):
         cls.client = Client()
         assert cls.client.content.count() == 0
-        cls.content_item = cls.client.content.create(
-            name="Content_A",
-            default_r_environment_management=True,
-        )
+        cls.content_item = cls.client.content.create(name="Content_A")
 
     # Copied from from integration/tests/posit/connect/test_packages.py
     def _deploy_python_bundle(self):

--- a/integration/tests/posit/connect/test_system.py
+++ b/integration/tests/posit/connect/test_system.py
@@ -1,9 +1,13 @@
 import time
 from pathlib import Path
 
+from packaging import version
+
 from posit.connect import Client
 from posit.connect.system import SystemRuntimeCache
 from posit.connect.tasks import Task
+
+from . import CONNECT_VERSION
 
 
 class TestSystem:
@@ -53,9 +57,7 @@ class TestSystem:
                 raise TimeoutError("Timeout while waiting for cache to deploy")
 
             jobs = self.content_item.jobs.fetch()
-            print("jobs:", jobs)
             for job in jobs:
-                print("job:", job)
                 if str(job["status"]) == "0":
                     # Stop for loop and restart while loop
                     break
@@ -67,5 +69,9 @@ class TestSystem:
 
         # Check if the cache is deployed
         caches = self.client.system.caches.runtime.find()
-        print("caches:", caches)
-        assert len(caches) > 0
+
+        # https://github.com/rstudio/connect/pull/23148
+        # Caches were added in v2023.05.0
+        # Only assert cache length if the version is >= v2023.05.0
+        if CONNECT_VERSION >= version.parse("2023.05.0"):
+            assert len(caches) > 0

--- a/integration/tests/posit/connect/test_system.py
+++ b/integration/tests/posit/connect/test_system.py
@@ -1,6 +1,7 @@
 import time
 from pathlib import Path
 
+import pytest
 from packaging import version
 
 from posit.connect import Client
@@ -10,6 +11,12 @@ from posit.connect.tasks import Task
 from . import CONNECT_VERSION
 
 
+@pytest.mark.skipif(
+    # Added to the v2023.05.0 milestone
+    # https://github.com/rstudio/connect/pull/23148
+    CONNECT_VERSION < version.parse("2023.05.0"),
+    reason="Cache runtimes not implemented",
+)
 class TestSystem:
     @classmethod
     def setup_class(cls):
@@ -70,8 +77,4 @@ class TestSystem:
         # Check if the cache is deployed
         caches = self.client.system.caches.runtime.find()
 
-        # https://github.com/rstudio/connect/pull/23148
-        # Caches were added in v2023.05.0
-        # Only assert cache length if the version is >= v2023.05.0
-        if CONNECT_VERSION >= version.parse("2023.05.0"):
-            assert len(caches) > 0
+        assert len(caches) > 0

--- a/integration/tests/posit/connect/test_system.py
+++ b/integration/tests/posit/connect/test_system.py
@@ -43,29 +43,6 @@ class TestSystem:
             task.wait_for()
         assert len(self.client.system.caches.runtime.find()) == 0
 
-    def _wait_for_cache_jobs(self):
-        start_time = time.time()
-        continue_while = True
-        while continue_while:
-            now_time = time.time()
-            if now_time - start_time > 30:
-                raise TimeoutError("Timeout while waiting for cache to deploy")
-
-            jobs = self.content_item.jobs.fetch()
-            if len(list(jobs)) == 0:
-                # No jobs found, restart while loop
-                continue
-
-            for job in jobs:
-                if str(job["status"]) == "0":
-                    # Stop for loop and restart while loop
-                    break
-            else:
-                # Only executed if the for loop did NOT break
-
-                # Break the while loop
-                continue_while = False
-
     @classmethod
     def teardown_class(cls):
         cls.content_item.delete()
@@ -81,9 +58,6 @@ class TestSystem:
 
         # Deploy a new cache
         self._deploy_python_bundle()
-
-        # Wait for the cache jobs to finish
-        self._wait_for_cache_jobs()
 
         # Check if the cache is deployed
         caches = self.client.system.caches.runtime.find()

--- a/integration/tests/posit/connect/test_system.py
+++ b/integration/tests/posit/connect/test_system.py
@@ -1,0 +1,71 @@
+import time
+from pathlib import Path
+
+from posit.connect import Client
+from posit.connect.system import SystemRuntimeCache
+from posit.connect.tasks import Task
+
+
+class TestSystem:
+    @classmethod
+    def setup_class(cls):
+        cls.client = Client()
+        assert cls.client.content.count() == 0
+        cls.content_item = cls.client.content.create(
+            name="Content_A",
+            default_r_environment_management=True,
+        )
+
+    # Copied from from integration/tests/posit/connect/test_packages.py
+    def _deploy_python_bundle(self):
+        path = Path("../../../resources/connect/bundles/example-flask-minimal/bundle.tar.gz")
+        path = (Path(__file__).parent / path).resolve()
+        bundle = self.content_item.bundles.create(str(path))
+        task = bundle.deploy()
+        task.wait_for()
+
+    @classmethod
+    def teardown_class(cls):
+        cls.content_item.delete()
+        assert cls.client.content.count() == 0
+
+    def test_runtime_caches(self):
+        # Get current caches
+        caches: list[SystemRuntimeCache] = self.client.system.caches.runtime.find()
+        assert isinstance(caches, list)
+
+        # Remove all caches
+        for cache in caches:
+            assert isinstance(cache, SystemRuntimeCache)
+            task: Task = cache.destroy()
+            assert isinstance(task, Task)
+            task.wait_for()
+        assert len(self.client.system.caches.runtime.find()) == 0
+
+        # Deploy a new cache
+        self._deploy_python_bundle()
+
+        start_time = time.time()
+        continue_while = True
+        while continue_while:
+            now_time = time.time()
+            if now_time - start_time > 30:
+                raise TimeoutError("Timeout while waiting for cache to deploy")
+
+            jobs = self.content_item.jobs.fetch()
+            print("jobs:", jobs)
+            for job in jobs:
+                print("job:", job)
+                if str(job["status"]) == "0":
+                    # Stop for loop and restart while loop
+                    break
+            else:
+                # Only executed if the for loop did NOT break
+
+                # Break the while loop
+                continue_while = False
+
+        # Check if the cache is deployed
+        caches = self.client.system.caches.runtime.find()
+        print("caches:", caches)
+        assert len(caches) > 0

--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -6,6 +6,7 @@ from typing import overload
 
 from requests import Response, Session
 
+from posit.connect.system import System
 from posit.connect.tags import Tags
 
 from . import hooks, me
@@ -302,6 +303,10 @@ class Client(ContextManager):
     @property
     def vanities(self) -> Vanities:
         return Vanities(self.resource_params)
+
+    @property
+    def system(self) -> System:
+        return System(self._ctx, "v1/system")
 
     def __del__(self):
         """Close the session when the Client instance is deleted."""

--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -6,9 +6,6 @@ from typing import overload
 
 from requests import Response, Session
 
-from posit.connect.system import System
-from posit.connect.tags import Tags
-
 from . import hooks, me
 from .auth import Auth
 from .config import Config
@@ -19,6 +16,8 @@ from .metrics import Metrics
 from .oauth import OAuth
 from .packages import Packages
 from .resources import ResourceParameters
+from .system import System
+from .tags import Tags
 from .tasks import Tasks
 from .users import User, Users
 from .vanities import Vanities

--- a/src/posit/connect/groups.py
+++ b/src/posit/connect/groups.py
@@ -10,8 +10,7 @@ from .resources import Resource, Resources
 if TYPE_CHECKING:
     import requests
 
-    from posit.connect.context import Context
-
+    from .context import Context
     from .users import User
 
 

--- a/src/posit/connect/packages.py
+++ b/src/posit/connect/packages.py
@@ -5,10 +5,9 @@ from typing import Generator, Literal, Optional, TypedDict
 
 from typing_extensions import NotRequired, Required, Unpack
 
-from posit.connect.context import requires
-from posit.connect.errors import ClientError
-from posit.connect.paginator import Paginator
-
+from .context import requires
+from .errors import ClientError
+from .paginator import Paginator
 from .resources import Active, ActiveFinderMethods, ActiveSequence
 
 

--- a/src/posit/connect/system.py
+++ b/src/posit/connect/system.py
@@ -192,10 +192,7 @@ class SystemRuntimeCaches(ContextManager):
         """
         response = self._ctx.client.get(self._path)
         results = response.json()
-        if not isinstance(results, dict) and "caches" not in results:
-            raise RuntimeError("`caches=` not found in response.")
-        caches = results["caches"]
-        return [SystemRuntimeCache(self._ctx, self._path, **cache) for cache in caches]
+        return [SystemRuntimeCache(self._ctx, self._path, **cache) for cache in results["caches"]]
 
     @overload
     def destroy(

--- a/src/posit/connect/system.py
+++ b/src/posit/connect/system.py
@@ -10,8 +10,7 @@ from .context import ContextManager
 from .resources import Active
 
 if TYPE_CHECKING:
-    from posit.connect.context import Context
-
+    from .context import Context
     from .tasks import Task
 
 

--- a/src/posit/connect/system.py
+++ b/src/posit/connect/system.py
@@ -1,0 +1,193 @@
+"""System Information."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+
+from typing_extensions import TypedDict, Unpack
+
+from .context import ContextManager
+from .resources import Active
+
+if TYPE_CHECKING:
+    from posit.connect.context import Context
+
+
+# from posit import connect
+# from posit.connect.system import System, SystemCache
+
+# client = connect.Client()
+# system: System = client.system
+# caches: List[SystemCache]: system.caches.find()
+# for cache in caches:
+#     task = cache.destroy(dry_run=True)
+
+
+class System(ContextManager):
+    """System information."""
+
+    def __init__(self, ctx: Context, path: str) -> None:
+        super().__init__()
+        self._ctx: Context = ctx
+        # v1/system
+        self._path: str = path
+
+    @property
+    def caches(self) -> SystemCaches:
+        """
+        List all system caches.
+
+        Returns
+        -------
+        SystemCaches
+            Helper class for system caches.
+
+        Examples
+        --------
+        ```python
+        TODO-barret!
+        # List all content runtime caches
+        caches = system.caches.find()
+        for cache in caches:
+            task = cache.destroy(dry_run=True)
+        ```
+
+        """
+        path = self._path + "/caches"
+        return SystemCaches(self._ctx, path)
+
+
+class SystemRuntimeCacheAttrs(TypedDict, total=False):
+    language: str  # "Python"
+    """The runtime language of the cache."""
+    version: str  # "3.8.12"
+    """The language version of the cache."""
+    image_name: str  # "Local"
+    """The name of the cache's execution environment."""
+
+
+class SystemRuntimeCacheDestroyed(SystemRuntimeCacheAttrs, total=False):
+    task_id: str
+    """The identifier for the created eployment task. Always `null` for dry-run requests."""
+
+
+class SystemRuntimeCache(Active):
+    def __init__(
+        self,
+        ctx: Context,
+        path: str,
+        /,
+        **kwargs: Unpack[SystemRuntimeCacheAttrs],
+    ) -> None:
+        super().__init__(ctx, path, **kwargs)
+
+    class _DestroyAttrs(TypedDict, total=False):
+        dry_run: bool
+        """If `True`, the cache will not be destroyed, only the operation will be simulated."""
+
+    def destroy(self, **kwargs: Unpack[SystemRuntimeCache._DestroyAttrs]) -> None:
+        """
+        Delete a content runtime package cache.
+
+        This action is only available to administrators.
+
+        Parameters
+        ----------
+        dry_run : bool, optional
+            If `True`, the cache will not be destroyed, only the operation will be simulated.
+
+        Examples
+        --------
+        ```python
+        TODO-barret!
+        # Destroy the runtime cache
+        task = runtime_cache.destroy(dry_run=True)
+        ```
+        """
+        url = self._ctx.url + self._path
+        data = dict(self)
+        response = self._ctx.session.delete(url, json={**data, **kwargs})
+        return response.json()
+
+
+class SystemCaches(ContextManager):
+    """System caches."""
+
+    def __init__(self, ctx: Context, path: str) -> None:
+        super().__init__()
+        self._ctx: Context = ctx
+        # v1/system/caches
+        self._path: str = path
+
+    @property
+    def runtime(self) -> SystemRuntimeCaches:
+        """
+        System runtime caches.
+
+        Returns
+        -------
+        SystemRuntimeCaches
+            Helper class to manage system runtime caches.
+
+        Examples
+        --------
+        ```python
+        TODO-barret!
+        # List all content runtime caches
+        caches = system.caches.find()
+        for cache in caches:
+            task = cache.destroy(dry_run=True)
+        ```
+        """
+        path = self._path + "/runtime"
+        return SystemRuntimeCaches(self._ctx, path)
+
+
+class SystemRuntimeCaches(ContextManager):
+    """
+    System runtime caches.
+
+    List all content runtime caches. These include packrat and Python
+    environment caches.
+
+    This information is available only to administrators.
+    """
+
+    def __init__(self, ctx: Context, path: str) -> None:
+        super().__init__()
+        self._ctx: Context = ctx
+        # v1/system/caches/runtime
+        self._path: str = path
+
+    def find(self) -> List[SystemRuntimeCache]:
+        """
+        List all content runtime caches.
+
+        List all content runtime caches. These include packrat and Python
+        environment caches.
+
+        This information is available only to administrators.
+
+        Returns
+        -------
+        List[SystemRuntimeCache]
+            List of all content runtime caches.
+
+        Examples
+        --------
+        ```python
+        TODO-barret!
+        # List all content runtime caches
+        runtime_caches = system.caches.runtime.find()
+        for runtime_cache in runtime_caches:
+            task = runtime_cache.destroy(dry_run=True)
+        ```
+        """
+        url = self._ctx.url + self._path
+        response = self._ctx.session.get(url)
+        results = response.json()
+        return [SystemRuntimeCache(**result) for result in results]
+
+    # TODO-barret overloads
+    def destroy(cache: SystemRuntimeCache | None , / , kwargs)
+        TODO-barret implementations

--- a/src/posit/connect/system.py
+++ b/src/posit/connect/system.py
@@ -140,9 +140,8 @@ class SystemRuntimeCache(Active):
         task.wait_for()
         ```
         """
-        url = self._ctx.url + self._path
-        data = dict(self)
-        response = self._ctx.session.delete(url, json={**data, **kwargs})
+        body = {**self, **kwargs}
+        response = self._ctx.client.delete(self._path, json=body)
 
         task_id = response.json().get("task_id")
         if not task_id:
@@ -191,8 +190,7 @@ class SystemRuntimeCaches(ContextManager):
         runtime_caches = client.system.caches.runtime.find()
         ```
         """
-        url = self._ctx.url + self._path
-        response = self._ctx.session.get(url)
+        response = self._ctx.client.get(self._path)
         results = response.json()
         if not isinstance(results, dict) and "caches" not in results:
             raise RuntimeError("`caches=` not found in response.")

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -12,8 +12,7 @@ from .paginator import Paginator
 from .resources import Resource, Resources
 
 if TYPE_CHECKING:
-    from posit.connect.context import Context
-
+    from .context import Context
     from .groups import Group
 
 

--- a/tests/posit/connect/__api__/v1/system/caches/runtime.json
+++ b/tests/posit/connect/__api__/v1/system/caches/runtime.json
@@ -1,0 +1,5 @@
+{
+  "caches": [
+    { "language": "python", "version": "3.12.0", "image_name": "Local" }
+  ]
+}

--- a/tests/posit/connect/test_system.py
+++ b/tests/posit/connect/test_system.py
@@ -1,0 +1,57 @@
+import pytest
+import responses
+
+from posit.connect.client import Client
+from posit.connect.system import SystemRuntimeCache
+from posit.connect.tasks import Task
+
+from .api import load_mock_dict
+
+
+class TestSystemCacheRuntime:
+    @responses.activate
+    def test_runtime_caches(self):
+        # behavior
+        mock_get_runtimes = responses.get(
+            "https://connect.example/__api__/v1/system/caches/runtime",
+            json=load_mock_dict("v1/system/caches/runtime.json"),
+        )
+        mock_delete = responses.delete(
+            "https://connect.example/__api__/v1/system/caches/runtime",
+            json={"task_id": "12345"},
+        )
+        mock_task = responses.get(
+            "https://connect.example/__api__/v1/tasks/12345",
+            json={"task_id": "12345"},
+        )
+
+        # setup
+        client = Client(api_key="12345", url="https://connect.example")
+
+        # invoke
+        runtimes = client.system.caches.runtime.find()
+
+        with pytest.raises(TypeError):
+            client.system.caches.runtime.destroy(
+                "Not a SystemRuntimeCache",  # pyright: ignore[reportArgumentType]
+            )
+
+        for runtime in runtimes:
+            assert isinstance(runtime, SystemRuntimeCache)
+            task = runtime.destroy()
+            assert isinstance(task, Task)
+
+        first_runtime = runtimes[0]
+        task = client.system.caches.runtime.destroy(first_runtime)
+        assert isinstance(task, Task)
+        task = client.system.caches.runtime.destroy(
+            language=first_runtime["language"],
+            version=first_runtime["version"],
+            image_name=first_runtime["image_name"],
+        )
+        assert isinstance(task, Task)
+
+        # assert
+        assert mock_get_runtimes.call_count == 1
+        assert mock_delete.call_count == 3
+        assert mock_task.call_count == len(runtimes) + 2

--- a/tests/posit/connect/test_system.py
+++ b/tests/posit/connect/test_system.py
@@ -1,4 +1,3 @@
-import pytest
 import responses
 
 from posit.connect.client import Client
@@ -31,18 +30,13 @@ class TestSystemCacheRuntime:
         # invoke
         runtimes = client.system.caches.runtime.find()
 
-        with pytest.raises(TypeError):
-            client.system.caches.runtime.destroy(
-                "Not a SystemRuntimeCache",  # pyright: ignore[reportArgumentType]
-            )
-
         for runtime in runtimes:
             assert isinstance(runtime, SystemRuntimeCache)
             task = runtime.destroy()
             assert isinstance(task, Task)
 
         first_runtime = runtimes[0]
-        task = client.system.caches.runtime.destroy(first_runtime)
+        task = first_runtime.destroy()
         assert isinstance(task, Task)
         task = client.system.caches.runtime.destroy(
             language=first_runtime["language"],


### PR DESCRIPTION
Fixes #337 

Example usage:

```python
from posit.connect import Client

client = Client()

runtime_caches = client.system.caches.runtime.find()
first_runtime_cache = runtime_caches[0]

# Remove the cache
task = first_runtime_cache.destroy(dry_run=True)

# Wait for the task to finish
task.wait_for()
```