### PR TITLE
feat: added standard token type enum; added aws_creds helper

### DIFF
--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -11,7 +11,7 @@ from .content import Content
 from .context import Context, ContextManager, requires
 from .groups import Groups
 from .metrics.metrics import Metrics
-from .oauth.oauth import API_KEY_TOKEN_TYPE, OAuth
+from .oauth.oauth import OAuth, OAuthTokenType
 from .resources import _PaginatedResourceSequence, _ResourceSequence
 from .sessions import Session
 from .system import System
@@ -256,7 +256,7 @@ class Client(ContextManager):
             raise ValueError("token must be set to non-empty string.")
 
         visitor_credentials = self.oauth.get_credentials(
-            token, requested_token_type=API_KEY_TOKEN_TYPE
+            token, requested_token_type=OAuthTokenType.API_KEY
         )
 
         visitor_api_key = visitor_credentials.get("access_token", "")

--- a/src/posit/connect/external/aws.py
+++ b/src/posit/connect/external/aws.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import base64
+import json
+
+from typing_extensions import TYPE_CHECKING, Dict
+
+from ..oauth.oauth import OAuthTokenType
+
+if TYPE_CHECKING:
+    from ..client import Client
+
+
+def get_aws_credentials(client: Client, user_session_token: str) -> Dict[str, str]:
+    """
+    Get AWS credentials using OAuth token exchange.
+
+    According to RFC 8693, the access token must be a base64 encoded JSON object
+    containing the AWS credentials. This function will decode and deserialize the
+    access token and return the AWS credentials.
+
+    Parameters
+    ----------
+    client : Client
+        The client to use for making requests
+    user_session_token : str
+        The user session token to exchange
+
+    Returns
+    -------
+    Dict[str, str]
+        Dictionary containing AWS credentials with keys:
+        access_key_id, secret_access_key, session_token, and expiration
+    """
+    # Get credentials using OAuth
+    credentials = client.oauth.get_credentials(
+        user_session_token=user_session_token,
+        requested_token_type=OAuthTokenType.AWS_CREDENTIALS,
+    )
+
+    # Decode base64 access token
+    access_token = credentials.get("access_token")
+    if not access_token:
+        raise ValueError("No access token found in credentials")
+    decoded_bytes = base64.b64decode(access_token)
+    decoded_str = decoded_bytes.decode("utf-8")
+    aws_credentials = json.loads(decoded_str)
+
+    return aws_credentials

--- a/tests/posit/connect/external/test_aws.py
+++ b/tests/posit/connect/external/test_aws.py
@@ -1,0 +1,68 @@
+import pytest
+import responses
+
+from posit.connect import Client
+from posit.connect.external.aws import get_aws_credentials
+
+aws_creds = {
+    "accessKeyId": "abc123",
+    "secretAccessKey": "def456",
+    "sessionToken": "ghi789",
+    "expiration": "2025-01-01T00:00:00Z",
+}
+
+encoded_aws_creds = "eyJhY2Nlc3NLZXlJZCI6ICJhYmMxMjMiLCAic2VjcmV0QWNjZXNzS2V5IjogImRlZjQ1NiIsICJzZXNzaW9uVG9rZW4iOiAiZ2hpNzg5IiwgImV4cGlyYXRpb24iOiAiMjAyNS0wMS0wMVQwMDowMDowMFoifQ=="
+
+
+class TestAWS:
+    @responses.activate
+    def test_get_aws_credentials(self):
+        responses.post(
+            "https://connect.example/__api__/v1/oauth/integrations/credentials",
+            match=[
+                responses.matchers.urlencoded_params_matcher(
+                    {
+                        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                        "subject_token_type": "urn:posit:connect:user-session-token",
+                        "subject_token": "cit",
+                        "requested_token_type": "urn:ietf:params:aws:token-type:credentials",
+                    }
+                )
+            ],
+            json={
+                "access_token": encoded_aws_creds,
+                "issued_token_type": "urn:ietf:params:aws:token-type:credentials",
+                "token_type": "aws_credentials",
+            },
+        )
+
+        c = Client(api_key="12345", url="https://connect.example/")
+        c._ctx.version = None
+        response = get_aws_credentials(c, "cit")
+
+        assert response == aws_creds
+
+    @responses.activate
+    def test_get_aws_credentials_no_token(self):
+        responses.post(
+            "https://connect.example/__api__/v1/oauth/integrations/credentials",
+            match=[
+                responses.matchers.urlencoded_params_matcher(
+                    {
+                        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                        "subject_token_type": "urn:posit:connect:user-session-token",
+                        "subject_token": "cit",
+                        "requested_token_type": "urn:ietf:params:aws:token-type:credentials",
+                    }
+                )
+            ],
+            json={},
+        )
+
+        c = Client(api_key="12345", url="https://connect.example/")
+        c._ctx.version = None
+
+        with pytest.raises(ValueError) as e:
+            get_aws_credentials(c, "cit")
+
+        assert e.match("No access token found in credentials")

--- a/tests/posit/connect/oauth/test_oauth.py
+++ b/tests/posit/connect/oauth/test_oauth.py
@@ -4,7 +4,7 @@ import pytest
 import responses
 
 from posit.connect import Client
-from posit.connect.oauth.oauth import API_KEY_TOKEN_TYPE, _get_content_session_token
+from posit.connect.oauth.oauth import OAuthTokenType, _get_content_session_token
 
 
 class TestOAuthIntegrations:
@@ -62,10 +62,37 @@ class TestOAuthIntegrations:
         )
         c = Client(api_key="12345", url="https://connect.example/")
         c._ctx.version = None
-        creds = c.oauth.get_credentials("cit", API_KEY_TOKEN_TYPE)
+        creds = c.oauth.get_credentials("cit", OAuthTokenType.API_KEY)
         assert creds.get("access_token") == "viewer-api-key"
         assert creds.get("issued_token_type") == "urn:posit:connect:api-key"
         assert creds.get("token_type") == "Key"
+
+    @responses.activate
+    def test_get_credentials_aws(self):
+        responses.post(
+            "https://connect.example/__api__/v1/oauth/integrations/credentials",
+            match=[
+                responses.matchers.urlencoded_params_matcher(
+                    {
+                        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                        "subject_token_type": "urn:posit:connect:user-session-token",
+                        "subject_token": "cit",
+                        "requested_token_type": "urn:ietf:params:aws:token-type:credentials",
+                    },
+                ),
+            ],
+            json={
+                "access_token": "encoded-aws-creds",
+                "issued_token_type": "urn:ietf:params:aws:token-type:credentials",
+                "token_type": "aws_credentials",
+            },
+        )
+        c = Client(api_key="12345", url="https://connect.example/")
+        c._ctx.version = None
+        creds = c.oauth.get_credentials("cit", OAuthTokenType.AWS_CREDENTIALS)
+        assert creds.get("access_token") == "encoded-aws-creds"
+        assert creds.get("issued_token_type") == "urn:ietf:params:aws:token-type:credentials"
+        assert creds.get("token_type") == "aws_credentials"
 
     @responses.activate
     def test_get_content_credentials(self):


### PR DESCRIPTION
- Refactored supported token types into a string enum
- Added aws creds helper to properly decode the value from the Connect credential exchange endpoint