### PR TITLE
fix: accept single integration guid on association update

### DIFF
--- a/src/posit/connect/oauth/associations.py
+++ b/src/posit/connect/oauth/associations.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from functools import partial
 
-from typing_extensions import TYPE_CHECKING, List, Optional
+from typing_extensions import TYPE_CHECKING, List, Optional, overload
 
 from ..resources import BaseResource, Resources, _matches_exact, _matches_pattern
 
@@ -127,8 +127,33 @@ class ContentItemAssociations(Resources):
         path = f"v1/content/{self.content_guid}/oauth/integrations/associations"
         self._ctx.client.put(path, json=data)
 
-    def update(self, integration_guids: list[str]) -> None:
+    @overload
+    def update(self, integration_guid: str) -> None:
+        """Set a single integration association.
+
+        Parameters
+        ----------
+        integration_guid : str
+            The unique identifier of the integration.
+        """
+
+    @overload
+    def update(self, integration_guid: list[str]) -> None:
+        """Set multiple integration associations.
+
+        Parameters
+        ----------
+        integration_guids : list[str]
+            A list of unique identifiers of the integrations.
+        """
+
+    def update(self, integration_guid: str | list[str]) -> None:
         """Set integration associations."""
+        if isinstance(integration_guid, str):
+            integration_guids = [integration_guid]
+        else:
+            integration_guids = integration_guid
+
         data = [{"oauth_integration_guid": guid} for guid in integration_guids]
 
         path = f"v1/content/{self.content_guid}/oauth/integrations/associations"

--- a/tests/posit/connect/oauth/test_associations.py
+++ b/tests/posit/connect/oauth/test_associations.py
@@ -138,6 +138,36 @@ class TestContentAssociationsUpdate:
         assert mock_put.call_count == 1
         assert mock_get_content.call_count == 1
 
+    @responses.activate
+    def test_overload_str_type(self):
+        guid = "f2f37341-e21d-3d80-c698-a935ad614066"
+
+        # behavior
+        mock_get_content = responses.get(
+            f"https://connect.example/__api__/v1/content/{guid}",
+            json=load_mock(f"v1/content/{guid}.json"),
+        )
+
+        new_integration_guid = "00000000-a27b-4118-ad06-e24459b05126"
+
+        mock_put = responses.put(
+            f"https://connect.example/__api__/v1/content/{guid}/oauth/integrations/associations",
+            json=[
+                {"oauth_integration_guid": new_integration_guid},
+            ],
+        )
+
+        # setup
+        c = Client("https://connect.example", "12345")
+        c._ctx.version = None
+
+        # invoke
+        c.content.get(guid).oauth.associations.update(new_integration_guid)
+
+        # assert
+        assert mock_put.call_count == 1
+        assert mock_get_content.call_count == 1
+
 
 class TestContentAssociationsDelete:
     @responses.activate


### PR DESCRIPTION
Restores the functionaility described in the cookbook.

Fixes https://github.com/posit-dev/connect/issues/34607