### PR TITLE
feat: speed up the packages api

### DIFF
--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -349,7 +349,9 @@ class Client(ContextManager):
     @property
     @requires(version="2024.11.0")
     def packages(self) -> Packages:
-        return _PaginatedResourceSequence(self._ctx, "v1/packages", uid="name")
+        return _PaginatedResourceSequence(
+            self._ctx, "v1/packages", uid="name", page_size=1_000_000
+        )
 
     @property
     def system(self) -> System:

--- a/src/posit/connect/paginator.py
+++ b/src/posit/connect/paginator.py
@@ -43,16 +43,14 @@ class Paginator:
     """
 
     def __init__(
-        self,
-        ctx: Context,
-        path: str,
-        params: dict | None = None,
+        self, ctx: Context, path: str, params: dict | None = None, page_size: int | None = None
     ) -> None:
         if params is None:
             params = {}
         self._ctx = ctx
         self._path = path
         self._params = params
+        self._page_size = page_size or _MAX_PAGE_SIZE
 
     def fetch_results(self) -> List[dict]:
         """
@@ -109,7 +107,7 @@ class Paginator:
         params = {
             **self._params,
             "page_number": page_number,
-            "page_size": _MAX_PAGE_SIZE,
+            "page_size": self._page_size,
         }
         response = self._ctx.client.get(self._path, params=params)
         return Page(**response.json())

--- a/src/posit/connect/resources.py
+++ b/src/posit/connect/resources.py
@@ -177,8 +177,12 @@ class _ResourceSequence(Sequence[T], ResourceSequence[T]):
 
 
 class _PaginatedResourceSequence(_ResourceSequence):
+    def __init__(self, ctx, path: str, *, uid: str = "guid", page_size: int | None = None):
+        super().__init__(ctx, path, uid=uid)
+        self._page_size = page_size
+
     def fetch(self, **conditions):
-        paginator = Paginator(self._ctx, self._path, dict(**conditions))
+        paginator = Paginator(self._ctx, self._path, dict(**conditions), page_size=self._page_size)
         for page in paginator.fetch_pages():
             resources = []
             results = page.results


### PR DESCRIPTION
The Connect Packages API (v1/packages) supports uncapped page size. By increasing the page size from the default of 500 to 1,000,000, there is a significant speed up when fetching all packages. This is due to a reduction in the number of round trips to the Connect server. The tradeoff is a larger payload. Since the Python requests package does not limit the  HTTP GET request-response body size, we are unconcerned with the larger payload.