### PR TITLE
ci: define matrix input using makefile output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,36 +34,25 @@ jobs:
       - run: make dev
       - run: make test
 
+  setup-integration-test:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.versions.outputs.versions }}
+    steps:
+        - uses: actions/checkout@v4
+        - id: versions
+          working-directory: ./integration
+          run: |
+            versions=$(make print-versions | jq -c -Rs 'split("\n") | .[:-1]')
+            echo "versions=$versions" >> "$GITHUB_OUTPUT"
+
   integration-test:
     runs-on: ubuntu-latest
+    needs: setup-integration-test
     strategy:
       fail-fast: false
       matrix:
-        CONNECT_VERSION:
-          - preview
-          - 2025.02.0
-          - 2025.01.0
-          - 2024.12.0
-          - 2024.11.0
-          - 2024.09.0
-          - 2024.08.0
-          - 2024.06.0
-          - 2024.05.0
-          - 2024.04.1
-          - 2024.04.0
-          - 2024.03.0
-          - 2024.02.0
-          - 2024.01.0
-          - 2023.12.0
-          - 2023.10.0
-          - 2023.09.0
-          - 2023.07.0
-          - 2023.06.0
-          - 2023.05.0
-          - 2023.01.1
-          - 2023.01.0
-          - 2022.12.0
-          - 2022.11.0
+        CONNECT_VERSION: ${{ fromJson(needs.setup-integration-test.outputs.versions) }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,7 @@ jobs:
         - uses: actions/checkout@v4
         - id: versions
           working-directory: ./integration
+          # The `jq` command is "output compact, raw input, slurp, split on new lines, and remove the last element". This results in a JSON array of Connect versions (e.g., ["2025.01.0", "2024.12.0"]).
           run: |
             versions=$(make print-versions | jq -c -Rs 'split("\n") | .[:-1]')
             echo "versions=$versions" >> "$GITHUB_OUTPUT"

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -102,6 +102,10 @@ up-%: build
 	PYTEST_ARGS="$(PYTEST_ARGS)" \
 	$(DOCKER_COMPOSE) -p $(PROJECT_NAME)-$(subst .,-,$(CONNECT_VERSION)) up -V --abort-on-container-exit --no-build
 
+# Show available versions
+print-versions:
+	@printf "%s\n" $(strip $(CONNECT_VERSIONS))
+
 # Show help message.
 help:
 	@echo "Makefile Targets:"
@@ -112,6 +116,7 @@ help:
 	@echo "  up               Start Docker Compose for all Connect versions."
 	@echo "  down             Tear down Docker resources for all Connect versions."
 	@echo "  clean            Clean up the project directory."
+	@echo "  print-versions   Show the available Connect versions."
 	@echo "  help             Show this help message."
 	@echo
 	@echo "Common Usage:"


### PR DESCRIPTION
Reads the supported Connect versions from `./integration/Makefile` via the `make print-versions` command.