### PR TITLE
bump required connect verions for with_user_session_token() to 2025.01.0

### DIFF
--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -173,7 +173,7 @@ class Client(ContextManager):
         self.session = session
         self._ctx = Context(self)
 
-    @requires("2025.01.0-dev")
+    @requires("2025.01.0")
     def with_user_session_token(self, token: str) -> Client:
         """Create a new Client scoped to the user specified in the user session token.
 


### PR DESCRIPTION
PR to bump required version in SDK to 2025.01.0 without the dev suffix.

This is slated for the 0.8.0 release of the Posit SDK.

Fixes #373