### PR TITLE
fix: Pin griffe==1.3.2 for quartodoc compatibility with Python 3.14

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,7 +7,7 @@ CURRENT_YEAR ?= $(shell date +%Y)
 # Quarto settings
 QUARTO ?= quarto
 # quartodoc doesn't like py3.8; Run using `--with` as it can conflict with the project's dependencies
-QUARTODOC ?= --no-cache --with "quartodoc==0.11.1" quartodoc
+QUARTODOC ?= --no-cache --with "quartodoc==0.11.1" --with "griffe==1.3.2" quartodoc
 
 # Netlify settings
 NETLIFY_SITE_ID ?= 5cea1f56-7935-4387-975a-18a7905d15ee


### PR DESCRIPTION
Without this pin, Python 3.14 installs the latest griffe which has a breaking change where parse_numpy() no longer accepts the allow_section_blank_line argument that quartodoc 0.11.1 tries to pass.

fixes #452 