### PR TITLE
refactor: remove usage of ResourceParaeters, ctx.url, and ctx.session

### DIFF
--- a/src/posit/connect/_api_call.py
+++ b/src/posit/connect/_api_call.py
@@ -19,13 +19,13 @@ class ApiCallProtocol(Protocol):
     def _put_api(self, *path, json: Jsonifiable | None) -> Jsonifiable: ...
 
 
-def endpoint(ctx: Context, *path) -> str:
-    return ctx.url + posixpath.join(*path)
+def endpoint(*path) -> str:
+    return posixpath.join(*path)
 
 
 # Helper methods for API interactions
 def get_api(ctx: Context, *path) -> Jsonifiable:
-    response = ctx.session.get(endpoint(ctx, *path))
+    response = ctx.client.get(*path)
     return response.json()
 
 
@@ -34,7 +34,7 @@ def put_api(
     *path,
     json: Jsonifiable | None,
 ) -> Jsonifiable:
-    response = ctx.session.put(endpoint(ctx, *path), json=json)
+    response = ctx.client.put(*path, json=json)
     return response.json()
 
 
@@ -43,14 +43,14 @@ def put_api(
 
 class ApiCallMixin:
     def _endpoint(self: ApiCallProtocol, *path) -> str:
-        return endpoint(self._ctx, self._path, *path)
+        return endpoint(self._path, *path)
 
     def _get_api(self: ApiCallProtocol, *path) -> Jsonifiable:
-        response = self._ctx.session.get(self._endpoint(*path))
+        response = self._ctx.client.get(self._endpoint(*path))
         return response.json()
 
     def _delete_api(self: ApiCallProtocol, *path) -> Jsonifiable | None:
-        response = self._ctx.session.delete(self._endpoint(*path))
+        response = self._ctx.client.delete(self._endpoint(*path))
         if len(response.content) == 0:
             return None
         return response.json()
@@ -60,7 +60,7 @@ class ApiCallMixin:
         *path,
         json: Jsonifiable | None,
     ) -> Jsonifiable:
-        response = self._ctx.session.patch(self._endpoint(*path), json=json)
+        response = self._ctx.client.patch(self._endpoint(*path), json=json)
         return response.json()
 
     def _put_api(
@@ -68,5 +68,5 @@ class ApiCallMixin:
         *path,
         json: Jsonifiable | None,
     ) -> Jsonifiable:
-        response = self._ctx.session.put(self._endpoint(*path), json=json)
+        response = self._ctx.client.put(self._endpoint(*path), json=json)
         return response.json()

--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -14,7 +14,7 @@ from .context import Context, ContextManager, requires
 from .groups import Groups
 from .metrics import Metrics
 from .oauth import OAuth
-from .resources import ResourceParameters, _PaginatedResourceSequence, _ResourceSequence
+from .resources import _PaginatedResourceSequence, _ResourceSequence
 from .tags import Tags
 from .tasks import Tasks
 from .users import User, Users
@@ -159,7 +159,6 @@ class Client(ContextManager):
         session.hooks["response"].append(hooks.check_for_deprecation_header)
         session.hooks["response"].append(hooks.handle_errors)
         self.session = session
-        self.resource_params = ResourceParameters(session, self.cfg.url)
         self._ctx = Context(self)
 
     @property
@@ -207,7 +206,7 @@ class Client(ContextManager):
         tasks.Tasks
             The tasks resource instance.
         """
-        return Tasks(self.resource_params)
+        return Tasks(self._ctx)
 
     @property
     def users(self) -> Users:
@@ -281,7 +280,7 @@ class Client(ContextManager):
         >>> len(events)
         24
         """
-        return Metrics(self.resource_params)
+        return Metrics(self._ctx)
 
     @property
     @requires(version="2024.08.0")
@@ -294,7 +293,7 @@ class Client(ContextManager):
         OAuth
             The oauth API instance.
         """
-        return OAuth(self.resource_params, self.cfg.api_key)
+        return OAuth(self._ctx, self.cfg.api_key)
 
     @property
     @requires(version="2024.11.0")
@@ -303,7 +302,7 @@ class Client(ContextManager):
 
     @property
     def vanities(self) -> Vanities:
-        return Vanities(self.resource_params)
+        return Vanities(self._ctx)
 
     @property
     @requires(version="2023.05.0")

--- a/src/posit/connect/context.py
+++ b/src/posit/connect/context.py
@@ -7,10 +7,7 @@ from typing import TYPE_CHECKING, Protocol
 from packaging.version import Version
 
 if TYPE_CHECKING:
-    import requests
-
     from .client import Client
-    from .urls import Url
 
 
 def requires(version: str):
@@ -31,8 +28,6 @@ def requires(version: str):
 
 class Context:
     def __init__(self, client: Client):
-        self.session: requests.Session = client.session
-        self.url: Url = client.cfg.url
         # Since this is a child object of the client, we use a weak reference to avoid circular
         # references (which would prevent garbage collection)
         self.client: Client = weakref.proxy(client)
@@ -40,8 +35,7 @@ class Context:
     @property
     def version(self) -> str | None:
         if not hasattr(self, "_version"):
-            endpoint = self.url + "server_settings"
-            response = self.session.get(endpoint)
+            response = self.client.get("server_settings")
             result = response.json()
             self._version: str | None = result.get("version")
 

--- a/src/posit/connect/cursors.py
+++ b/src/posit/connect/cursors.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generator, List
 
 if TYPE_CHECKING:
-    import requests
+    from .context import Context
 
 # The maximum page size supported by the API.
 _MAX_PAGE_SIZE = 500
@@ -19,15 +19,16 @@ class CursorPage:
 class CursorPaginator:
     def __init__(
         self,
-        session: requests.Session,
-        url: str,
+        ctx: Context,
+        path: str,
         params: dict[str, Any] | None = None,
     ) -> None:
         if params is None:
             params = {}
-        self.session = session
-        self.url = url
-        self.params = params
+
+        self._ctx = ctx
+        self._path = path
+        self._params = params
 
     def fetch_results(self) -> List[dict]:
         """Fetch results.
@@ -74,9 +75,9 @@ class CursorPaginator:
         Page
         """
         params = {
-            **self.params,
+            **self._params,
             "next": next_page,
             "limit": _MAX_PAGE_SIZE,
         }
-        response = self.session.get(self.url, params=params)
+        response = self._ctx.client.get(self._path, params=params)
         return CursorPage(**response.json())

--- a/src/posit/connect/env.py
+++ b/src/posit/connect/env.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-from typing import Any, Iterator, List, Mapping, MutableMapping, Optional
+from typing import TYPE_CHECKING, Any, Iterator, List, Mapping, MutableMapping, Optional
 
-from .resources import ResourceParameters, Resources
+from .resources import Resources
+
+if TYPE_CHECKING:
+    from .context import Context
 
 
 class EnvVars(Resources, MutableMapping[str, Optional[str]]):
-    def __init__(self, params: ResourceParameters, content_guid: str) -> None:
-        super().__init__(params)
+    def __init__(self, ctx: Context, content_guid: str) -> None:
+        super().__init__(ctx)
         self.content_guid = content_guid
 
     def __delitem__(self, key: str, /) -> None:
@@ -63,8 +66,7 @@ class EnvVars(Resources, MutableMapping[str, Optional[str]]):
         >>> clear()
         """
         path = f"v1/content/{self.content_guid}/environment"
-        url = self.params.url + path
-        self.params.session.put(url, json=[])
+        self._ctx.client.put(path, json=[])
 
     def create(self, key: str, value: str, /) -> None:
         """Create an environment variable.
@@ -121,8 +123,7 @@ class EnvVars(Resources, MutableMapping[str, Optional[str]]):
         ['DATABASE_URL']
         """
         path = f"v1/content/{self.content_guid}/environment"
-        url = self.params.url + path
-        response = self.params.session.get(url)
+        response = self._ctx.client.get(path)
         return response.json()
 
     def items(self):
@@ -194,5 +195,4 @@ class EnvVars(Resources, MutableMapping[str, Optional[str]]):
 
         body = [{"name": key, "value": value} for key, value in d.items()]
         path = f"v1/content/{self.content_guid}/environment"
-        url = self.params.url + path
-        self.params.session.patch(url, json=body)
+        self._ctx.client.patch(path, json=body)

--- a/src/posit/connect/groups.py
+++ b/src/posit/connect/groups.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 class Group(Resource):
     def __init__(self, ctx: Context, **kwargs) -> None:
-        super().__init__(ctx.client.resource_params, **kwargs)
+        super().__init__(ctx, **kwargs)
         self._ctx: Context = ctx
 
     @property
@@ -67,9 +67,8 @@ class Group(Resource):
 
 class GroupMembers(Resources):
     def __init__(self, ctx: Context, group_guid: str) -> None:
-        super().__init__(ctx.client.resource_params)
+        super().__init__(ctx)
         self._group_guid = group_guid
-        self._ctx: Context = ctx
 
     @overload
     def add(self, user: User, /) -> None: ...
@@ -261,10 +260,6 @@ class GroupMembers(Resources):
 class Groups(Resources):
     """Groups resource."""
 
-    def __init__(self, ctx: Context) -> None:
-        super().__init__(ctx.client.resource_params)
-        self._ctx: Context = ctx
-
     @overload
     def create(self, *, name: str, unique_id: str | None) -> Group:
         """Create a group.
@@ -416,7 +411,6 @@ class Groups(Resources):
         * https://docs.posit.co/connect/api/#get-/v1/groups
         """
         path = "v1/groups"
-        url = self._ctx.url + path
-        response: requests.Response = self._ctx.session.get(url, params={"page_size": 1})
+        response: requests.Response = self._ctx.client.get(path, params={"page_size": 1})
         result: dict = response.json()
         return result["total"]

--- a/src/posit/connect/me.py
+++ b/src/posit/connect/me.py
@@ -14,6 +14,6 @@ def get(ctx: Context) -> User:
     -------
         User: The current user.
     """
-    url = ctx.url + "v1/user"
-    response = ctx.session.get(url)
+    path = "v1/user"
+    response = ctx.client.get(path)
     return User(ctx, **response.json())

--- a/src/posit/connect/metrics/metrics.py
+++ b/src/posit/connect/metrics/metrics.py
@@ -15,4 +15,4 @@ class Metrics(resources.Resources):
 
     @property
     def usage(self) -> Usage:
-        return Usage(self.params)
+        return Usage(self._ctx)

--- a/src/posit/connect/metrics/shiny_usage.py
+++ b/src/posit/connect/metrics/shiny_usage.py
@@ -105,12 +105,11 @@ class ShinyUsage(Resources):
         params = rename_params(kwargs)
 
         path = "/v1/instrumentation/shiny/usage"
-        url = self.params.url + path
-        paginator = CursorPaginator(self.params.session, url, params=params)
+        paginator = CursorPaginator(self._ctx, path, params=params)
         results = paginator.fetch_results()
         return [
             ShinyUsageEvent(
-                self.params,
+                self._ctx,
                 **result,
             )
             for result in results
@@ -161,13 +160,12 @@ class ShinyUsage(Resources):
         """
         params = rename_params(kwargs)
         path = "/v1/instrumentation/shiny/usage"
-        url = self.params.url + path
-        paginator = CursorPaginator(self.params.session, url, params=params)
+        paginator = CursorPaginator(self._ctx, path, params=params)
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)
         visits = (
             ShinyUsageEvent(
-                self.params,
+                self._ctx,
                 **result,
             )
             for result in results

--- a/src/posit/connect/metrics/usage.py
+++ b/src/posit/connect/metrics/usage.py
@@ -26,7 +26,7 @@ class UsageEvent(resources.Resource):
     @staticmethod
     def from_visit_event(event: visits.VisitEvent) -> UsageEvent:
         return UsageEvent(
-            event.params,
+            event._ctx,
             content_guid=event.content_guid,
             user_guid=event.user_guid,
             variant_key=event.variant_key,
@@ -43,7 +43,7 @@ class UsageEvent(resources.Resource):
         event: shiny_usage.ShinyUsageEvent,
     ) -> UsageEvent:
         return UsageEvent(
-            event.params,
+            event._ctx,
             content_guid=event.content_guid,
             user_guid=event.user_guid,
             variant_key=None,
@@ -197,7 +197,7 @@ class Usage(resources.Resources):
         events = []
         finders = (visits.Visits, shiny_usage.ShinyUsage)
         for finder in finders:
-            instance = finder(self.params)
+            instance = finder(self._ctx)
             events.extend(
                 [
                     UsageEvent.from_event(event)
@@ -251,7 +251,7 @@ class Usage(resources.Resources):
         """
         finders = (visits.Visits, shiny_usage.ShinyUsage)
         for finder in finders:
-            instance = finder(self.params)
+            instance = finder(self._ctx)
             event = instance.find_one(**kwargs)  # type: ignore[attr-defined]
             if event:
                 return UsageEvent.from_event(event)

--- a/src/posit/connect/metrics/visits.py
+++ b/src/posit/connect/metrics/visits.py
@@ -137,12 +137,11 @@ class Visits(Resources):
         params = rename_params(kwargs)
 
         path = "/v1/instrumentation/content/visits"
-        url = self.params.url + path
-        paginator = CursorPaginator(self.params.session, url, params=params)
+        paginator = CursorPaginator(self._ctx, path, params=params)
         results = paginator.fetch_results()
         return [
             VisitEvent(
-                self.params,
+                self._ctx,
                 **result,
             )
             for result in results
@@ -193,13 +192,12 @@ class Visits(Resources):
         """
         params = rename_params(kwargs)
         path = "/v1/instrumentation/content/visits"
-        url = self.params.url + path
-        paginator = CursorPaginator(self.params.session, url, params=params)
+        paginator = CursorPaginator(self._ctx, path, params=params)
         pages = paginator.fetch_pages()
         results = (result for page in pages for result in page.results)
         visits = (
             VisitEvent(
-                self.params,
+                self._ctx,
                 **result,
             )
             for result in results

--- a/src/posit/connect/oauth/associations.py
+++ b/src/posit/connect/oauth/associations.py
@@ -2,7 +2,8 @@
 
 from typing import List
 
-from ..resources import Resource, ResourceParameters, Resources
+from ..context import Context
+from ..resources import Resource, Resources
 
 
 class Association(Resource):
@@ -12,8 +13,8 @@ class Association(Resource):
 class IntegrationAssociations(Resources):
     """IntegrationAssociations resource."""
 
-    def __init__(self, params: ResourceParameters, integration_guid: str) -> None:
-        super().__init__(params)
+    def __init__(self, ctx: Context, integration_guid: str) -> None:
+        super().__init__(ctx)
         self.integration_guid = integration_guid
 
     def find(self) -> List[Association]:
@@ -24,12 +25,10 @@ class IntegrationAssociations(Resources):
         List[Association]
         """
         path = f"v1/oauth/integrations/{self.integration_guid}/associations"
-        url = self.params.url + path
-
-        response = self.params.session.get(url)
+        response = self._ctx.client.get(path)
         return [
             Association(
-                self.params,
+                self._ctx,
                 **result,
             )
             for result in response.json()
@@ -39,8 +38,8 @@ class IntegrationAssociations(Resources):
 class ContentItemAssociations(Resources):
     """ContentItemAssociations resource."""
 
-    def __init__(self, params: ResourceParameters, content_guid: str) -> None:
-        super().__init__(params)
+    def __init__(self, ctx, content_guid: str):
+        super().__init__(ctx)
         self.content_guid = content_guid
 
     def find(self) -> List[Association]:
@@ -51,11 +50,10 @@ class ContentItemAssociations(Resources):
         List[Association]
         """
         path = f"v1/content/{self.content_guid}/oauth/integrations/associations"
-        url = self.params.url + path
-        response = self.params.session.get(url)
+        response = self._ctx.client.get(path)
         return [
             Association(
-                self.params,
+                self._ctx,
                 **result,
             )
             for result in response.json()
@@ -66,13 +64,11 @@ class ContentItemAssociations(Resources):
         data = []
 
         path = f"v1/content/{self.content_guid}/oauth/integrations/associations"
-        url = self.params.url + path
-        self.params.session.put(url, json=data)
+        self._ctx.client.put(path, json=data)
 
     def update(self, integration_guid: str) -> None:
         """Set integration associations."""
         data = [{"oauth_integration_guid": integration_guid}]
 
         path = f"v1/content/{self.content_guid}/oauth/integrations/associations"
-        url = self.params.url + path
-        self.params.session.put(url, json=data)
+        self._ctx.client.put(path, json=data)

--- a/src/posit/connect/oauth/integrations.py
+++ b/src/posit/connect/oauth/integrations.py
@@ -11,13 +11,12 @@ class Integration(Resource):
 
     @property
     def associations(self) -> IntegrationAssociations:
-        return IntegrationAssociations(self.params, integration_guid=self["guid"])
+        return IntegrationAssociations(self._ctx, integration_guid=self["guid"])
 
     def delete(self) -> None:
         """Delete the OAuth integration."""
         path = f"v1/oauth/integrations/{self['guid']}"
-        url = self.params.url + path
-        self.params.session.delete(url)
+        self._ctx.client.delete(path)
 
     @overload
     def update(
@@ -44,8 +43,8 @@ class Integration(Resource):
     def update(self, *args, **kwargs) -> None:
         """Update the OAuth integration."""
         body = dict(*args, **kwargs)
-        url = self.params.url + f"v1/oauth/integrations/{self['guid']}"
-        response = self.params.session.patch(url, json=body)
+        path = f"v1/oauth/integrations/{self['guid']}"
+        response = self._ctx.client.patch(path, json=body)
         super().update(**response.json())
 
 
@@ -99,9 +98,8 @@ class Integrations(Resources):
         Integration
         """
         path = "v1/oauth/integrations"
-        url = self.params.url + path
-        response = self.params.session.post(url, json=kwargs)
-        return Integration(self.params, **response.json())
+        response = self._ctx.client.post(path, json=kwargs)
+        return Integration(self._ctx, **response.json())
 
     def find(self) -> List[Integration]:
         """Find OAuth integrations.
@@ -111,12 +109,10 @@ class Integrations(Resources):
         List[Integration]
         """
         path = "v1/oauth/integrations"
-        url = self.params.url + path
-
-        response = self.params.session.get(url)
+        response = self._ctx.client.get(path)
         return [
             Integration(
-                self.params,
+                self._ctx,
                 **result,
             )
             for result in response.json()
@@ -134,6 +130,5 @@ class Integrations(Resources):
         Integration
         """
         path = f"v1/oauth/integrations/{guid}"
-        url = self.params.url + path
-        response = self.params.session.get(url)
-        return Integration(self.params, **response.json())
+        response = self._ctx.client.get(path)
+        return Integration(self._ctx, **response.json())

--- a/src/posit/connect/oauth/sessions.py
+++ b/src/posit/connect/oauth/sessions.py
@@ -10,8 +10,7 @@ class Session(Resource):
 
     def delete(self) -> None:
         path = f"v1/oauth/sessions/{self['guid']}"
-        url = self.params.url + path
-        self.params.session.delete(url)
+        self._ctx.client.delete(path)
 
 
 class Sessions(Resources):
@@ -26,10 +25,10 @@ class Sessions(Resources):
     def find(self, **kwargs) -> List[Session]: ...
 
     def find(self, **kwargs) -> List[Session]:
-        url = self.params.url + "v1/oauth/sessions"
-        response = self.params.session.get(url, params=kwargs)
+        path = "v1/oauth/sessions"
+        response = self._ctx.client.get(path, params=kwargs)
         results = response.json()
-        return [Session(self.params, **result) for result in results]
+        return [Session(self._ctx, **result) for result in results]
 
     def get(self, guid: str) -> Session:
         """Get an OAuth session.
@@ -43,6 +42,5 @@ class Sessions(Resources):
         Session
         """
         path = f"v1/oauth/sessions/{guid}"
-        url = self.params.url + path
-        response = self.params.session.get(url)
-        return Session(self.params, **response.json())
+        response = self._ctx.client.get(path)
+        return Session(self._ctx, **response.json())

--- a/src/posit/connect/resources.py
+++ b/src/posit/connect/resources.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import posixpath
 import warnings
 from abc import ABC
-from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -11,38 +10,17 @@ from typing import (
     Sequence,
 )
 
-from posit.connect.paginator import Paginator
-
 from .context import Context
+from .paginator import Paginator
 
 if TYPE_CHECKING:
-    import requests
-
     from .context import Context
-    from .urls import Url
-
-
-@dataclass(frozen=True)
-class ResourceParameters:
-    """Shared parameter object for resources.
-
-    Attributes
-    ----------
-    session: requests.Session
-        A `requests.Session` object. Provides cookie persistence, connection-pooling, and
-        configuration.
-    url: str
-        The Connect API base URL (e.g., https://connect.example.com/__api__)
-    """
-
-    session: requests.Session
-    url: Url
 
 
 class Resource(dict):
-    def __init__(self, /, params: ResourceParameters, **kwargs):
-        self.params = params
+    def __init__(self, /, ctx: Context, **kwargs):
         super().__init__(**kwargs)
+        self._ctx = ctx
 
     def __getattr__(self, name):
         if name in self:
@@ -60,8 +38,8 @@ class Resource(dict):
 
 
 class Resources:
-    def __init__(self, params: ResourceParameters) -> None:
-        self.params = params
+    def __init__(self, ctx: Context) -> None:
+        self._ctx = ctx
 
 
 class Active(ABC, Resource):
@@ -79,8 +57,7 @@ class Active(ABC, Resource):
         **attributes : dict
             Resource attributes passed
         """
-        params = ResourceParameters(ctx.session, ctx.url)
-        super().__init__(params, **attributes)
+        super().__init__(ctx, **attributes)
         self._ctx = ctx
         self._path = path
 

--- a/src/posit/connect/tasks.py
+++ b/src/posit/connect/tasks.py
@@ -91,8 +91,7 @@ class Task(resources.Resource):
         """
         params = dict(*args, **kwargs)
         path = f"v1/tasks/{self['id']}"
-        url = self.params.url + path
-        response = self.params.session.get(url, params=kwargs)
+        response = self._ctx.client.get(path, params=params)
         result = response.json()
         super().update(**result)
 
@@ -154,7 +153,6 @@ class Tasks(resources.Resources):
         Task
         """
         path = f"v1/tasks/{uid}"
-        url = self.params.url + path
-        response = self.params.session.get(url, params=kwargs)
+        response = self._ctx.client.get(path, params=kwargs)
         result = response.json()
-        return Task(self.params, **result)
+        return Task(self._ctx, **result)

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 class User(Resource):
     def __init__(self, ctx: Context, /, **attributes) -> None:
-        super().__init__(ctx.client.resource_params, **attributes)
+        super().__init__(ctx, **attributes)
         self._ctx: Context = ctx
 
     @property
@@ -162,7 +162,7 @@ class User(Resource):
 
 class UserGroups(Resources):
     def __init__(self, ctx: Context, user_guid: str) -> None:
-        super().__init__(ctx.client.resource_params)
+        super().__init__(ctx)
         self._ctx: Context = ctx
         self._user_guid: str = user_guid
 
@@ -308,7 +308,7 @@ class Users(Resources):
     """Users resource."""
 
     def __init__(self, ctx: Context) -> None:
-        super().__init__(ctx.client.resource_params)
+        super().__init__(ctx)
         self._ctx: Context = ctx
 
     class CreateUser(TypedDict):

--- a/src/posit/connect/vanities.py
+++ b/src/posit/connect/vanities.py
@@ -2,8 +2,9 @@ from typing import Callable, List, Optional
 
 from typing_extensions import NotRequired, Required, TypedDict, Unpack
 
+from .context import Context
 from .errors import ClientError
-from .resources import Resource, ResourceParameters, Resources
+from .resources import Resource, Resources
 
 
 class Vanity(Resource):
@@ -54,7 +55,7 @@ class Vanity(Resource):
     def __init__(
         self,
         /,
-        params: ResourceParameters,
+        ctx: Context,
         *,
         after_destroy: Optional[AfterDestroyCallback] = None,
         **kwargs: Unpack[VanityAttributes],
@@ -63,11 +64,11 @@ class Vanity(Resource):
 
         Parameters
         ----------
-        params : ResourceParameters
+        _ctx : ResourceParameters
         after_destroy : AfterDestroyCallback, optional
             Called after the Vanity is successfully destroyed, by default None
         """
-        super().__init__(params, **kwargs)
+        super().__init__(ctx, **kwargs)
         self._after_destroy = after_destroy
         self._content_guid = kwargs["content_guid"]
 
@@ -87,8 +88,8 @@ class Vanity(Resource):
         ----
         This action requires administrator privileges.
         """
-        endpoint = self.params.url + f"v1/content/{self._content_guid}/vanity"
-        self.params.session.delete(endpoint)
+        path = f"v1/content/{self._content_guid}/vanity"
+        self._ctx.client.delete(path)
 
         if self._after_destroy:
             self._after_destroy()
@@ -108,10 +109,10 @@ class Vanities(Resources):
         -----
         This action requires administrator privileges.
         """
-        endpoint = self.params.url + "v1/vanities"
-        response = self.params.session.get(endpoint)
+        path = "v1/vanities"
+        response = self._ctx.client.get(path)
         results = response.json()
-        return [Vanity(self.params, **result) for result in results]
+        return [Vanity(self._ctx, **result) for result in results]
 
 
 class VanityMixin(Resource):
@@ -122,8 +123,8 @@ class VanityMixin(Resource):
 
         guid: Required[str]
 
-    def __init__(self, params: ResourceParameters, **kwargs: Unpack[HasGuid]):
-        super().__init__(params, **kwargs)
+    def __init__(self, ctx: Context, **kwargs: Unpack[HasGuid]):
+        super().__init__(ctx, **kwargs)
         self._content_guid = kwargs["guid"]
         self._vanity: Optional[Vanity] = None
 
@@ -215,10 +216,10 @@ class VanityMixin(Resource):
         --------
         If setting force=True, the destroy operation performed on the other vanity is irreversible.
         """
-        endpoint = self.params.url + f"v1/content/{self._content_guid}/vanity"
-        response = self.params.session.put(endpoint, json=kwargs)
+        path = f"v1/content/{self._content_guid}/vanity"
+        response = self._ctx.client.put(path, json=kwargs)
         result = response.json()
-        return Vanity(self.params, **result)
+        return Vanity(self._ctx, **result)
 
     def find_vanity(self) -> Vanity:
         """Find the vanity.
@@ -227,7 +228,7 @@ class VanityMixin(Resource):
         -------
         Vanity
         """
-        endpoint = self.params.url + f"v1/content/{self._content_guid}/vanity"
-        response = self.params.session.get(endpoint)
+        path = f"v1/content/{self._content_guid}/vanity"
+        response = self._ctx.client.get(path)
         result = response.json()
-        return Vanity(self.params, **result)
+        return Vanity(self._ctx, **result)

--- a/src/posit/connect/variants.py
+++ b/src/posit/connect/variants.py
@@ -1,25 +1,24 @@
 from typing import List
 
-from .resources import Resource, ResourceParameters, Resources
+from .context import Context
+from .resources import Resource, Resources
 from .tasks import Task
 
 
 class Variant(Resource):
     def render(self) -> Task:
         path = f"variants/{self['id']}/render"
-        url = self.params.url + path
-        response = self.params.session.post(url)
-        return Task(self.params, **response.json())
+        response = self._ctx.client.post(path)
+        return Task(self._ctx, **response.json())
 
 
 class Variants(Resources):
-    def __init__(self, params: ResourceParameters, content_guid: str) -> None:
-        super().__init__(params)
+    def __init__(self, ctx: Context, content_guid: str) -> None:
+        super().__init__(ctx)
         self.content_guid = content_guid
 
     def find(self) -> List[Variant]:
         path = f"applications/{self.content_guid}/variants"
-        url = self.params.url + path
-        response = self.params.session.get(url)
+        response = self._ctx.client.get(path)
         results = response.json() or []
-        return [Variant(self.params, **result) for result in results]
+        return [Variant(self._ctx, **result) for result in results]

--- a/tests/posit/connect/metrics/test_shiny_usage.py
+++ b/tests/posit/connect/metrics/test_shiny_usage.py
@@ -1,12 +1,10 @@
 from unittest import mock
 
-import requests
 import responses
 from responses import matchers
 
+from posit import connect
 from posit.connect.metrics import shiny_usage
-from posit.connect.resources import ResourceParameters
-from posit.connect.urls import Url
 
 from ..api import load_mock, load_mock_dict
 
@@ -68,10 +66,10 @@ class TestShinyUsageFind:
         ]
 
         # setup
-        params = ResourceParameters(requests.Session(), Url("https://connect.example/__api__"))
+        c = connect.Client("https://connect.example", "12345")
 
         # invoke
-        events = shiny_usage.ShinyUsage(params).find()
+        events = shiny_usage.ShinyUsage(c._ctx).find()
 
         # assert
         assert mock_get[0].call_count == 1
@@ -110,10 +108,10 @@ class TestShinyUsageFindOne:
         ]
 
         # setup
-        params = ResourceParameters(requests.Session(), Url("https://connect.example/__api__"))
+        c = connect.Client("https://connect.example", "12345")
 
         # invoke
-        event = shiny_usage.ShinyUsage(params).find_one()
+        event = shiny_usage.ShinyUsage(c._ctx).find_one()
 
         # assert
         assert mock_get[0].call_count == 1

--- a/tests/posit/connect/metrics/test_visits.py
+++ b/tests/posit/connect/metrics/test_visits.py
@@ -1,12 +1,10 @@
 from unittest import mock
 
-import requests
 import responses
 from responses import matchers
 
+from posit import connect
 from posit.connect.metrics import visits
-from posit.connect.resources import ResourceParameters
-from posit.connect.urls import Url
 
 from ..api import load_mock, load_mock_dict
 
@@ -81,10 +79,10 @@ class TestVisitsFind:
         ]
 
         # setup
-        params = ResourceParameters(requests.Session(), Url("https://connect.example/__api__"))
+        c = connect.Client("https://connect.example", "12345")
 
         # invoke
-        events = visits.Visits(params).find()
+        events = visits.Visits(c._ctx).find()
 
         # assert
         assert mock_get[0].call_count == 1
@@ -125,10 +123,10 @@ class TestVisitsFindOne:
         ]
 
         # setup
-        params = ResourceParameters(requests.Session(), Url("https://connect.example/__api__"))
+        c = connect.Client("https://connect.example", "12345")
 
         # invoke
-        event = visits.Visits(params).find_one()
+        event = visits.Visits(c._ctx).find_one()
 
         # assert
         assert mock_get[0].call_count == 1

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -4,8 +4,6 @@ from responses import matchers
 
 from posit.connect.client import Client
 from posit.connect.content import ContentItem, ContentItemRepository
-from posit.connect.context import Context
-from posit.connect.resources import ResourceParameters
 
 from .api import load_mock, load_mock_dict
 
@@ -550,9 +548,8 @@ class TestRestart:
 
 
 class TestContentRepository:
-    @property
-    def base_url(self):
-        return "http://connect.example"
+    base_url = "http://connect.example"
+    client = Client(base_url, "12345")
 
     @property
     def content_guid(self):
@@ -567,16 +564,8 @@ class TestContentRepository:
         return f"{self.base_url}/__api__/v1/content/{self.content_guid}/repository"
 
     @property
-    def client(self):
-        return Client(self.base_url, "12345")
-
-    @property
     def ctx(self):
-        return Context(self.client)
-
-    @property
-    def params(self):
-        return ResourceParameters(self.ctx.session, self.ctx.url)
+        return self.client._ctx
 
     def mock_repository_info(self):
         content_item = self.content_item

--- a/tests/posit/connect/test_context.py
+++ b/tests/posit/connect/test_context.py
@@ -64,7 +64,8 @@ class TestContextVersion:
             json={},
         )
 
-        ctx = Context(Client("http://connect.example", "12345"))
+        c = Client("http://connect.example", "12345")
+        ctx = c._ctx
 
         assert ctx.version is None
 
@@ -75,7 +76,8 @@ class TestContextVersion:
             json={"version": "2024.09.24"},
         )
 
-        ctx = Context(Client("http://connect.example", "12345"))
+        c = Client("http://connect.example", "12345")
+        ctx = c._ctx
 
         assert ctx.version == "2024.09.24"
 

--- a/tests/posit/connect/test_resources.py
+++ b/tests/posit/connect/test_resources.py
@@ -22,7 +22,7 @@ class TestResource:
         v = "bar"
         d = {k: v}
         r = FakeResource(p, **d)
-        assert r.params == p
+        assert r._ctx == p
 
     def test__getitem__(self):
         warnings.filterwarnings("ignore", category=FutureWarning)

--- a/tests/posit/connect/test_vanities.py
+++ b/tests/posit/connect/test_vanities.py
@@ -1,11 +1,9 @@
 from unittest.mock import Mock
 
-import requests
 import responses
 from responses.matchers import json_params_matcher
 
-from posit.connect.resources import ResourceParameters
-from posit.connect.urls import Url
+from posit import connect
 from posit.connect.vanities import Vanities, Vanity, VanityMixin
 
 
@@ -13,14 +11,12 @@ class TestVanityDestroy:
     @responses.activate
     def test_destroy_sends_delete_request(self):
         content_guid = "8ce6eaca-60af-4c2f-93a0-f5f3cddf5ee5"
-        base_url = "http://connect.example/__api__"
+        base_url = "https://connect.example/__api__"
         endpoint = f"{base_url}/v1/content/{content_guid}/vanity"
         mock_delete = responses.delete(endpoint)
 
-        session = requests.Session()
-        url = Url(base_url)
-        params = ResourceParameters(session, url)
-        vanity = Vanity(params, content_guid=content_guid, path=Mock(), created_time=Mock())
+        c = connect.Client("https://connect.example", "12345")
+        vanity = Vanity(c._ctx, content_guid=content_guid, path=Mock(), created_time=Mock())
 
         vanity.destroy()
 
@@ -29,16 +25,14 @@ class TestVanityDestroy:
     @responses.activate
     def test_destroy_calls_after_destroy_callback(self):
         content_guid = "8ce6eaca-60af-4c2f-93a0-f5f3cddf5ee5"
-        base_url = "http://connect.example/__api__"
+        base_url = "https://connect.example/__api__"
         endpoint = f"{base_url}/v1/content/{content_guid}/vanity"
         responses.delete(endpoint)
 
-        session = requests.Session()
-        url = Url(base_url)
+        c = connect.Client("https://connect.example", "12345")
         after_destroy = Mock()
-        params = ResourceParameters(session, url)
         vanity = Vanity(
-            params,
+            c._ctx,
             after_destroy=after_destroy,
             content_guid=content_guid,
             path=Mock(),
@@ -53,14 +47,12 @@ class TestVanityDestroy:
 class TestVanitiesAll:
     @responses.activate
     def test_all_sends_get_request(self):
-        base_url = "http://connect.example/__api__"
+        base_url = "https://connect.example/__api__"
         endpoint = f"{base_url}/v1/vanities"
         mock_get = responses.get(endpoint, json=[])
 
-        session = requests.Session()
-        url = Url(base_url)
-        params = ResourceParameters(session, url)
-        vanities = Vanities(params)
+        c = connect.Client("https://connect.example", "12345")
+        vanities = Vanities(c._ctx)
 
         vanities.all()
 
@@ -71,14 +63,12 @@ class TestVanityMixin:
     @responses.activate
     def test_vanity_getter_returns_vanity(self):
         guid = "8ce6eaca-60af-4c2f-93a0-f5f3cddf5ee5"
-        base_url = "http://connect.example/__api__"
+        base_url = "https://connect.example/__api__"
         endpoint = f"{base_url}/v1/content/{guid}/vanity"
         mock_get = responses.get(endpoint, json={"content_guid": guid, "path": "my-dashboard"})
 
-        session = requests.Session()
-        url = Url(base_url)
-        params = ResourceParameters(session, url)
-        content = VanityMixin(params, guid=guid)
+        c = connect.Client("https://connect.example", "12345")
+        content = VanityMixin(c._ctx, guid=guid)
 
         assert content.vanity == "my-dashboard"
         assert mock_get.call_count == 1
@@ -86,7 +76,7 @@ class TestVanityMixin:
     @responses.activate
     def test_vanity_setter_with_string(self):
         guid = "8ce6eaca-60af-4c2f-93a0-f5f3cddf5ee5"
-        base_url = "http://connect.example/__api__"
+        base_url = "https://connect.example/__api__"
         endpoint = f"{base_url}/v1/content/{guid}/vanity"
         path = "example"
         mock_put = responses.put(
@@ -95,10 +85,8 @@ class TestVanityMixin:
             match=[json_params_matcher({"path": path})],
         )
 
-        session = requests.Session()
-        url = Url(base_url)
-        params = ResourceParameters(session, url)
-        content = VanityMixin(params, guid=guid)
+        c = connect.Client("https://connect.example", "12345")
+        content = VanityMixin(c._ctx, guid=guid)
         content.vanity = path
         assert content.vanity == path
 
@@ -107,15 +95,13 @@ class TestVanityMixin:
     @responses.activate
     def test_vanity_deleter(self):
         guid = "8ce6eaca-60af-4c2f-93a0-f5f3cddf5ee5"
-        base_url = "http://connect.example/__api__"
+        base_url = "https://connect.example/__api__"
         endpoint = f"{base_url}/v1/content/{guid}/vanity"
         mock_delete = responses.delete(endpoint)
 
-        session = requests.Session()
-        url = Url(base_url)
-        params = ResourceParameters(session, url)
-        content = VanityMixin(params, guid=guid)
-        content._vanity = Vanity(params, path=Mock(), content_guid=guid, created_time=Mock())
+        c = connect.Client("https://connect.example", "12345")
+        content = VanityMixin(c._ctx, guid=guid)
+        content._vanity = Vanity(c._ctx, path=Mock(), content_guid=guid, created_time=Mock())
         del content.vanity
 
         assert content._vanity is None


### PR DESCRIPTION
Now that Client exists on the Context, we can remove all usage of `ctx.params`, `ctx.session`, and `ctx.url` with calls to `ctx.client`.