### PR TITLE
feat: extend content.get() to automatically use `include` param

### DIFF
--- a/integration/tests/posit/connect/test_content.py
+++ b/integration/tests/posit/connect/test_content.py
@@ -24,16 +24,16 @@ class TestContent:
 
     def test_get(self):
         item = self.client.content.get(self.content["guid"])
-        # get() always includes owner, tags, and vanity_url. Owner data is always present in all
-        # content, tags and vanity_url is only present if explicitly set in the content.
         # Check that essential fields match instead of exact equality
         for key in self.content:
             assert key in item
             assert item[key] == self.content[key]
-        # Also verify we have the additional fields that should always be included
-        assert "owner" in item
-        assert "tags" not in item
-        assert "vanity_url" not in item
+        if CONNECT_VERSION >= version.parse("2024.06.0"):
+            # get() always includes owner, tags, and vanity_url. Owner data is always present in
+            # all content, tags and vanity_url are only present if explicitly set in the content.
+            assert "owner" in item
+            assert "tags" not in item
+            assert "vanity_url" not in item
 
     def test_find(self):
         assert self.client.content.find()

--- a/integration/tests/posit/connect/test_content.py
+++ b/integration/tests/posit/connect/test_content.py
@@ -23,15 +23,17 @@ class TestContent:
         assert self.client.content.count() == 1
 
     def test_get(self):
-        assert self.client.content.get(self.content["guid"]) == self.content
-
-    def test_get_with_include_string(self):
-        assert self.client.content.get(self.content["guid"], include="owner")
-
-    def test_get_with_include_list(self):
-        assert self.client.content.get(
-            self.content["guid"], include=["owner", "tags", "vanity_url"]
-        )
+        item = self.client.content.get(self.content["guid"])
+        # get() always includes owner, tags, and vanity_url. Owner data is always present in all
+        # content, tags and vanity_url is only present if explicitly set in the content.
+        # Check that essential fields match instead of exact equality
+        for key in self.content:
+            assert key in item
+            assert item[key] == self.content[key]
+        # Also verify we have the additional fields that should always be included
+        assert "owner" in item
+        assert "tags" not in item
+        assert "vanity_url" not in item
 
     def test_find(self):
         assert self.client.content.find()

--- a/integration/tests/posit/connect/test_content.py
+++ b/integration/tests/posit/connect/test_content.py
@@ -26,7 +26,7 @@ class TestContent:
         assert self.client.content.get(self.content["guid"]) == self.content
 
     def test_get_with_include_string(self):
-        assert  self.client.content.get(self.content["guid"], include="owner")
+        assert self.client.content.get(self.content["guid"], include="owner")
 
     def test_get_with_include_list(self):
         assert self.client.content.get(

--- a/integration/tests/posit/connect/test_content.py
+++ b/integration/tests/posit/connect/test_content.py
@@ -25,6 +25,14 @@ class TestContent:
     def test_get(self):
         assert self.client.content.get(self.content["guid"]) == self.content
 
+    def test_get_with_include_string(self):
+        assert  self.client.content.get(self.content["guid"], include="owner")
+
+    def test_get_with_include_list(self):
+        assert self.client.content.get(
+            self.content["guid"], include=["owner", "tags", "vanity_url"]
+        )
+
     def test_find(self):
         assert self.client.content.find()
 

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -983,34 +983,20 @@ class Content(Resources):
         items = self.find(**conditions)
         return next(iter(items), None)
 
-    def get(
-        self,
-        guid: str,
-        *,
-        include: Optional[
-            Literal["owner", "tags", "vanity_url"] | list[Literal["owner", "tags", "vanity_url"]]
-        ] = None,
-    ) -> ContentItem:
+    def get(self, guid: str) -> ContentItem:
         """Get a content item.
 
         Parameters
         ----------
         guid : str
             The unique identifier of the content item.
-        include : str or list of str, optional
-            Additional details to include in the response.
-            Allowed values: 'owner', 'tags', 'vanity_url'.
 
         Returns
         -------
         ContentItem
         """
-        params = {}
-        if include is not None:
-            if isinstance(include, list):
-                params["include"] = ",".join(include)
-            else:
-                params["include"] = include
+        # Always request all available optional fields for the content item
+        params = {"include": "owner,tags,vanity_url"}
 
         response = self._ctx.client.get(f"v1/content/{guid}", params=params)
         return ContentItem(self._ctx, **response.json())

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -983,16 +983,34 @@ class Content(Resources):
         items = self.find(**conditions)
         return next(iter(items), None)
 
-    def get(self, guid: str) -> ContentItem:
+    def get(
+        self,
+        guid: str,
+        *,
+        include: Optional[
+            Literal["owner", "tags", "vanity_url"] | list[Literal["owner", "tags", "vanity_url"]]
+        ] = None,
+    ) -> ContentItem:
         """Get a content item.
 
         Parameters
         ----------
         guid : str
+            The unique identifier of the content item.
+        include : str or list of str, optional
+            Additional details to include in the response.
+            Allowed values: 'owner', 'tags', 'vanity_url'.
 
         Returns
         -------
         ContentItem
         """
-        response = self._ctx.client.get(f"v1/content/{guid}")
+        params = {}
+        if include is not None:
+            if isinstance(include, list):
+                params["include"] = ",".join(include)
+            else:
+                params["include"] = include
+
+        response = self._ctx.client.get(f"v1/content/{guid}", params=params)
         return ContentItem(self._ctx, **response.json())

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -169,7 +169,7 @@ class TestContentsFind:
         assert content[2]["name"] == "My-Streamlit-app"
 
     @responses.activate
-    def test_params_include(self):
+    def test_params_include_string(self):
         # behavior
         mock_get = responses.get(
             "https://connect.example/__api__/v1/content",
@@ -200,24 +200,6 @@ class TestContentsFind:
 
         # invoke
         client.content.find(include=["tags", "owner"])
-
-        #  assert
-        assert mock_get.call_count == 1
-
-    @responses.activate
-    def test_params_include_none(self):
-        # behavior
-        mock_get = responses.get(
-            "https://connect.example/__api__/v1/content",
-            json=load_mock("v1/content.json"),
-            match=[matchers.query_param_matcher({})],
-        )
-
-        # setup
-        client = Client("https://connect.example", "12345")
-
-        # invoke
-        client.content.find(include=None)
 
         #  assert
         assert mock_get.call_count == 1
@@ -373,6 +355,38 @@ class TestContentsGet:
         get_one = con.content.get("f2f37341-e21d-3d80-c698-a935ad614066")
         assert get_one["name"] == "Performance-Data-1671216053560"
 
+    @responses.activate
+    def test_get_with_include_string(self):
+        guid = "f2f37341-e21d-3d80-c698-a935ad614066"
+        mock_get = responses.get(
+            f"https://connect.example/__api__/v1/content/{guid}",
+            json=load_mock(f"v1/content/{guid}.json"),
+            match=[matchers.query_param_matcher({"include": "owner"})],
+        )
+
+        con = Client("https://connect.example", "12345")
+        content = con.content.get(guid, include="owner")
+        assert content["guid"] == guid
+
+        #  assert
+        assert mock_get.call_count == 1
+
+
+    @responses.activate
+    def test_get_with_include_list(self):
+        guid = "f2f37341-e21d-3d80-c698-a935ad614066"
+        mock_get = responses.get(
+            f"https://connect.example/__api__/v1/content/{guid}",
+            json=load_mock(f"v1/content/{guid}.json"),
+            match=[matchers.query_param_matcher({"include": "owner,tags,vanity_url"})],
+        )
+
+        con = Client("https://connect.example", "12345")
+        content = con.content.get(guid, include=["owner", "tags", "vanity_url"])
+        assert content["guid"] == guid
+
+        #  assert
+        assert mock_get.call_count == 1
 
 class TestContentsCount:
     @responses.activate

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -325,7 +325,7 @@ class TestContentsFindOne:
         assert content_item["name"] == name
 
     @responses.activate
-    def test_params_include(self):
+    def test_params_include_string(self):
         # behavior
         mock_get = responses.get(
             "https://connect.example/__api__/v1/content",
@@ -373,7 +373,7 @@ class TestContentsGet:
         assert get_one["name"] == "Performance-Data-1671216053560"
 
     @responses.activate
-    def test_get_with_include_string(self):
+    def test_params_include_string(self):
         guid = "f2f37341-e21d-3d80-c698-a935ad614066"
         mock_get = responses.get(
             f"https://connect.example/__api__/v1/content/{guid}",
@@ -390,7 +390,7 @@ class TestContentsGet:
 
 
     @responses.activate
-    def test_get_with_include_list(self):
+    def test_params_include_list(self):
         guid = "f2f37341-e21d-3d80-c698-a935ad614066"
         mock_get = responses.get(
             f"https://connect.example/__api__/v1/content/{guid}",
@@ -406,7 +406,7 @@ class TestContentsGet:
         assert mock_get.call_count == 1
 
     @responses.activate
-    def test_get_with_include_none(self):
+    def test_params_include_none(self):
         guid = "f2f37341-e21d-3d80-c698-a935ad614066"
         mock_get = responses.get(
             f"https://connect.example/__api__/v1/content/{guid}",

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -204,6 +204,23 @@ class TestContentsFind:
         #  assert
         assert mock_get.call_count == 1
 
+    @responses.activate
+    def test_params_include_none(self):
+        # behavior
+        mock_get = responses.get(
+            "https://connect.example/__api__/v1/content",
+            json=load_mock("v1/content.json"),
+            match=[matchers.query_param_matcher({})],
+        )
+
+        # setup
+        client = Client("https://connect.example", "12345")
+
+        # invoke
+        client.content.find(include=None)
+
+        #  assert
+        assert mock_get.call_count == 1
 
 class TestContentsFindBy:
     @responses.activate

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -405,6 +405,23 @@ class TestContentsGet:
         #  assert
         assert mock_get.call_count == 1
 
+    @responses.activate
+    def test_get_with_include_none(self):
+        guid = "f2f37341-e21d-3d80-c698-a935ad614066"
+        mock_get = responses.get(
+            f"https://connect.example/__api__/v1/content/{guid}",
+            json=load_mock(f"v1/content/{guid}.json"),
+            match=[matchers.query_param_matcher({})],
+        )
+
+        con = Client("https://connect.example", "12345")
+        content = con.content.get(guid, include=None)
+        assert content["guid"] == guid
+
+        # assert
+        assert mock_get.call_count == 1
+
+
 class TestContentsCount:
     @responses.activate
     def test(self):

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -222,6 +222,7 @@ class TestContentsFind:
         #  assert
         assert mock_get.call_count == 1
 
+
 class TestContentsFindBy:
     @responses.activate
     def test(self):
@@ -387,7 +388,6 @@ class TestContentsGet:
 
         #  assert
         assert mock_get.call_count == 1
-
 
     @responses.activate
     def test_params_include_list(self):

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -365,61 +365,15 @@ class TestContentsFindOne:
 class TestContentsGet:
     @responses.activate
     def test(self):
+        # All calls to get() should automatically include all available optional fields
         responses.get(
             "https://connect.example/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066",
             json=load_mock("v1/content/f2f37341-e21d-3d80-c698-a935ad614066.json"),
+            match=[matchers.query_param_matcher({"include": "owner,tags,vanity_url"})],
         )
         con = Client("https://connect.example", "12345")
         get_one = con.content.get("f2f37341-e21d-3d80-c698-a935ad614066")
         assert get_one["name"] == "Performance-Data-1671216053560"
-
-    @responses.activate
-    def test_params_include_string(self):
-        guid = "f2f37341-e21d-3d80-c698-a935ad614066"
-        mock_get = responses.get(
-            f"https://connect.example/__api__/v1/content/{guid}",
-            json=load_mock(f"v1/content/{guid}.json"),
-            match=[matchers.query_param_matcher({"include": "owner"})],
-        )
-
-        con = Client("https://connect.example", "12345")
-        content = con.content.get(guid, include="owner")
-        assert content["guid"] == guid
-
-        #  assert
-        assert mock_get.call_count == 1
-
-    @responses.activate
-    def test_params_include_list(self):
-        guid = "f2f37341-e21d-3d80-c698-a935ad614066"
-        mock_get = responses.get(
-            f"https://connect.example/__api__/v1/content/{guid}",
-            json=load_mock(f"v1/content/{guid}.json"),
-            match=[matchers.query_param_matcher({"include": "owner,tags,vanity_url"})],
-        )
-
-        con = Client("https://connect.example", "12345")
-        content = con.content.get(guid, include=["owner", "tags", "vanity_url"])
-        assert content["guid"] == guid
-
-        #  assert
-        assert mock_get.call_count == 1
-
-    @responses.activate
-    def test_params_include_none(self):
-        guid = "f2f37341-e21d-3d80-c698-a935ad614066"
-        mock_get = responses.get(
-            f"https://connect.example/__api__/v1/content/{guid}",
-            json=load_mock(f"v1/content/{guid}.json"),
-            match=[matchers.query_param_matcher({})],
-        )
-
-        con = Client("https://connect.example", "12345")
-        content = con.content.get(guid, include=None)
-        assert content["guid"] == guid
-
-        # assert
-        assert mock_get.call_count == 1
 
 
 class TestContentsCount:


### PR DESCRIPTION
Adds `include` param support for `content.get()`

- Add the param support, opting to hardcode it so it is always used
- Add unit test
- Add integration test
- Also manually verified by testing locally against a live Connect instance

Replaces previous fork PR: https://github.com/posit-dev/posit-sdk-py/pull/416