### PR TITLE
docs: Remove random string in examples, fix quotes

### DIFF
--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -121,7 +121,7 @@ class Client(ContextManager):
 
         Examples
         --------
-        >>> Client("https://connect.example.com", "{your API key}")
+        >>> Client("https://connect.example.com", os.getenv("CONNECT_API_KEY"))
         """
 
     def __init__(self, *args, **kwargs) -> None:
@@ -152,8 +152,8 @@ class Client(ContextManager):
         --------
         >>> Client()
         >>> Client("https://connect.example.com")
-        >>> Client("https://connect.example.com", "{your API key}")
-        >>> Client(api_key="{your API key}", url="https://connect.example.com")
+        >>> Client("https://connect.example.com", os.getenv("CONNECT_API_KEY"))
+        >>> Client(api_key=os.getenv("CONNECT_API_KEY"), url="https://connect.example.com")
         """
         api_key = None
         url = None


### PR DESCRIPTION
The string isn't actually an issue (since it's made up), but it was caught in [secret scanning](https://github.com/posit-dev/posit-sdk-py/security/secret-scanning/2). IMO it's nice(r) to be explicit about what one puts there (hence `{your API key}` rather than a random string that could (in shape at least) be an API key, but have the person figure out that's the thing that goes there.

I also fixed up some really wonky quotes. They were in comments so I'm not surprised nothing complained about this, but the lacking a quote and then one having double was really strange!