### PR TITLE
chore: Correct example syntax in Client constructor

### DIFF
--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -105,7 +105,7 @@ class Client(ContextManager):
 
         Examples
         --------
-        Client("https://connect.example.com)
+        Client("https://connect.example.com")
         """
 
     @overload


### PR DESCRIPTION
#428 fixed most of the odd quotes but I saw this one was left