### PR TITLE
feat: add optional audience parameter to credential exchange related methods

### DIFF
--- a/integration/tests/posit/connect/oauth/test_associations.py
+++ b/integration/tests/posit/connect/oauth/test_associations.py
@@ -70,7 +70,7 @@ class TestAssociations:
         task = bundle.deploy()
         task.wait_for()
 
-        cls.content.oauth.associations.update(cls.integration["guid"])
+        cls.content.oauth.associations.update([cls.integration["guid"]])
 
     @classmethod
     def teardown_class(cls):
@@ -102,7 +102,7 @@ class TestAssociations:
         assert associations[0]["oauth_integration_guid"] == self.integration["guid"]
 
         # update content association to another_integration
-        self.content.oauth.associations.update(self.another_integration["guid"])
+        self.content.oauth.associations.update([self.another_integration["guid"]])
         updated_associations = self.content.oauth.associations.find()
         assert len(updated_associations) == 1
         assert updated_associations[0]["app_guid"] == self.content["guid"]

--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
-from typing_extensions import TYPE_CHECKING, overload
+from typing_extensions import TYPE_CHECKING, Optional, overload
 
 from . import hooks, me
 from .auth import Auth

--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -11,7 +11,8 @@ from .content import Content
 from .context import Context, ContextManager, requires
 from .groups import Groups
 from .metrics.metrics import Metrics
-from .oauth.oauth import OAuth, OAuthTokenType
+from .oauth.oauth import OAuth
+from .oauth.types import OAuthTokenType
 from .resources import _PaginatedResourceSequence, _ResourceSequence
 from .sessions import Session
 from .system import System

--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 from typing_extensions import TYPE_CHECKING, overload
 
 from . import hooks, me
@@ -176,7 +178,11 @@ class Client(ContextManager):
         self._ctx = Context(self)
 
     @requires("2025.01.0")
-    def with_user_session_token(self, token: str) -> Client:
+    def with_user_session_token(
+        self,
+        token: str,
+        audience: Optional[str] = None,
+    ) -> Client:
         """Create a new Client scoped to the user specified in the user session token.
 
         Create a new Client instance from a user session token exchange for an api key scoped to the
@@ -256,7 +262,9 @@ class Client(ContextManager):
             raise ValueError("token must be set to non-empty string.")
 
         visitor_credentials = self.oauth.get_credentials(
-            token, requested_token_type=OAuthTokenType.API_KEY
+            token,
+            requested_token_type=OAuthTokenType.API_KEY,
+            audience=audience,
         )
 
         visitor_api_key = visitor_credentials.get("access_token", "")

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import posixpath
 import time
 
@@ -1000,3 +1001,16 @@ class Content(Resources):
 
         response = self._ctx.client.get(f"v1/content/{guid}", params=params)
         return ContentItem(self._ctx, **response.json())
+
+    @property
+    def current(self) -> ContentItem:
+        """Get the content item for the current context.
+
+        Returns
+        -------
+        ContentItem
+        """
+        guid = os.getenv("CONNECT_CONTENT_GUID")
+        if not guid:
+            raise RuntimeError("CONNECT_CONTENT_GUID environment variable is not set.")
+        return self.get(guid)

--- a/src/posit/connect/external/aws.py
+++ b/src/posit/connect/external/aws.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 from typing_extensions import TYPE_CHECKING, Optional, TypedDict
 
-from ..oauth.oauth import OAuthTokenType
+from ..oauth.types import OAuthTokenType
 
 if TYPE_CHECKING:
     from ..client import Client

--- a/src/posit/connect/external/aws.py
+++ b/src/posit/connect/external/aws.py
@@ -19,7 +19,11 @@ class Credentials(TypedDict):
     expiration: datetime
 
 
-def get_credentials(client: Client, user_session_token: str) -> Credentials:
+def get_credentials(
+    client: Client,
+    user_session_token: str,
+    audience: Optional[str] = None,
+) -> Credentials:
     """
     Get AWS credentials using OAuth token exchange for an AWS Viewer integration.
 
@@ -66,6 +70,7 @@ def get_credentials(client: Client, user_session_token: str) -> Credentials:
     credentials = client.oauth.get_credentials(
         user_session_token=user_session_token,
         requested_token_type=OAuthTokenType.AWS_CREDENTIALS,
+        audience=audience,
     )
 
     # Decode base64 access token
@@ -76,7 +81,9 @@ def get_credentials(client: Client, user_session_token: str) -> Credentials:
 
 
 def get_content_credentials(
-    client: Client, content_session_token: Optional[str] = None
+    client: Client,
+    content_session_token: Optional[str] = None,
+    audience: Optional[str] = None,
 ) -> Credentials:
     """
     Get AWS credentials using OAuth token exchange for an AWS Service Account integration.
@@ -122,6 +129,7 @@ def get_content_credentials(
     credentials = client.oauth.get_content_credentials(
         content_session_token=content_session_token,
         requested_token_type=OAuthTokenType.AWS_CREDENTIALS,
+        audience=audience,
     )
 
     # Decode base64 access token

--- a/src/posit/connect/external/snowflake.py
+++ b/src/posit/connect/external/snowflake.py
@@ -69,10 +69,12 @@ class PositAuthenticator:
         local_authenticator: Optional[str] = None,
         client: Optional[Client] = None,
         user_session_token: Optional[str] = None,
+        audience: Optional[str] = None,
     ):
         self._local_authenticator = local_authenticator
         self._client = client
         self._user_session_token = user_session_token
+        self._audience = audience
 
     @property
     def authenticator(self) -> Optional[str]:
@@ -93,5 +95,8 @@ class PositAuthenticator:
         if self._client is None:
             self._client = Client()
 
-        credentials = self._client.oauth.get_credentials(self._user_session_token)
+        credentials = self._client.oauth.get_credentials(
+            self._user_session_token,
+            audience=self._audience,
+        )
         return credentials.get("access_token")

--- a/src/posit/connect/oauth/associations.py
+++ b/src/posit/connect/oauth/associations.py
@@ -2,16 +2,13 @@
 
 from __future__ import annotations
 
-import re
-
-from typing_extensions import TYPE_CHECKING, List, Optional
+from typing_extensions import TYPE_CHECKING, List
 
 # from ..context import requires
 from ..resources import BaseResource, Resources
 
 if TYPE_CHECKING:
     from ..context import Context
-    from ..oauth import types
 
 
 class Association(BaseResource):
@@ -67,42 +64,6 @@ class ContentItemAssociations(Resources):
             for result in response.json()
         ]
 
-    # TODO turn this on before merging
-    # @requires("2025.07.0")
-    def find_by(
-        self,
-        integration_type: Optional[types.OAuthIntegrationType] = None,
-        auth_type: Optional[types.OAuthIntegrationAuthType] = None,
-        name: Optional[str] = None,
-        guid: Optional[str] = None,
-    ) -> Association | None:
-        for association in self.find():
-            match = True
-
-            if (
-                integration_type is not None
-                and association.get("oauth_integration_template") != integration_type
-            ):
-                match = False
-
-            if (
-                auth_type is not None
-                and association.get("oauth_integration_auth_type") != auth_type
-            ):
-                match = False
-
-            if name is not None:
-                integration_name = association.get("oauth_integration_name", "")
-                if not re.search(name, integration_name):
-                    match = False
-
-            if guid is not None and association.get("oauth_integration_guid") != guid:
-                match = False
-
-            if match:
-                return association
-        return None
-
     def delete(self) -> None:
         """Delete integration associations."""
         data = []
@@ -110,10 +71,8 @@ class ContentItemAssociations(Resources):
         path = f"v1/content/{self.content_guid}/oauth/integrations/associations"
         self._ctx.client.put(path, json=data)
 
-    def update(self, integration_guid: str | list[str]) -> None:
+    def update(self, integration_guid: list[str]) -> None:
         """Set integration associations."""
-        if isinstance(integration_guid, str):
-            integration_guid = [integration_guid]
         data = [{"oauth_integration_guid": guid} for guid in integration_guid]
 
         path = f"v1/content/{self.content_guid}/oauth/integrations/associations"

--- a/src/posit/connect/oauth/associations.py
+++ b/src/posit/connect/oauth/associations.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from typing_extensions import List
+from typing_extensions import TYPE_CHECKING, List
 
 from ..resources import BaseResource, Resources
 

--- a/src/posit/connect/oauth/associations.py
+++ b/src/posit/connect/oauth/associations.py
@@ -67,7 +67,7 @@ class ContentItemAssociations(Resources):
             for result in response.json()
         ]
 
-    @requires("2025.06.0-dev")
+    @requires("2025.07.0-dev")
     def find_by(
         self,
         integration_type: Optional[types.OAuthIntegrationType | str] = None,

--- a/src/posit/connect/oauth/associations.py
+++ b/src/posit/connect/oauth/associations.py
@@ -1,9 +1,15 @@
 """OAuth association resources."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from typing_extensions import List
 
-from ..context import Context
 from ..resources import BaseResource, Resources
+
+if TYPE_CHECKING:
+    from ..context import Context
 
 
 class Association(BaseResource):
@@ -66,9 +72,11 @@ class ContentItemAssociations(Resources):
         path = f"v1/content/{self.content_guid}/oauth/integrations/associations"
         self._ctx.client.put(path, json=data)
 
-    def update(self, integration_guid: str) -> None:
+    def update(self, integration_guid: str | list[str]) -> None:
         """Set integration associations."""
-        data = [{"oauth_integration_guid": integration_guid}]
+        if isinstance(integration_guid, str):
+            integration_guid = [integration_guid]
+        data = [{"oauth_integration_guid": guid} for guid in integration_guid]
 
         path = f"v1/content/{self.content_guid}/oauth/integrations/associations"
         self._ctx.client.put(path, json=data)

--- a/src/posit/connect/oauth/associations.py
+++ b/src/posit/connect/oauth/associations.py
@@ -101,8 +101,7 @@ class ContentItemAssociations(Resources):
 
             if match:
                 return association
-            else:
-                return None
+        return None
 
     def delete(self) -> None:
         """Delete integration associations."""

--- a/src/posit/connect/oauth/associations.py
+++ b/src/posit/connect/oauth/associations.py
@@ -6,7 +6,7 @@ from functools import partial
 
 from typing_extensions import TYPE_CHECKING, List, Optional
 
-# from ..context import requires
+from ..context import requires
 from ..resources import BaseResource, Resources, _matches_exact, _matches_pattern
 
 if TYPE_CHECKING:
@@ -67,8 +67,7 @@ class ContentItemAssociations(Resources):
             for result in response.json()
         ]
 
-    # TODO turn this on before merging
-    # @requires("2025.07.0")
+    @requires("2025.06.0-dev")
     def find_by(
         self,
         integration_type: Optional[types.OAuthIntegrationType | str] = None,

--- a/src/posit/connect/oauth/associations.py
+++ b/src/posit/connect/oauth/associations.py
@@ -116,9 +116,9 @@ class ContentItemAssociations(Resources):
         if guid is not None:
             filters.append(partial(_matches_exact, key="oauth_integration_guid", value=guid))
 
-        for integration in self.find():
-            if all(f(integration) for f in filters):
-                return integration
+        for association in self.find():
+            if all(f(association) for f in filters):
+                return association
 
         return None
 

--- a/src/posit/connect/oauth/associations.py
+++ b/src/posit/connect/oauth/associations.py
@@ -71,9 +71,9 @@ class ContentItemAssociations(Resources):
         path = f"v1/content/{self.content_guid}/oauth/integrations/associations"
         self._ctx.client.put(path, json=data)
 
-    def update(self, integration_guid: list[str]) -> None:
+    def update(self, integration_guids: list[str]) -> None:
         """Set integration associations."""
-        data = [{"oauth_integration_guid": guid} for guid in integration_guid]
+        data = [{"oauth_integration_guid": guid} for guid in integration_guids]
 
         path = f"v1/content/{self.content_guid}/oauth/integrations/associations"
         self._ctx.client.put(path, json=data)

--- a/src/posit/connect/oauth/integrations.py
+++ b/src/posit/connect/oauth/integrations.py
@@ -132,7 +132,7 @@ class Integrations(Resources):
             for result in response.json()
         ]
 
-    @requires("2025.06.0-dev")
+    @requires("2025.07.0-dev")
     def find_by(
         self,
         integration_type: Optional[types.OAuthIntegrationType | str] = None,

--- a/src/posit/connect/oauth/integrations.py
+++ b/src/posit/connect/oauth/integrations.py
@@ -129,8 +129,8 @@ class Integrations(Resources):
     # @requires("2025.07.0")
     def find_by(
         self,
-        integration_type: Optional[types.OAuthIntegrationType] = None,
-        auth_type: Optional[types.OAuthIntegrationAuthType] = None,
+        integration_type: Optional[types.OAuthIntegrationType | str] = None,
+        auth_type: Optional[types.OAuthIntegrationAuthType | str] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
         guid: Optional[str] = None,
@@ -140,14 +140,16 @@ class Integrations(Resources):
 
         Parameters
         ----------
-        integration_type : Optional[types.OAuthIntegrationType]
+        integration_type : Optional[types.OAuthIntegrationType | str]
             The type of the integration (e.g., "aws", "azure").
-        auth_type : Optional[types.OAuthIntegrationAuthType]
+        auth_type : Optional[types.OAuthIntegrationAuthType | str]
             The authentication type of the integration (e.g., "Viewer", "Service Account").
         name : Optional[str]
-            A regex pattern to match the integration name.
+            A regex pattern to match the integration name. For exact matches, use `^` and `$`. For example,
+            `^My Integration$` will match only "My Integration".
         description : Optional[str]
-            A regex pattern to match the integration description.
+            A regex pattern to match the integration description. For exact matches, use `^` and `$`. For example,
+            `^My Integration Description$` will match only "My Integration Description".
         guid : Optional[str]
             The unique identifier of the integration.
         config : Optional[dict]
@@ -160,34 +162,32 @@ class Integrations(Resources):
             The first matching integration, or None if no match is found.
         """
         for integration in self.find():
-            match = True
-
             if integration_type is not None and integration.get("template") != integration_type:
-                match = False
+                continue
 
             if auth_type is not None and integration.get("auth_type") != auth_type:
-                match = False
+                continue
 
             if name is not None:
                 integration_name = integration.get("name", "")
                 if not re.search(name, integration_name):
-                    match = False
+                    continue
 
             if description is not None:
                 integration_description = integration.get("description", "")
                 if not re.search(description, integration_description):
-                    match = False
+                    continue
 
             if guid is not None and integration.get("guid") != guid:
-                match = False
+                continue
 
             if config is not None:
                 integration_config = integration.get("config", {})
                 if not all(integration_config.get(k) == v for k, v in config.items()):
-                    match = False
+                    continue
 
-            if match:
-                return integration
+            return integration
+
         return None
 
     def get(self, guid: str) -> Integration:

--- a/src/posit/connect/oauth/integrations.py
+++ b/src/posit/connect/oauth/integrations.py
@@ -6,6 +6,7 @@ from functools import partial
 
 from typing_extensions import TYPE_CHECKING, List, Optional, overload
 
+from ..context import requires
 from ..resources import (
     BaseResource,
     Resources,
@@ -131,8 +132,7 @@ class Integrations(Resources):
             for result in response.json()
         ]
 
-    # TODO turn this on before merging
-    # @requires("2025.07.0")
+    @requires("2025.06.0-dev")
     def find_by(
         self,
         integration_type: Optional[types.OAuthIntegrationType | str] = None,

--- a/src/posit/connect/oauth/oauth.py
+++ b/src/posit/connect/oauth/oauth.py
@@ -1,50 +1,16 @@
 from __future__ import annotations
 
 import os
-import re
-from enum import Enum
 
 from typing_extensions import TYPE_CHECKING, Optional, TypedDict
 
-from posit.connect.oauth.associations import ContentItemAssociations
-
+from ..oauth import types
 from ..resources import Resources
 from .integrations import Integrations
 from .sessions import Sessions
 
 if TYPE_CHECKING:
-    from posit.connect.external import aws
-
     from ..context import Context
-
-GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
-
-
-class OAuthTokenType(str, Enum):
-    ACCESS_TOKEN = "urn:ietf:params:oauth:token-type:access_token"
-    AWS_CREDENTIALS = "urn:ietf:params:aws:token-type:credentials"
-    API_KEY = "urn:posit:connect:api-key"
-    CONTENT_SESSION_TOKEN = "urn:posit:connect:content-session-token"
-    USER_SESSION_TOKEN = "urn:posit:connect:user-session-token"
-
-
-class OAuthIntegrationAuthType(str, Enum):
-    """OAuth integration authentication type."""
-
-    VIEWER = "Viewer"
-    SERVICE_ACCOUNT = "Service Account"
-    VISITOR_API_KEY = "Visitor API Key"
-
-
-class OAuthIntegrationType(str, Enum):
-    """OAuth integration type."""
-
-    AWS = "aws"
-    AZURE = "azure"
-    CONNECT = "connect"
-    SNOWFLAKE = "snowflake"
-    CUSTOM = "custom"
-    # TODO add the rest
 
 
 def _get_content_session_token() -> str:
@@ -85,14 +51,14 @@ class OAuth(Resources):
     def get_credentials(
         self,
         user_session_token: Optional[str] = None,
-        requested_token_type: Optional[str | OAuthTokenType] = None,
+        requested_token_type: Optional[str | types.OAuthTokenType] = None,
         audience: Optional[str] = None,
     ) -> Credentials:
         """Perform an oauth credential exchange with a user-session-token."""
         # craft a credential exchange request
         data = {}
-        data["grant_type"] = GRANT_TYPE
-        data["subject_token_type"] = OAuthTokenType.USER_SESSION_TOKEN
+        data["grant_type"] = types.GRANT_TYPE
+        data["subject_token_type"] = types.OAuthTokenType.USER_SESSION_TOKEN
         if user_session_token:
             data["subject_token"] = user_session_token
         if requested_token_type:
@@ -106,14 +72,14 @@ class OAuth(Resources):
     def get_content_credentials(
         self,
         content_session_token: Optional[str] = None,
-        requested_token_type: Optional[str | OAuthTokenType] = None,
+        requested_token_type: Optional[str | types.OAuthTokenType] = None,
         audience: Optional[str] = None,
     ) -> Credentials:
         """Perform an oauth credential exchange with a content-session-token."""
         # craft a credential exchange request
         data = {}
-        data["grant_type"] = GRANT_TYPE
-        data["subject_token_type"] = OAuthTokenType.CONTENT_SESSION_TOKEN
+        data["grant_type"] = types.GRANT_TYPE
+        data["subject_token_type"] = types.OAuthTokenType.CONTENT_SESSION_TOKEN
         data["subject_token"] = content_session_token or _get_content_session_token()
         if requested_token_type:
             data["requested_token_type"] = requested_token_type
@@ -122,74 +88,6 @@ class OAuth(Resources):
 
         response = self._ctx.client.post(self._path, data=data)
         return Credentials(**response.json())
-
-    def get_credentials_by(
-        self,
-        user_session_token: str,
-        content_session_token: Optional[str] = None,
-        integration_type: Optional[OAuthIntegrationType] = None,
-        auth_type: Optional[OAuthIntegrationAuthType] = None,
-        name: Optional[str | re.Pattern] = None,
-        guid: Optional[str] = None,
-    ) -> Credentials | aws.Credentials:
-        """Perform an oauth credential exchange for all integrations associated with the current content item."""
-        content_guid = os.getenv("CONNECT_CONTENT_GUID")
-        if not content_guid:
-            raise ValueError("CONNECT_CONTENT_GUID environment variable is required.")
-        content_associations = ContentItemAssociations(self._ctx, content_guid=content_guid).find()
-        # associations format: [{
-        #     content_guid: uuid
-        #     app_guid: uuid
-        #     oauth_integration_guid: uuid
-        #     oauth_integration_name: string
-        #     oauth_integration_description: string┃null
-        #     oauth_integration_template: string
-        #     oauth_integration_auth_type: string
-        #     created_time: date-time
-        # }]
-        for association in content_associations:
-            match = True
-
-            if (
-                integration_type is not None
-                and association.get("oauth_integration_template") != integration_type
-            ):
-                match = False
-
-            if (
-                auth_type is not None
-                and association.get("oauth_integration_auth_type") != auth_type
-            ):
-                match = False
-
-            if name is not None:
-                integration_name = association.get("oauth_integration_name", "")
-                if isinstance(name, re.Pattern):
-                    if not name.search(integration_name):
-                        match = False
-                else:
-                    if integration_name != name:
-                        match = False
-
-            if guid is not None and association.get("oauth_integration_guid") != guid:
-                match = False
-
-            if match:
-                # Use the first matching association to get credentials
-                if association.get("oauth_integration_auth_type") in [
-                    OAuthIntegrationAuthType.VIEWER,
-                    OAuthIntegrationAuthType.VISITOR_API_KEY,
-                ]:
-                    return self.get_credentials(
-                        user_session_token=user_session_token,
-                        audience=association.get("oauth_integration_guid"),
-                    )
-                return self.get_content_credentials(
-                    content_session_token=content_session_token,
-                    audience=association.get("oauth_integration_guid"),
-                )
-
-        raise ValueError("No matching OAuth integration found for the specified criteria.")
 
 
 class Credentials(TypedDict, total=False):

--- a/src/posit/connect/oauth/oauth.py
+++ b/src/posit/connect/oauth/oauth.py
@@ -12,6 +12,12 @@ from .sessions import Sessions
 if TYPE_CHECKING:
     from ..context import Context
 
+# Adding constants for backwards compatibility
+# Moving these could break existing code that imports them directly
+GRANT_TYPE = types.GRANT_TYPE
+
+OAuthTokenType = types.OAuthTokenType
+
 
 def _get_content_session_token() -> str:
     """Return the content session token.

--- a/src/posit/connect/oauth/oauth.py
+++ b/src/posit/connect/oauth/oauth.py
@@ -62,6 +62,7 @@ class OAuth(Resources):
         self,
         user_session_token: Optional[str] = None,
         requested_token_type: Optional[str | OAuthTokenType] = None,
+        audience: Optional[str] = None,
     ) -> Credentials:
         """Perform an oauth credential exchange with a user-session-token."""
         # craft a credential exchange request
@@ -72,6 +73,8 @@ class OAuth(Resources):
             data["subject_token"] = user_session_token
         if requested_token_type:
             data["requested_token_type"] = requested_token_type
+        if audience:
+            data["audience"] = audience
 
         response = self._ctx.client.post(self._path, data=data)
         return Credentials(**response.json())
@@ -80,6 +83,7 @@ class OAuth(Resources):
         self,
         content_session_token: Optional[str] = None,
         requested_token_type: Optional[str | OAuthTokenType] = None,
+        audience: Optional[str] = None,
     ) -> Credentials:
         """Perform an oauth credential exchange with a content-session-token."""
         # craft a credential exchange request
@@ -89,6 +93,8 @@ class OAuth(Resources):
         data["subject_token"] = content_session_token or _get_content_session_token()
         if requested_token_type:
             data["requested_token_type"] = requested_token_type
+        if audience:
+            data["audience"] = audience
 
         response = self._ctx.client.post(self._path, data=data)
         return Credentials(**response.json())

--- a/src/posit/connect/oauth/oauth.py
+++ b/src/posit/connect/oauth/oauth.py
@@ -56,17 +56,31 @@ class OAuth(Resources):
 
     def get_credentials(
         self,
-        user_session_token: Optional[str] = None,
+        user_session_token: str,
         requested_token_type: Optional[str | types.OAuthTokenType] = None,
         audience: Optional[str] = None,
     ) -> Credentials:
-        """Perform an oauth credential exchange with a user-session-token."""
+        """Perform an oauth credential exchange with a user-session-token.
+
+        Parameters
+        ----------
+        user_session_token : str
+            The user session token to use for the exchange.
+        requested_token_type : str or OAuthTokenType, optional
+            The type of token being requested. This can be one of the predefined types in `OAuthTokenType` or a custom string.
+        audience : str, optional
+            The intended audience for the token. This must be a valid integration GUID.
+
+        Returns
+        -------
+        Credentials
+            The credentials obtained from the exchange.
+        """
         # craft a credential exchange request
         data = {}
         data["grant_type"] = types.GRANT_TYPE
         data["subject_token_type"] = types.OAuthTokenType.USER_SESSION_TOKEN
-        if user_session_token:
-            data["subject_token"] = user_session_token
+        data["subject_token"] = user_session_token
         if requested_token_type:
             data["requested_token_type"] = requested_token_type
         if audience:
@@ -81,7 +95,23 @@ class OAuth(Resources):
         requested_token_type: Optional[str | types.OAuthTokenType] = None,
         audience: Optional[str] = None,
     ) -> Credentials:
-        """Perform an oauth credential exchange with a content-session-token."""
+        """Perform an oauth credential exchange with a content-session-token.
+
+        Parameters
+        ----------
+        content_session_token : str, optional
+            The content session token to use for the exchange. If not provided, the function will attempt to read the token from the environment variable 'CONNECT_CONTENT_SESSION_TOKEN'.
+        requested_token_type : str or OAuthTokenType, optional
+            The type of token being requested. This can be one of the predefined types in `OAuthTokenType` or a custom string.
+        audience : str, optional
+            The intended audience for the token. This must be a valid integration GUID.
+
+        Returns
+        -------
+        Credentials
+            The credentials obtained from the exchange.
+
+        """
         # craft a credential exchange request
         data = {}
         data["grant_type"] = types.GRANT_TYPE

--- a/src/posit/connect/oauth/oauth.py
+++ b/src/posit/connect/oauth/oauth.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
 import os
+import re
 from enum import Enum
 
 from typing_extensions import TYPE_CHECKING, Optional, TypedDict
+
+from posit.connect.oauth.associations import ContentItemAssociations
 
 from ..resources import Resources
 from .integrations import Integrations
 from .sessions import Sessions
 
 if TYPE_CHECKING:
+    from posit.connect.external import aws
+
     from ..context import Context
 
 GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
@@ -21,6 +26,25 @@ class OAuthTokenType(str, Enum):
     API_KEY = "urn:posit:connect:api-key"
     CONTENT_SESSION_TOKEN = "urn:posit:connect:content-session-token"
     USER_SESSION_TOKEN = "urn:posit:connect:user-session-token"
+
+
+class OAuthIntegrationAuthType(str, Enum):
+    """OAuth integration authentication type."""
+
+    VIEWER = "Viewer"
+    SERVICE_ACCOUNT = "Service Account"
+    VISITOR_API_KEY = "Visitor API Key"
+
+
+class OAuthIntegrationType(str, Enum):
+    """OAuth integration type."""
+
+    AWS = "aws"
+    AZURE = "azure"
+    CONNECT = "connect"
+    SNOWFLAKE = "snowflake"
+    CUSTOM = "custom"
+    # TODO add the rest
 
 
 def _get_content_session_token() -> str:
@@ -98,6 +122,74 @@ class OAuth(Resources):
 
         response = self._ctx.client.post(self._path, data=data)
         return Credentials(**response.json())
+
+    def get_credentials_by(
+        self,
+        user_session_token: str,
+        content_session_token: Optional[str] = None,
+        integration_type: Optional[OAuthIntegrationType] = None,
+        auth_type: Optional[OAuthIntegrationAuthType] = None,
+        name: Optional[str | re.Pattern] = None,
+        guid: Optional[str] = None,
+    ) -> Credentials | aws.Credentials:
+        """Perform an oauth credential exchange for all integrations associated with the current content item."""
+        content_guid = os.getenv("CONNECT_CONTENT_GUID")
+        if not content_guid:
+            raise ValueError("CONNECT_CONTENT_GUID environment variable is required.")
+        content_associations = ContentItemAssociations(self._ctx, content_guid=content_guid).find()
+        # associations format: [{
+        #     content_guid: uuid
+        #     app_guid: uuid
+        #     oauth_integration_guid: uuid
+        #     oauth_integration_name: string
+        #     oauth_integration_description: string┃null
+        #     oauth_integration_template: string
+        #     oauth_integration_auth_type: string
+        #     created_time: date-time
+        # }]
+        for association in content_associations:
+            match = True
+
+            if (
+                integration_type is not None
+                and association.get("oauth_integration_template") != integration_type
+            ):
+                match = False
+
+            if (
+                auth_type is not None
+                and association.get("oauth_integration_auth_type") != auth_type
+            ):
+                match = False
+
+            if name is not None:
+                integration_name = association.get("oauth_integration_name", "")
+                if isinstance(name, re.Pattern):
+                    if not name.search(integration_name):
+                        match = False
+                else:
+                    if integration_name != name:
+                        match = False
+
+            if guid is not None and association.get("oauth_integration_guid") != guid:
+                match = False
+
+            if match:
+                # Use the first matching association to get credentials
+                if association.get("oauth_integration_auth_type") in [
+                    OAuthIntegrationAuthType.VIEWER,
+                    OAuthIntegrationAuthType.VISITOR_API_KEY,
+                ]:
+                    return self.get_credentials(
+                        user_session_token=user_session_token,
+                        audience=association.get("oauth_integration_guid"),
+                    )
+                return self.get_content_credentials(
+                    content_session_token=content_session_token,
+                    audience=association.get("oauth_integration_guid"),
+                )
+
+        raise ValueError("No matching OAuth integration found for the specified criteria.")
 
 
 class Credentials(TypedDict, total=False):

--- a/src/posit/connect/oauth/types.py
+++ b/src/posit/connect/oauth/types.py
@@ -1,0 +1,30 @@
+from enum import Enum
+
+GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+
+class OAuthTokenType(str, Enum):
+    ACCESS_TOKEN = "urn:ietf:params:oauth:token-type:access_token"
+    AWS_CREDENTIALS = "urn:ietf:params:aws:token-type:credentials"
+    API_KEY = "urn:posit:connect:api-key"
+    CONTENT_SESSION_TOKEN = "urn:posit:connect:content-session-token"
+    USER_SESSION_TOKEN = "urn:posit:connect:user-session-token"
+
+
+class OAuthIntegrationAuthType(str, Enum):
+    """OAuth integration authentication type."""
+
+    VIEWER = "Viewer"
+    SERVICE_ACCOUNT = "Service Account"
+    VISITOR_API_KEY = "Visitor API Key"
+
+
+class OAuthIntegrationType(str, Enum):
+    """OAuth integration type."""
+
+    AWS = "aws"
+    AZURE = "azure"
+    CONNECT = "connect"
+    SNOWFLAKE = "snowflake"
+    CUSTOM = "custom"
+    # TODO add the rest

--- a/src/posit/connect/oauth/types.py
+++ b/src/posit/connect/oauth/types.py
@@ -24,7 +24,16 @@ class OAuthIntegrationType(str, Enum):
 
     AWS = "aws"
     AZURE = "azure"
+    AZURE_OPENAI = "azure-openai"
     CONNECT = "connect"
-    SNOWFLAKE = "snowflake"
     CUSTOM = "custom"
-    # TODO add the rest
+    DATABRICKS = "databricks"
+    GITHUB = "github"
+    GOOGLE_BIGQUERY = "bigquery"
+    GOOGLE_DRIVE = "drive"
+    GOOGLE_SHEETS = "sheets"
+    GOOGLE_VERTEX_AI = "vertex-ai"
+    MSGRAPH = "msgraph"
+    SALESFORCE = "salesforce"
+    SHAREPOINT = "sharepoint"
+    SNOWFLAKE = "snowflake"

--- a/src/posit/connect/resources.py
+++ b/src/posit/connect/resources.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import posixpath
+import re
 import warnings
 from abc import ABC
 
@@ -192,3 +193,24 @@ class _PaginatedResourceSequence(_ResourceSequence):
                 resource = _Resource(self._ctx, path, **result)
                 resources.append(resource)
             yield from resources
+
+
+def _matches_exact(item: BaseResource, key: str, value: str):
+    item_value = item.get(key)
+    if item_value is None or not isinstance(item_value, str):
+        return False
+    return item_value == value
+
+
+def _matches_pattern(item: BaseResource, key: str, pattern: str):
+    item_value = item.get(key)
+    if item_value is None or not isinstance(item_value, str):
+        return False
+    return re.search(pattern, item_value) is not None
+
+
+def _contains_dict_key_values(item: BaseResource, key: str, value: dict):
+    item_value = item.get(key)
+    if item_value is None or not isinstance(item_value, dict):
+        return False
+    return all(item_value.get(k) == v for k, v in value.items())

--- a/tests/posit/connect/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066/oauth/integrations/associations.json
+++ b/tests/posit/connect/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066/oauth/integrations/associations.json
@@ -6,5 +6,13 @@
     "oauth_integration_description": "integration description",
     "oauth_integration_template": "custom",
     "created_time": "2024-10-01T18:16:09Z"
+  },
+  {
+    "app_guid": "f2f37341-e21d-3d80-c698-a935ad614066",
+    "oauth_integration_guid": "00000000-a27b-4118-ad06-e24459b05126",
+    "oauth_integration_name": "another integration",
+    "oauth_integration_description": "another description",
+    "oauth_integration_template": "custom",
+    "created_time": "2024-10-02T18:16:09Z"
   }
 ]

--- a/tests/posit/connect/__api__/v1/oauth/integrations.json
+++ b/tests/posit/connect/__api__/v1/oauth/integrations.json
@@ -32,5 +32,17 @@
             "token_endpoint_auth_method": "client_secret_post",
             "token_uri": "http://keycloak:8080/realms/rsconnect/protocol/openid-connect/token"
         }
+    },
+    {
+        "id": "5",
+        "guid": "d32b3f4e-3f4a-4c5a-9f1e-8b6e2f7c9a2b",
+        "created_time": "2025-07-15T20:35:11Z",
+        "updated_time": "2025-07-15T20:35:11Z",
+        "name": "Connect Visitor API Key",
+        "description": "Allows access to Connect APIs on behalf of a Connect user.",
+        "template": "connect",
+        "config": {
+            "scopes": "admin"
+        }
     }
 ]

--- a/tests/posit/connect/oauth/test_associations.py
+++ b/tests/posit/connect/oauth/test_associations.py
@@ -120,7 +120,7 @@ class TestContentAssociationsUpdate:
         c._ctx.version = None
 
         # invoke
-        c.content.get(guid).oauth.associations.update(new_integration_guid)
+        c.content.get(guid).oauth.associations.update([new_integration_guid])
 
         # assert
         assert mock_put.call_count == 1

--- a/tests/posit/connect/oauth/test_associations.py
+++ b/tests/posit/connect/oauth/test_associations.py
@@ -89,9 +89,12 @@ class TestContentAssociationsFind:
         associations = c.content.get(guid).oauth.associations.find()
 
         # assert
-        assert len(associations) == 1
-        association = associations[0]
-        assert association["app_guid"] == guid
+        assert len(associations) == 2
+        assert associations[0]["app_guid"] == guid
+        assert associations[1]["app_guid"] == guid
+        assert (
+            associations[0]["oauth_integration_guid"] != associations[1]["oauth_integration_guid"]
+        )
 
         assert mock_get_content.call_count == 1
         assert mock_get_association.call_count == 1
@@ -108,11 +111,15 @@ class TestContentAssociationsUpdate:
             json=load_mock(f"v1/content/{guid}.json"),
         )
 
-        new_integration_guid = "00000000-a27b-4118-ad06-e24459b05126"
+        new_integration_guid1 = "00000000-a27b-4118-ad06-e24459b05126"
+        new_integration_guid2 = "00000001-a27b-4118-ad06-e24459b05126"
 
         mock_put = responses.put(
             f"https://connect.example/__api__/v1/content/{guid}/oauth/integrations/associations",
-            json=[{"oauth_integration_guid": new_integration_guid}],
+            json=[
+                {"oauth_integration_guid": new_integration_guid1},
+                {"oauth_integration_guid": new_integration_guid2},
+            ],
         )
 
         # setup
@@ -120,7 +127,12 @@ class TestContentAssociationsUpdate:
         c._ctx.version = None
 
         # invoke
-        c.content.get(guid).oauth.associations.update([new_integration_guid])
+        c.content.get(guid).oauth.associations.update(
+            [
+                new_integration_guid1,
+                new_integration_guid2,
+            ]
+        )
 
         # assert
         assert mock_put.call_count == 1

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -388,7 +388,7 @@ class TestContentCurrent:
             match=[matchers.query_param_matcher({"include": "owner,tags,vanity_url"})],
         )
         c = Client("https://connect.example", "12345")
-        content_item = c.content.current
+        content_item = c.content.get()
         assert content_item["guid"] == guid
 
     def test_without_env_var(self, monkeypatch):
@@ -397,7 +397,7 @@ class TestContentCurrent:
         with pytest.raises(
             RuntimeError, match="CONNECT_CONTENT_GUID environment variable is not set."
         ):
-            _ = c.content.current
+            _ = c.content.get()
 
 
 class TestContentsCount:

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -376,6 +376,30 @@ class TestContentsGet:
         assert get_one["name"] == "Performance-Data-1671216053560"
 
 
+class TestContentCurrent:
+    @responses.activate
+    def test_with_env_var(self, monkeypatch):
+        guid = "f2f37341-e21d-3d80-c698-a935ad614066"
+        monkeypatch.setenv("CONNECT_CONTENT_GUID", guid)
+
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{guid}",
+            json=load_mock(f"v1/content/{guid}.json"),
+            match=[matchers.query_param_matcher({"include": "owner,tags,vanity_url"})],
+        )
+        c = Client("https://connect.example", "12345")
+        content_item = c.content.current
+        assert content_item["guid"] == guid
+
+    def test_without_env_var(self, monkeypatch):
+        monkeypatch.delenv("CONNECT_CONTENT_GUID", raising=False)
+        c = Client("https://connect.example", "12345")
+        with pytest.raises(
+            RuntimeError, match="CONNECT_CONTENT_GUID environment variable is not set."
+        ):
+            _ = c.content.current
+
+
 class TestContentsCount:
     @responses.activate
     def test(self):

--- a/tests/posit/connect/test_resources.py
+++ b/tests/posit/connect/test_resources.py
@@ -4,7 +4,12 @@ from unittest.mock import Mock
 
 from typing_extensions import Optional
 
-from posit.connect.resources import BaseResource
+from posit.connect.resources import (
+    BaseResource,
+    _contains_dict_key_values,
+    _matches_exact,
+    _matches_pattern,
+)
 
 config = Mock()
 session = Mock()
@@ -62,3 +67,74 @@ class TestResource:
         d = {k: v}
         r = FakeResource(mock.Mock(), **d)
         assert r.foo == v
+
+
+class TestContainsDictKeyValues:
+    def test_empty_value_dict(self):
+        r = FakeResource(mock.Mock(), foo={"a": 1, "b": 2})
+        assert _contains_dict_key_values(r, "foo", {}) is True
+
+    def test_matching_single_key_value(self):
+        r = FakeResource(mock.Mock(), foo={"a": 1, "b": 2})
+        assert _contains_dict_key_values(r, "foo", {"a": 1}) is True
+
+    def test_matching_multiple_key_values(self):
+        r = FakeResource(mock.Mock(), foo={"a": 1, "b": 2, "c": 3})
+        assert _contains_dict_key_values(r, "foo", {"a": 1, "b": 2}) is True
+
+    def test_non_matching_key_value(self):
+        r = FakeResource(mock.Mock(), foo={"a": 1, "b": 2})
+        assert _contains_dict_key_values(r, "foo", {"a": 2}) is False
+
+    def test_missing_key_in_item(self):
+        r = FakeResource(mock.Mock(), foo={"a": 1})
+        assert _contains_dict_key_values(r, "foo", {"b": 2}) is False
+
+    def test_missing_field_in_resource(self):
+        r = FakeResource(mock.Mock())
+        assert _contains_dict_key_values(r, "nonexistent", {"a": 1}) is False
+
+    def test_non_dict_field_value(self):
+        r = FakeResource(mock.Mock(), foo="not_a_dict")
+        assert _contains_dict_key_values(r, "foo", {"a": 1}) is False
+
+    def test_nested_dict_values(self):
+        r = FakeResource(mock.Mock(), foo={"nested": {"x": 10}, "simple": "value"})
+        assert _contains_dict_key_values(r, "foo", {"nested": {"x": 10}}) is True
+        assert _contains_dict_key_values(r, "foo", {"nested": {"x": 20}}) is False
+
+
+class TestMatchesPattern:
+    def test_pattern_matches(self):
+        r = FakeResource(mock.Mock(), name="test-app-123")
+        assert _matches_pattern(r, "name", r"test-.*-\d+") is True
+
+    def test_pattern_does_not_match(self):
+        r = FakeResource(mock.Mock(), name="production-app")
+        assert _matches_pattern(r, "name", r"test-.*-\d+") is False
+
+    def test_missing_field_returns_false(self):
+        r = FakeResource(mock.Mock())
+        assert _matches_pattern(r, "nonexistent", ".*") is False
+
+    def test_empty_pattern_matches_any_string(self):
+        r = FakeResource(mock.Mock(), description="any text here")
+        assert _matches_pattern(r, "description", "") is True
+
+    def test_partial_match_returns_true(self):
+        r = FakeResource(mock.Mock(), title="My Great App")
+        assert _matches_pattern(r, "title", "Great") is True
+
+
+class TestMatchesExact:
+    def test_exact_match_returns_true(self):
+        r = FakeResource(mock.Mock(), name="test-app")
+        assert _matches_exact(r, "name", "test-app") is True
+
+    def test_no_match_returns_false(self):
+        r = FakeResource(mock.Mock(), name="test-app")
+        assert _matches_exact(r, "name", "other-app") is False
+
+    def test_missing_field_returns_false(self):
+        r = FakeResource(mock.Mock())
+        assert _matches_exact(r, "nonexistent", "value") is False


### PR DESCRIPTION
- Adds in support for the optional audience parameter for the credential exchange endpoint to determine which integration to use
- Removes "only 1 association" constraint on updating content's oauth integration associations.
- Adds `find_by` helper method for integrations and associations to allow a user to search available integrations (globally or scoped to a specific piece of content) to get the GUID for the integration they need dynamically.