### PR TITLE
refactor: `Tag.update()` should return `None`

### DIFF
--- a/integration/tests/posit/connect/test_tags.py
+++ b/integration/tests/posit/connect/test_tags.py
@@ -151,12 +151,12 @@ class TestTags:
         }
 
         # Update tag
-        tagDName = tagD.update(name="tagD_updated")
-        assert tagDName["name"] == "tagD_updated"
+        tagD.update(name="tagD_updated")
+        assert tagD["name"] == "tagD_updated"
         assert self.client.tags.get(tagD["id"])["name"] == "tagD_updated"
 
-        tagDParent = tagDName.update(parent=tagB)
-        assert tagDParent["parent_id"] == tagB["id"]
+        tagD.update(parent=tagB)
+        assert tagD["parent_id"] == tagB["id"]
         assert self.client.tags.get(tagD["id"])["parent_id"] == tagB["id"]
 
         # Cleanup

--- a/src/posit/connect/_utils.py
+++ b/src/posit/connect/_utils.py
@@ -3,3 +3,28 @@ from __future__ import annotations
 from typing import Any
 
 
+def update_dict_values(obj: dict[str, Any], /, **kwargs: Any) -> None:
+    """
+    Update the values of a dictionary.
+
+    This helper method exists as a workaround for the `dict.update` method. Sometimes, `super()` does not return the `dict` class and. If `super().update(**kwargs)` is called unintended behavior will occur.
+
+    Therefore, this helper method exists to update the `dict`'s values.
+
+    Parameters
+    ----------
+    obj : dict[str, Any]
+        The object to update.
+    kwargs : Any
+        The key-value pairs to update the object with.
+
+    See Also
+    --------
+    * https://github.com/posit-dev/posit-sdk-py/pull/366#discussion_r1887845267
+    """
+    # Could also be performed with:
+    # for key, value in kwargs.items():
+    #     obj[key] = value
+
+    # Use the `dict` class to explicity update the object in-place
+    dict.update(obj, **kwargs)

--- a/src/posit/connect/_utils.py
+++ b/src/posit/connect/_utils.py
@@ -3,5 +3,3 @@ from __future__ import annotations
 from typing import Any
 
 
-def drop_none(x: dict[str, Any]) -> dict[str, Any]:
-    return {k: v for k, v in x.items() if v is not None}

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -228,7 +228,7 @@ class ContentItem(Active, ContentItemRepositoryMixin, VanityMixin, BaseResource)
                 f"Restart not supported for this application mode: {self['app_mode']}. Did you need to use the 'render()' method instead? Note that some application modes do not support 'render()' or 'restart()'.",
             )
 
-    def update(  # type: ignore[reportIncompatibleMethodOverride]
+    def update(
         self,
         **attrs: Unpack[ContentItem._Attrs],
     ) -> None:

--- a/src/posit/connect/env.py
+++ b/src/posit/connect/env.py
@@ -131,7 +131,7 @@ class EnvVars(Resources, MutableMapping[str, Optional[str]]):
             "Since environment variables may contain sensitive information, the values are not accessible outside of Connect.",
         )
 
-    def update(self, other=(), /, **kwargs: Optional[str]):
+    def update(self, other=(), /, **kwargs: Optional[str]) -> None:
         """
         Update environment variables.
 

--- a/src/posit/connect/metrics/usage.py
+++ b/src/posit/connect/metrics/usage.py
@@ -199,10 +199,7 @@ class Usage(resources.Resources):
         for finder in finders:
             instance = finder(self._ctx)
             events.extend(
-                [
-                    UsageEvent.from_event(event)
-                    for event in instance.find(**kwargs)  # type: ignore[attr-defined]
-                ],
+                [UsageEvent.from_event(event) for event in instance.find(**kwargs)],
             )
         return events
 
@@ -252,7 +249,7 @@ class Usage(resources.Resources):
         finders = (visits.Visits, shiny_usage.ShinyUsage)
         for finder in finders:
             instance = finder(self._ctx)
-            event = instance.find_one(**kwargs)  # type: ignore[attr-defined]
+            event = instance.find_one(**kwargs)
             if event:
                 return UsageEvent.from_event(event)
         return None

--- a/src/posit/connect/repository.py
+++ b/src/posit/connect/repository.py
@@ -9,6 +9,7 @@ from typing_extensions import (
     runtime_checkable,
 )
 
+from ._utils import update_dict_values
 from .errors import ClientError
 from .resources import Resource, _Resource
 
@@ -18,10 +19,8 @@ class _ContentItemRepository(_Resource):
     def update(self, **attributes):
         response = self._ctx.client.patch(self._path, json=attributes)
         result = response.json()
-        # # Calling this method will call `_Resource.update` which will try to PUT to the path.
-        # super().update(**result)
-        # Instead, update the dict directly.
-        dict.update(self, **result)
+
+        update_dict_values(self, **result)
 
 
 @runtime_checkable

--- a/src/posit/connect/repository.py
+++ b/src/posit/connect/repository.py
@@ -16,7 +16,7 @@ from .resources import Resource, _Resource
 
 # ContentItem Repository uses a PATCH method, not a PUT for updating.
 class _ContentItemRepository(_Resource):
-    def update(self, **attributes):
+    def update(self, **attributes) -> None:
         response = self._ctx.client.patch(self._path, json=attributes)
         result = response.json()
 

--- a/src/posit/connect/resources.py
+++ b/src/posit/connect/resources.py
@@ -85,7 +85,7 @@ class _Resource(dict, Resource):
     def destroy(self) -> None:
         self._ctx.client.delete(self._path)
 
-    def update(self, **attributes):  # type: ignore[reportIncompatibleMethodOverride]
+    def update(self, **attributes):  # pyright: ignore[reportIncompatibleMethodOverride]
         response = self._ctx.client.put(self._path, json=attributes)
         result = response.json()
         super().update(**result)

--- a/src/posit/connect/tags.py
+++ b/src/posit/connect/tags.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Optional, overload
 
 from typing_extensions import NotRequired, TypedDict, Unpack
 
+from ._utils import update_dict_values
 from .context import Context, ContextManager
 from .resources import Active
 
@@ -162,14 +163,14 @@ class Tag(Active):
 
     # Allow for every combination of `name` and (`parent` or `parent_id`)
     @overload
-    def update(self, /, *, name: str = ..., parent: Tag | None = ...) -> Tag: ...
+    def update(self, /, *, name: str = ..., parent: Tag | None = ...) -> None: ...
     @overload
-    def update(self, /, *, name: str = ..., parent_id: str | None = ...) -> Tag: ...
+    def update(self, /, *, name: str = ..., parent_id: str | None = ...) -> None: ...
 
     def update(  # pyright: ignore[reportIncompatibleMethodOverride] ; This method returns `Tag`. Parent method returns `None`
         self,
         **kwargs,
-    ) -> Tag:
+    ) -> None:
         """
         Update the tag.
 
@@ -214,7 +215,7 @@ class Tag(Active):
         updated_kwargs = _update_parent_kwargs(kwargs)
         response = self._ctx.client.patch(self._path, json=updated_kwargs)
         result = response.json()
-        return Tag(self._ctx, self._path, **result)
+        update_dict_values(self, **result)
 
 
 class TagContentItems(ContextManager):

--- a/src/posit/connect/tags.py
+++ b/src/posit/connect/tags.py
@@ -167,7 +167,7 @@ class Tag(Active):
     @overload
     def update(self, /, *, name: str = ..., parent_id: str | None = ...) -> None: ...
 
-    def update(  # pyright: ignore[reportIncompatibleMethodOverride] ; This method returns `Tag`. Parent method returns `None`
+    def update(
         self,
         **kwargs,
     ) -> None:

--- a/tests/posit/connect/test_packages.py
+++ b/tests/posit/connect/test_packages.py
@@ -2,7 +2,7 @@ import responses
 
 from posit.connect.client import Client
 
-from .api import load_mock  # type: ignore
+from .api import load_mock
 
 
 class TestPackagesFindBy:

--- a/tests/posit/connect/test_tags.py
+++ b/tests/posit/connect/test_tags.py
@@ -289,19 +289,16 @@ class TestTag:
         tag33 = client.tags.get("33")
 
         # invoke
-        updated_tag33_0 = tag33.update(name="academy-updated", parent_id=None)
-        updated_tag33_1 = tag33.update(name="academy-updated", parent=None)
+        tag33.update(name="academy-updated", parent_id=None)
+        tag33.update(name="academy-updated", parent=None)
 
         parent_tag = Tag(client._ctx, "/v1/tags/1", id="42", name="Parent")
-        updated_tag33_2 = tag33.update(name="academy-updated", parent=parent_tag)
-        updated_tag33_3 = tag33.update(name="academy-updated", parent_id=parent_tag["id"])
+        tag33.update(name="academy-updated", parent=parent_tag)
+        tag33.update(name="academy-updated", parent_id=parent_tag["id"])
 
         # assert
         assert mock_get_33_tag.call_count == 1
         assert mock_update_33_tag.call_count == 4
-
-        for tag in [updated_tag33_0, updated_tag33_1, updated_tag33_2, updated_tag33_3]:
-            assert isinstance(tag, Tag)
 
         # Asserting updated values are deferred to integration testing
         # to avoid agreening with the mocked data


### PR DESCRIPTION
Other changes: 
* Added `update_dict_values(obj, **kwargs)` to update the dict values of an object from https://github.com/posit-dev/posit-sdk-py/pull/366#discussion_r1887845267


This is the last `.update()` that needs to be fixed.

- [x] rstudio/connect does not need to be updated. [Link to search results](https://github.com/search?q=repo%3Arstudio%2Fconnect+%22.update%28%22+path%3A%2F%5Edocs%5C%2F%2F&type=code)