### PR TITLE
ci: remove ghcr login

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,11 +65,6 @@ jobs:
           - 2022.11.0
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/setup-buildx-action@v3
       - name: Write Posit Connect license to disk
         run: echo "$CONNECT_LICENSE" > ./integration/license.lic


### PR DESCRIPTION
Not needed because this repository only uses public images.

Reverts #386.