### PR TITLE
feat: adds `client.url` attribute which exposes the known server API URL

### DIFF
--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -70,6 +70,8 @@ class Client(ContextManager):
         Vanities resource.
     version: str
         The server version.
+    url: str
+        The server URL.
     """
 
     @overload
@@ -441,6 +443,18 @@ class Client(ContextManager):
             The version of the Posit Connect server.
         """
         return self._ctx.version
+
+    @property
+    def url(self) -> str:
+        """
+        The server URL.
+
+        Returns
+        -------
+        str
+            The URL of the Posit Connect server.
+        """
+        return self.cfg.url
 
     def __del__(self):
         """Close the session when the Client instance is deleted."""

--- a/tests/posit/connect/test_client.py
+++ b/tests/posit/connect/test_client.py
@@ -579,6 +579,13 @@ class TestClient:
             "https://connect.example.com/__api__/foo"
         )
 
+    def test_url(self, MockConfig):
+        api_key = "12345"
+        url = "https://connect.example.com"
+        client = Client(api_key=api_key, url=url)
+        MockConfig.return_value.url = "https://connect.example.com/__api__"
+        assert client.url == "https://connect.example.com/__api__"
+
 
 class TestClientOAuth:
     def test_required_version(self):


### PR DESCRIPTION
Resolves #440 