### PR TITLE
chore: Add `*.lic` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ cython_debug/
 
 /.luarc.json
 _dev/
+
+# license files should not be commited to this repository
+*.lic

--- a/integration/.gitignore
+++ b/integration/.gitignore
@@ -1,3 +1,2 @@
-*.lic
 logs
 reports


### PR DESCRIPTION
Adding `*.lic` to `.gitignore` so that accidentally committing license files requires additional steps.