### PR TITLE
test(fix): destroy the default integration before testing

### DIFF
--- a/integration/Makefile
+++ b/integration/Makefile
@@ -26,6 +26,8 @@ PYTEST_ARGS ?= "-s"
 
 # Versions
 CONNECT_VERSIONS := \
+	2025.06.0 \
+	2025.05.0 \
 	2025.04.0 \
 	2025.03.0 \
 	2025.02.0 \

--- a/integration/tests/posit/connect/test_groups.py
+++ b/integration/tests/posit/connect/test_groups.py
@@ -5,21 +5,21 @@ class TestGroups:
     @classmethod
     def setup_class(cls):
         cls.client = connect.Client()
-        cls.item = cls.client.groups.create(name="Friends")
+        cls.group = cls.client.groups.create(name="Friends")
 
     @classmethod
     def teardown_class(cls):
-        cls.item.delete()
+        cls.group.delete()
         assert cls.client.groups.count() == 0
 
     def test_count(self):
         assert self.client.groups.count() == 1
 
     def test_get(self):
-        assert self.client.groups.get(self.item["guid"])
+        assert self.client.groups.get(self.group["guid"])
 
     def test_find(self):
-        assert self.client.groups.find() == [self.item]
+        assert self.client.groups.find() == [self.group]
 
     def test_find_one(self):
-        assert self.client.groups.find_one() == self.item
+        assert self.client.groups.find_one() == self.group

--- a/tests/posit/connect/test_client.py
+++ b/tests/posit/connect/test_client.py
@@ -234,35 +234,45 @@ class TestClient:
         url = "https://connect.example.com"
         client = Client(api_key=api_key, url=url)
         client.get("/foo")
-        client.session.get.assert_called_once_with("https://connect.example.com/__api__/foo")
+        MockSession.return_value.get.assert_called_once_with(
+            "https://connect.example.com/__api__/foo"
+        )
 
     def test_post(self, MockSession):
         api_key = "12345"
         url = "https://connect.example.com"
         client = Client(api_key=api_key, url=url)
         client.post("/foo")
-        client.session.post.assert_called_once_with("https://connect.example.com/__api__/foo")
+        MockSession.return_value.post.assert_called_once_with(
+            "https://connect.example.com/__api__/foo"
+        )
 
     def test_put(self, MockSession):
         api_key = "12345"
         url = "https://connect.example.com"
         client = Client(api_key=api_key, url=url)
         client.put("/foo")
-        client.session.put.assert_called_once_with("https://connect.example.com/__api__/foo")
+        MockSession.return_value.put.assert_called_once_with(
+            "https://connect.example.com/__api__/foo"
+        )
 
     def test_patch(self, MockSession):
         api_key = "12345"
         url = "https://connect.example.com"
         client = Client(api_key=api_key, url=url)
         client.patch("/foo")
-        client.session.patch.assert_called_once_with("https://connect.example.com/__api__/foo")
+        MockSession.return_value.patch.assert_called_once_with(
+            "https://connect.example.com/__api__/foo"
+        )
 
     def test_delete(self, MockSession):
         api_key = "12345"
         url = "https://connect.example.com"
         client = Client(api_key=api_key, url=url)
         client.delete("/foo")
-        client.session.delete.assert_called_once_with("https://connect.example.com/__api__/foo")
+        MockSession.return_value.delete.assert_called_once_with(
+            "https://connect.example.com/__api__/foo"
+        )
 
 
 class TestClientOAuth:

--- a/tests/posit/connect/test_hooks.py
+++ b/tests/posit/connect/test_hooks.py
@@ -77,5 +77,8 @@ def test_deprecation_warning():
     )
     c = Client("https://connect.example", "12345")
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(
+        DeprecationWarning,
+        match="https://connect.example/__api__/v0 is deprecated and will be removed in a future version of Connect. Please upgrade `posit-sdk` in order to use the new APIs.",
+    ):
         c.get("v0")


### PR DESCRIPTION
Starting in 2025.05.0, a default integration is created by Connect. We want to destroy that integration before running the test suite.