### PR TITLE
test: use ghcr image repository

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,11 @@ jobs:
           - 2022.11.0
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/setup-buildx-action@v3
       - name: Write Posit Connect license to disk
         run: echo "$CONNECT_LICENSE" > ./integration/license.lic


### PR DESCRIPTION
Updates CI to use GHCR image repository instead of Docker Hub.