### PR TITLE
feat: add environments

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,9 @@
 # This file contains the configuration settings for the coverage report generated.
 
 [report]
-# exclude '...' (ellipsis literal). This option uses regex, so an escaped literal is required.
 exclude_also =
     \.\.\.
+exclude_lines =
+    if TYPE_CHECKING:
 
 fail_under = 80

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -140,5 +140,5 @@ test:
 	set -o pipefail; \
 		CONNECT_VERSION=${CONNECT_VERSION} \
 		CONNECT_API_KEY="$(shell $(UV) run rsconnect bootstrap -i -s http://connect:3939 --raw)" \
-		$(UV) run pytest -s --junit-xml=./reports/$(CONNECT_VERSION).xml | \
+		$(UV) run pytest -s -k Environments --junit-xml=./reports/$(CONNECT_VERSION).xml | \
 		tee ./logs/$(CONNECT_VERSION).log;

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -140,5 +140,5 @@ test:
 	set -o pipefail; \
 		CONNECT_VERSION=${CONNECT_VERSION} \
 		CONNECT_API_KEY="$(shell $(UV) run rsconnect bootstrap -i -s http://connect:3939 --raw)" \
-		$(UV) run pytest -s -k Environments --junit-xml=./reports/$(CONNECT_VERSION).xml | \
+		$(UV) run pytest -s --junit-xml=./reports/$(CONNECT_VERSION).xml | \
 		tee ./logs/$(CONNECT_VERSION).log;

--- a/integration/tests/posit/connect/test_environments.py
+++ b/integration/tests/posit/connect/test_environments.py
@@ -1,0 +1,42 @@
+import pytest
+from packaging import version
+
+from posit import connect
+
+from . import CONNECT_VERSION
+
+
+@pytest.mark.skipif(
+    CONNECT_VERSION < version.parse("2023.05.0"),
+    reason="Environments API unavailable",
+)
+class TestEnvironments:
+    @classmethod
+    def setup_class(cls):
+        cls.client = connect.Client()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def test(self):
+        environment = self.client.environments.create(
+            title="original-title", name="test", cluster_name="Kubernetes"
+        )
+
+        assert environment["title"] == "original-title"
+
+        assert len(self.client.environments.reload()) == 1
+
+        environment.update(title="new-title")
+        assert environment["title"] == "new-title"
+
+        environment = self.client.environments.find_by(title="new-title")
+        assert environment
+        assert environment["title"] == "new-title"
+
+        environment.destroy()
+        environment = self.client.environments.find_by(title="new-title")
+        assert environment is None
+
+        assert len(self.client.environments.reload()) == 0

--- a/integration/tests/posit/connect/test_environments.py
+++ b/integration/tests/posit/connect/test_environments.py
@@ -14,29 +14,25 @@ class TestEnvironments:
     @classmethod
     def setup_class(cls):
         cls.client = connect.Client()
+        cls.environment = cls.client.environments.create(
+            title="title", name="name", cluster_name="Kubernetes"
+        )
 
     @classmethod
     def teardown_class(cls):
-        pass
+        cls.environment.destroy()
+        assert len(cls.client.environments.reload()) == 0
 
-    def test(self):
-        environment = self.client.environments.create(
-            title="original-title", name="test", cluster_name="Kubernetes"
-        )
+    def test_find(self):
+        uid = self.environment["guid"]
+        environment = self.client.environments.find(uid)
+        assert environment == self.environment
 
-        assert environment["title"] == "original-title"
+    def test_find_by(self):
+        environment = self.client.environments.find_by(name="name")
+        assert environment == self.environment
 
-        assert len(self.client.environments.reload()) == 1
-
-        environment.update(title="new-title")
-        assert environment["title"] == "new-title"
-
-        environment = self.client.environments.find_by(title="new-title")
-        assert environment
-        assert environment["title"] == "new-title"
-
-        environment.destroy()
-        environment = self.client.environments.find_by(title="new-title")
-        assert environment is None
-
-        assert len(self.client.environments.reload()) == 0
+    def test_update(self):
+        assert self.environment["title"] == "title"
+        self.environment.update(title="new-title")
+        assert self.environment["title"] == "new-title"

--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -6,6 +6,7 @@ from typing import overload
 
 from requests import Response, Session
 
+from posit.connect.environments import Environments
 from posit.connect.tags import Tags
 
 from . import hooks, me
@@ -302,6 +303,11 @@ class Client(ContextManager):
     @property
     def vanities(self) -> Vanities:
         return Vanities(self.resource_params)
+
+    @property
+    @requires(version="2023.05.0")
+    def environments(self) -> Environments:
+        return Environments(self._ctx, "v1/environments")
 
     def __del__(self):
         """Close the session when the Client instance is deleted."""

--- a/src/posit/connect/environments.py
+++ b/src/posit/connect/environments.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, TypedDict
-
-from typing_extensions import NotRequired, Required, Unpack
+from typing import TYPE_CHECKING, List, Literal, TypedDict, overload
 
 from .resources import (
     Active,
@@ -17,73 +15,169 @@ if TYPE_CHECKING:
     from .context import Context
 
 
+class _Installation(TypedDict):
+    """Interpreter installation in an execution environment."""
+
+    path: str
+    """The absolute path to the interpreter's executable."""
+
+    version: str
+    """The semantic version of the interpreter."""
+
+
+class _Installations(TypedDict):
+    """Interpreter installations in an execution environment."""
+
+    installations: List[_Installation]
+    """Interpreter installations in an execution environment."""
+
+
 class Environment(ActiveUpdater, ActiveDestroyer, Active):
-    class _Installation(TypedDict):
-        """Represents an interpreter installation in an execution environment."""
+    @overload
+    def __init__(
+        self,
+        ctx: Context,
+        path: str,
+        /,
+        *,
+        id: str,
+        guid: str,
+        created_time: str,
+        updated_time: str,
+        title: str,
+        name: str,
+        description: str | None,
+        cluster_name: str | Literal["Kubernetes"],
+        environment_type: str | Literal["Kubernetes"],
+        matching: Literal["any", "exact", "none"],
+        supervisor: str | None,
+        python: _Installations | None,
+        quarto: _Installations | None,
+        r: _Installations | None,
+        tensorflow: _Installations | None,
+    ):
+        """Initialize an environment.
 
-        path: Required[str]
-        """The absolute path to the interpreter's executable."""
+        Parameters
+        ----------
+        ctx : Context
+            The SDK context.
+        path : str
+            The URL endpoint path.
+        id : str
+            The numerical identifier.
+        guid : str
+            The unique identifier.
+        created_time : str
+            The timestamp (RFC3339) when the environment was created.
+        updated_time : str
+            The timestamp (RFC3339) when the environment was updated.
+        title : str
+            A human-readable title.
+        name : str
+            The container image name used for execution in this environment.
+        description : str, optional
+            A human-readable description.
+        cluster_name : str | Literal["Kubernetes"]
+            The cluster identifier for this environment. Defaults to "Kubernetes" when Off-Host-Execution is enabled.
+        environment_type : str | Literal["Kubernetes"]
+            The cluster environment type. Defaults to "Kubernetes" when Off-Host-Execution is enabled.
+        matching : Literal["any", "exact", "none"]
+            Directions for how environments are considered for selection.
+            any: The image may be selected by Connect if not defined in the bundle manifest.
+            exact: The image must be defined in the bundle manifest
+            none: Never use this environment
+        supervisor : str, optional
+            Path to the supervisor script
+        python : _Installations, optional
+            The Python installations available in this environment
+        quarto : _Installations, optional
+            The Quarto installations available in this environment
+        r : _Installations, optional
+            The R installations available in this environment
+        tensorflow : _Installations, optional
+            The Tensorflow installations available in this environment
+        """
 
-        version: Required[str]
-        """The semantic version of the interpreter."""
+    @overload
+    def __init__(self, ctx: Context, path: str, /, **attributes): ...
 
-    class _Environment(TypedDict):
-        # Identifiers
-        id: Required[str]
-        """The internal numeric identifier of this environment."""
-
-        guid: Required[str]
-        """The unique identifier of this environment to be used with REST API requests."""
-
-        # Timestamps
-        created_time: Required[str]
-        """The timestamp (RFC3339) indicating when this environment was created."""
-
-        updated_time: Required[str]
-        """The timestamp (RFC3339) indicating when this environment was last updated."""
-
-        # Descriptive Information
-        title: NotRequired[str]
-        """A human-readable title for this environment."""
-
-        description: Required[Optional[str]]
-        """A human-readable description of this environment. Defaults to null."""
-
-        # Cluster Information
-        cluster_name: Required[str]
-        """The cluster identifier for this environment. Always 'Kubernetes' when Off Host Execution is enabled."""
-
-        # Execution Details
-        name: Required[str]
-        """The container image used when executing content with this environment."""
-
-        environment_type: Required[str]
-        """The type of environment. Always 'Kubernetes' when Off Host Execution is enabled."""
-
-        matching: Required[Literal["any", "exact", "none"]]
-        """How environments are considered for selection:
-        - any: Default. The image can be automatically selected by Connect or targeted in the bundle's manifest.
-        - exact: The image must be explicitly asked for in the bundle's manifest.
-        - none: The image should never be selected by Posit Connect."""
-
-        supervisor: Required[Optional[str]]
-        """The path to the script or command used as the program supervisor when executing content with this environment. Defaults to null."""
-
-        # Installations
-        python: Required[Optional[Dict[str, List[Environment._Installation]]]]
-        """Available Python installations in this environment."""
-
-        quarto: Optional[Dict[str, List[Environment._Installation]]]
-        """Available Quarto installations in this environment."""
-
-        r: Optional[Dict[str, List[Environment._Installation]]]
-        """Available R installations in this environment."""
-
-        tensorflow: Optional[Dict[str, List["Environment._Installation"]]]
-        """Available TensorFlow installations in this environment."""
-
-    def __init__(self, ctx: Context, path: str, /, **attributes: Unpack[_Environment]):
+    def __init__(self, ctx: Context, path: str, /, **attributes):
         super().__init__(ctx, path, **attributes)
+
+    def destroy(self):
+        """Destroy the environment.
+
+        Warnings
+        --------
+        This operation is irreversible.
+
+        Note
+        ----
+        This action requires administrator privileges.
+        """
+        return super().destroy()
+
+    @overload
+    def update(
+        self,
+        /,
+        *,
+        title: str,
+        description: str | None = ...,
+        matching: Literal["any", "exact", "none"] = ...,
+        supervisor: str | None = ...,
+        python: _Installations | None = ...,
+        quarto: _Installations | None = ...,
+        r: _Installations | None = ...,
+        tensorflow: _Installations | None = ...,
+    ) -> None:
+        """Update the environment.
+
+        Parameters
+        ----------
+        title : str
+            A human-readable title.
+        description : str | None, optional, not required
+            A human-readable description.
+        matching : Literal["any", "exact", "none"], optional, not required
+            Directions for how environments are considered for selection.
+            any: The image may be selected by Connect if not defined in the bundle manifest.
+            exact: The image must be defined in the bundle manifest
+            none: Never use this environment
+        supervisor : str | None, optional, not required
+            Path to the supervisor script.
+        python : _Installations | None, optional, not required
+            The Python installations available in this environment
+        quarto : _Installations | None, optional, not required
+            The Quarto installations available in this environment
+        r : _Installations | None, optional, not required
+            The Python installations available in this environment
+        tensorflow : _Installations | None, optional, not required
+            The Python installations available in this environment
+
+        Note
+        ----
+        This action requires administrator privileges.
+        """
+
+    @overload
+    def update(self, /, **attributes) -> None:
+        """Update the environment.
+
+        Note
+        ----
+        This action requires administrator privileges.
+        """
+
+    def update(self, /, **attributes) -> None:
+        """Update the environment.
+
+        Note
+        ----
+        This action requires administrator privileges.
+        """
+        return super().update(**attributes)
 
 
 class Environments(
@@ -93,3 +187,195 @@ class Environments(
 ):
     def _create_instance(self, path, /, **attributes) -> Environment:
         return Environment(self._ctx, path, **attributes)
+
+    @overload
+    def create(
+        self,
+        /,
+        *,
+        title: str,
+        name: str,
+        cluster_name: str | Literal["Kubernetes"],
+        description: str | None = ...,
+        matching: Literal["any", "exact", "none"] = "any",
+        supervisor: str | None = ...,
+        python: _Installations | None = ...,
+        quarto: _Installations | None = ...,
+        r: _Installations | None = ...,
+        tensorflow: _Installations | None = ...,
+    ) -> Environment:
+        """Create an environment.
+
+        Parameters
+        ----------
+        title : str
+            A human-readable title.
+        name : str
+            The container image name used for execution in this environment.
+        cluster_name : str | Literal["Kubernetes"]
+            The cluster identifier for this environment. Defaults to "Kubernetes" when Off-Host-Execution is enabled.
+        description : str, optional
+            A human-readable description.
+        matching : Literal["any", "exact", "none"]
+            Directions for how environments are considered for selection.
+            any: The image may be selected by Connect if not defined in the bundle manifest.
+            exact: The image must be defined in the bundle manifest
+            none: Never use this environment
+        supervisor : str, optional
+            Path to the supervisor script
+        python : _Installations, optional
+            The Python installations available in this environment
+        quarto : _Installations, optional
+            The Quarto installations available in this environment
+        r : _Installations, optional
+            The R installations available in this environment
+        tensorflow : _Installations, optional
+            The Tensorflow installations available in this environment
+
+        Returns
+        -------
+        Environment
+
+        Note
+        ----
+        This action requires administrator privileges.
+        """
+
+    @overload
+    def create(self, **attributes) -> Environment:
+        """Create an environment.
+
+        Returns
+        -------
+        Environment
+
+        Note
+        ----
+        This action requires administrator privileges.
+        """
+
+    def create(self, **attributes) -> Environment:
+        """Create an environment.
+
+        Returns
+        -------
+        Environment
+
+        Note
+        ----
+        This action requires administrator privileges.
+        """
+        return super().create(**attributes)
+
+    def find(self, uid: str) -> Environment:
+        """Find a record by its unique identifier.
+
+        Parameters
+        ----------
+        uid : str
+            The unique identifier.
+
+        Returns
+        -------
+        Environment
+        """
+        return super().find(uid)
+
+    @overload
+    def find_by(
+        self,
+        *,
+        id: str,
+        guid: str,
+        created_time: str,
+        updated_time: str,
+        title: str,
+        name: str,
+        description: str | None,
+        cluster_name: str | Literal["Kubernetes"],
+        environment_type: str | Literal["Kubernetes"],
+        matching: Literal["any", "exact", "none"],
+        supervisor: str | None,
+        python: _Installations | None,
+        quarto: _Installations | None,
+        r: _Installations | None,
+        tensorflow: _Installations | None,
+    ) -> Environment | None:
+        """Find the first record matching the specified conditions.
+
+        There is no implied ordering, so if order matters, you should specify it yourself.
+
+        Parameters
+        ----------
+        id : str
+            The numerical identifier.
+        guid : str
+            The unique identifier.
+        created_time : str
+            The timestamp (RFC3339) when the environment was created.
+        updated_time : str
+            The timestamp (RFC3339) when the environment was updated.
+        title : str
+            A human-readable title.
+        name : str
+            The container image name used for execution in this environment.
+        description : str, optional
+            A human-readable description.
+        cluster_name : str | Literal["Kubernetes"]
+            The cluster identifier for this environment. Defaults to "Kubernetes" when Off-Host-Execution is enabled.
+        environment_type : str | Literal["Kubernetes"]
+            The cluster environment type. Defaults to "Kubernetes" when Off-Host-Execution is enabled.
+        matching : Literal["any", "exact", "none"]
+            Directions for how environments are considered for selection.
+            any: The image may be selected by Connect if not defined in the bundle manifest.
+            exact: The image must be defined in the bundle manifest
+            none: Never use this environment
+        supervisor : str, optional
+            Path to the supervisor script
+        python : _Installations, optional
+            The Python installations available in this environment
+        quarto : _Installations, optional
+            The Quarto installations available in this environment
+        r : _Installations, optional
+            The R installations available in this environment
+        tensorflow : _Installations, optional
+            The Tensorflow installations available in this environment
+
+        Returns
+        -------
+        Environment | None
+
+        Note
+        ----
+        This action requires administrator or publisher privileges.
+        """
+
+    @overload
+    def find_by(self, **conditions) -> Environment | None:
+        """Find the first record matching the specified conditions.
+
+        There is no implied ordering, so if order matters, you should specify it yourself.
+
+        Returns
+        -------
+        Environment | None
+
+        Note
+        ----
+        This action requires administrator or publisher privileges.
+        """
+
+    def find_by(self, **conditions) -> Environment | None:
+        """Find the first record matching the specified conditions.
+
+        There is no implied ordering, so if order matters, you should specify it yourself.
+
+        Returns
+        -------
+        Environment | None
+
+        Note
+        ----
+        This action requires administrator or publisher privileges.
+        """
+        return super().find_by(**conditions)

--- a/src/posit/connect/environments.py
+++ b/src/posit/connect/environments.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, TypedDict
+
+from typing_extensions import NotRequired, Required, Unpack
+
+from .resources import (
+    Active,
+    ActiveDestroyer,
+    ActiveFinderMethods,
+    ActiveSequence,
+    ActiveSequenceCreator,
+    ActiveUpdater,
+)
+
+if TYPE_CHECKING:
+    from .context import Context
+
+
+class Environment(ActiveUpdater, ActiveDestroyer, Active):
+    class _Installation(TypedDict):
+        """Represents an interpreter installation in an execution environment."""
+
+        path: Required[str]
+        """The absolute path to the interpreter's executable."""
+
+        version: Required[str]
+        """The semantic version of the interpreter."""
+
+    class _Environment(TypedDict):
+        # Identifiers
+        id: Required[str]
+        """The internal numeric identifier of this environment."""
+
+        guid: Required[str]
+        """The unique identifier of this environment to be used with REST API requests."""
+
+        # Timestamps
+        created_time: Required[str]
+        """The timestamp (RFC3339) indicating when this environment was created."""
+
+        updated_time: Required[str]
+        """The timestamp (RFC3339) indicating when this environment was last updated."""
+
+        # Descriptive Information
+        title: NotRequired[str]
+        """A human-readable title for this environment."""
+
+        description: Required[Optional[str]]
+        """A human-readable description of this environment. Defaults to null."""
+
+        # Cluster Information
+        cluster_name: Required[str]
+        """The cluster identifier for this environment. Always 'Kubernetes' when Off Host Execution is enabled."""
+
+        # Execution Details
+        name: Required[str]
+        """The container image used when executing content with this environment."""
+
+        environment_type: Required[str]
+        """The type of environment. Always 'Kubernetes' when Off Host Execution is enabled."""
+
+        matching: Required[Literal["any", "exact", "none"]]
+        """How environments are considered for selection:
+        - any: Default. The image can be automatically selected by Connect or targeted in the bundle's manifest.
+        - exact: The image must be explicitly asked for in the bundle's manifest.
+        - none: The image should never be selected by Posit Connect."""
+
+        supervisor: Required[Optional[str]]
+        """The path to the script or command used as the program supervisor when executing content with this environment. Defaults to null."""
+
+        # Installations
+        python: Required[Optional[Dict[str, List[Environment._Installation]]]]
+        """Available Python installations in this environment."""
+
+        quarto: Optional[Dict[str, List[Environment._Installation]]]
+        """Available Quarto installations in this environment."""
+
+        r: Optional[Dict[str, List[Environment._Installation]]]
+        """Available R installations in this environment."""
+
+        tensorflow: Optional[Dict[str, List["Environment._Installation"]]]
+        """Available TensorFlow installations in this environment."""
+
+    def __init__(self, ctx: Context, path: str, /, **attributes: Unpack[_Environment]):
+        super().__init__(ctx, path, **attributes)
+
+
+class Environments(
+    ActiveFinderMethods[Environment],
+    ActiveSequenceCreator[Environment],
+    ActiveSequence[Environment],
+):
+    def _create_instance(self, path, /, **attributes) -> Environment:
+        return Environment(self._ctx, path, **attributes)

--- a/src/posit/connect/resources.py
+++ b/src/posit/connect/resources.py
@@ -95,7 +95,7 @@ class ActiveDestroyer(Active, ABC):
 
 
 class ActiveUpdater(Active, ABC):
-    def update(self, /, **attributes):
+    def update(self, /, **attributes: Any):
         endpoint = self._ctx.url + self._path
         response = self._ctx.session.put(endpoint, json=attributes)
         result = response.json()

--- a/src/posit/connect/resources.py
+++ b/src/posit/connect/resources.py
@@ -88,6 +88,20 @@ class Active(ABC, Resource):
         self._path = path
 
 
+class ActiveDestroyer(Active, ABC):
+    def destroy(self):
+        endpoint = self._ctx.url + self._path
+        self._ctx.session.delete(endpoint)
+
+
+class ActiveUpdater(Active, ABC):
+    def update(self, /, **attributes):
+        endpoint = self._ctx.url + self._path
+        response = self._ctx.session.put(endpoint, json=attributes)
+        result = response.json()
+        super().update(**result)
+
+
 T = TypeVar("T", bound="Active")
 """A type variable that is bound to the `Active` class"""
 
@@ -234,3 +248,12 @@ class ActiveFinderMethods(ActiveSequence[T]):
         """
         collection = self.fetch(**conditions)
         return next((v for v in collection if v.items() >= conditions.items()), None)
+
+
+class ActiveSequenceCreator(ActiveSequence[T], ABC):
+    def create(self, **attributes) -> T:
+        endpoint = self._ctx.url + self._path
+        response = self._ctx.session.post(endpoint, json=attributes)
+        result = response.json()
+        print(result)
+        return self._to_instance(result)

--- a/src/posit/connect/resources.py
+++ b/src/posit/connect/resources.py
@@ -255,5 +255,4 @@ class ActiveSequenceCreator(ActiveSequence[T], ABC):
         endpoint = self._ctx.url + self._path
         response = self._ctx.session.post(endpoint, json=attributes)
         result = response.json()
-        print(result)
         return self._to_instance(result)

--- a/tests/posit/connect/__api__/v1/environments.json
+++ b/tests/posit/connect/__api__/v1/environments.json
@@ -1,0 +1,20 @@
+[
+    {
+        "id": "314",
+        "guid": "25438b83-ea6d-4839-ae8e-53c52ac5f9ce",
+        "created_time": "2006-01-02T15:04:05-07:00",
+        "updated_time": "2006-01-02T15:04:05-07:00",
+        "title": "Project Alpha (R 4.1.1, Python 3.10)",
+        "description": "This is my description of the environment",
+        "cluster_name": "Kubernetes",
+        "name": "ghcr.io/rstudio/content-base:r4.1.3-py3.10.4-ubuntu1804",
+        "environment_type": "Kubernetes",
+        "matching": "any",
+        "supervisor": "/usr/local/bin/supervisor.sh",
+        "python": null,
+        "quarto": null,
+        "r": null,
+        "tensorflow": null
+    }
+
+]

--- a/tests/posit/connect/__api__/v1/environments/25438b83-ea6d-4839-ae8e-53c52ac5f9ce.json
+++ b/tests/posit/connect/__api__/v1/environments/25438b83-ea6d-4839-ae8e-53c52ac5f9ce.json
@@ -1,0 +1,17 @@
+{
+    "id": "314",
+    "guid": "25438b83-ea6d-4839-ae8e-53c52ac5f9ce",
+    "created_time": "2006-01-02T15:04:05-07:00",
+    "updated_time": "2006-01-02T15:04:05-07:00",
+    "title": "Project Alpha (R 4.1.1, Python 3.10)",
+    "description": "This is my description of the environment",
+    "cluster_name": "Kubernetes",
+    "name": "ghcr.io/rstudio/content-base:r4.1.3-py3.10.4-ubuntu1804",
+    "environment_type": "Kubernetes",
+    "matching": "any",
+    "supervisor": "/usr/local/bin/supervisor.sh",
+    "python": null,
+    "quarto": null,
+    "r": null,
+    "tensorflow": null
+}

--- a/tests/posit/connect/test_environments.py
+++ b/tests/posit/connect/test_environments.py
@@ -1,0 +1,101 @@
+import responses
+
+from posit.connect.client import Client
+
+from .api import load_mock
+
+
+class TestEnvironmentsFind:
+    @responses.activate
+    def test(self):
+        responses.get(
+            "https://connect.example/__api__/v1/environments/25438b83-ea6d-4839-ae8e-53c52ac5f9ce",
+            json=load_mock(
+                "v1/environments/25438b83-ea6d-4839-ae8e-53c52ac5f9ce.json",
+            ),
+        )
+        c = Client("https://connect.example", "12345")
+        c._ctx.version = None
+        environment = c.environments.find("25438b83-ea6d-4839-ae8e-53c52ac5f9ce")
+        assert environment["id"] == "314"
+
+
+class TestEnvironmentsFindBy:
+    @responses.activate
+    def test(self):
+        responses.get(
+            "https://connect.example/__api__/v1/environments",
+            json=load_mock(
+                "v1/environments.json",
+            ),
+        )
+        c = Client("https://connect.example", "12345")
+        c._ctx.version = None
+        environment = c.environments.find_by(id="314")
+        assert environment
+        assert environment["id"] == "314"
+
+
+class TestEnvironmentsCreate:
+    @responses.activate
+    def test(self):
+        responses.post(
+            "https://connect.example/__api__/v1/environments",
+            json=load_mock(
+                "v1/environments/25438b83-ea6d-4839-ae8e-53c52ac5f9ce.json",
+            ),
+        )
+        c = Client("https://connect.example", "12345")
+        c._ctx.version = None
+        environment = c.environments.create(title="Project Alpha (R 4.1.1, Python 3.10)")
+        assert environment
+        assert environment["id"] == "314"
+
+
+class TestEnvironmentDestroy:
+    @responses.activate
+    def test(self):
+        responses.get(
+            "https://connect.example/__api__/v1/environments/25438b83-ea6d-4839-ae8e-53c52ac5f9ce",
+            json=load_mock(
+                "v1/environments/25438b83-ea6d-4839-ae8e-53c52ac5f9ce.json",
+            ),
+        )
+
+        mock_delete = responses.delete(
+            "https://connect.example/__api__/v1/environments/25438b83-ea6d-4839-ae8e-53c52ac5f9ce",
+        )
+
+        c = Client("https://connect.example", "12345")
+        c._ctx.version = None
+        environment = c.environments.find("25438b83-ea6d-4839-ae8e-53c52ac5f9ce")
+        assert environment["id"] == "314"
+
+        environment.destroy()
+        assert mock_delete.call_count == 1
+
+
+class TestEnvironmentUpdate:
+    @responses.activate
+    def test(self):
+        responses.get(
+            "https://connect.example/__api__/v1/environments/25438b83-ea6d-4839-ae8e-53c52ac5f9ce",
+            json=load_mock(
+                "v1/environments/25438b83-ea6d-4839-ae8e-53c52ac5f9ce.json",
+            ),
+        )
+
+        mock_put = responses.put(
+            "https://connect.example/__api__/v1/environments/25438b83-ea6d-4839-ae8e-53c52ac5f9ce",
+            json=load_mock(
+                "v1/environments/25438b83-ea6d-4839-ae8e-53c52ac5f9ce.json",
+            ),
+        )
+
+        c = Client("https://connect.example", "12345")
+        c._ctx.version = None
+        environment = c.environments.find("25438b83-ea6d-4839-ae8e-53c52ac5f9ce")
+        assert environment["id"] == "314"
+
+        environment.update(title="test")
+        assert mock_put.call_count == 1


### PR DESCRIPTION
Adds environment support.

The create, update, and destroy methods are abstracted in the resources module as base classes. This alleviates potential duplication across API bindings. Future changes should utilize these classes instead of reimplementing these methods from scratch.

Closes #307 