### PR TITLE
ci: fixes issues with `site.yaml` action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@v6
       - run: uv python install
       - run: make dev
       - run: make lint
@@ -29,7 +29,7 @@ jobs:
           - "3.13"
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@v6
       - run: uv python install ${{ matrix.python-version }}
       - run: make dev
       - run: make test
@@ -61,7 +61,7 @@ jobs:
         run: echo "$CONNECT_LICENSE" > ./integration/license.lic
         env:
           CONNECT_LICENSE: ${{ secrets.CONNECT_LICENSE }}
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@v6
       - run: uv python install
       - run: make -C ./integration ${{ matrix.CONNECT_VERSION }}
       - uses: actions/upload-artifact@v4
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@v6
       - run: uv python install
       - run: make dev
       - run: make build

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@v6
       - run: uv python install
       - run: make dev
       - run: make test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       - run: uv python install
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - run: make build
       - run: make install
       - id: release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,9 +12,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@v6
       - run: uv python install
       - uses: actions/setup-node@v4
+        with:
+          node-version: 18
       - run: make build
       - run: make install
       - id: release

--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@v6
       - run: uv python install
       - run: make build install
       - uses: quarto-dev/quarto-actions/setup@v2
@@ -40,9 +40,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@v6
       - run: uv python install
       - uses: actions/setup-node@v4
+        with:
+          node-version: 18
       - uses: quarto-dev/quarto-actions/setup@v2
       - run: make dev
       - run: make docs

--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -44,7 +44,7 @@ jobs:
       - run: uv python install
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - uses: quarto-dev/quarto-actions/setup@v2
       - run: make dev
       - run: make docs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -37,7 +37,6 @@ api: ensure-dev
 build: ensure-dev
 	CURRENT_YEAR=$(CURRENT_YEAR) \
 	PROJECT_VERSION=$(PROJECT_VERSION) \
-	$(UV) tool run --with ../ \
 	$(QUARTO) render
 
 clean:
@@ -48,12 +47,12 @@ _extensions/posit-dev/posit-docs/_extension.yml:
 	$(QUARTO) add --no-prompt posit-dev/product-doc-theme@v4.0.2
 _extensions/machow/interlinks/_extension.yml:
 	$(QUARTO) add --no-prompt machow/quartodoc
+
 deps: ensure-dev _extensions/posit-dev/posit-docs/_extension.yml _extensions/machow/interlinks/_extension.yml
 
 preview: ensure-dev
 	CURRENT_YEAR=$(CURRENT_YEAR) \
 	PROJECT_VERSION=$(PROJECT_VERSION) \
-	$(UV) tool run --with ../ \
 	$(QUARTO) preview
 
 deploy:

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -26,6 +26,7 @@ PYTEST_ARGS ?= "-s"
 
 # Versions
 CONNECT_VERSIONS := \
+	2025.04.0 \
 	2025.03.0 \
 	2025.02.0 \
 	2025.01.0 \


### PR DESCRIPTION
- ci: fixes `site.yaml` action
- ci: updates imported actions to latest version
- build: remove use of `uv run --with` since it no longer supports bash
- test: add Connect v2025.04.0 to test suite
- ci: update Node to v22