### PR TITLE
feat: add visits and shiny usage to metrics api

### DIFF
--- a/src/posit/connect/metrics/metrics.py
+++ b/src/posit/connect/metrics/metrics.py
@@ -1,7 +1,9 @@
 """Metric resources."""
 
 from .. import resources
+from .shiny_usage import ShinyUsage
 from .usage import Usage
+from .visits import Visits
 
 
 class Metrics(resources.Resources):
@@ -16,3 +18,11 @@ class Metrics(resources.Resources):
     @property
     def usage(self) -> Usage:
         return Usage(self._ctx)
+
+    @property
+    def visits(self) -> Visits:
+        return Visits(self._ctx)
+
+    @property
+    def shiny_usage(self) -> ShinyUsage:
+        return ShinyUsage(self._ctx)


### PR DESCRIPTION
A start of a change to expose each of the two current metrics endpoints independently. It needs tests and documentation. 

However this isn't intended to and likely will not land: What's the use case for comparing them separately? It's a pain to manually coalesce them when analyzing user traffic, which is why I decided on the approach on main. Here's a summary of the differences I observed. https://docs.posit.co/connect/cookbook/metrics/viewing-content-usage-information/#discussion