### PR TITLE
feat: add has_content_credentials and return None from get_content_credentials

### DIFF
--- a/src/posit/connect/external/aws.py
+++ b/src/posit/connect/external/aws.py
@@ -131,6 +131,8 @@ def get_content_credentials(
         requested_token_type=OAuthTokenType.AWS_CREDENTIALS,
         audience=audience,
     )
+    if credentials is None:
+        raise ValueError("No content session token is available for credential exchange.")
 
     # Decode base64 access token
     access_token = credentials.get("access_token")

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -72,6 +72,8 @@ class _PositConnectContentCredentialsProvider:
 
     def __call__(self) -> Dict[str, str]:
         credentials = self._client.oauth.get_content_credentials(audience=self._audience)
+        if credentials is None:
+            raise ValueError("No content session token is available for credential exchange.")
         return _new_bearer_authorization_header(credentials)
 
 

--- a/src/posit/connect/external/snowflake.py
+++ b/src/posit/connect/external/snowflake.py
@@ -110,5 +110,7 @@ class PositAuthenticator:
                 self._content_session_token,
                 audience=self._audience,
             )
+            if credentials is None:
+                raise ValueError("No content session token is available for credential exchange.")
 
         return credentials.get("access_token")

--- a/src/posit/connect/oauth/oauth.py
+++ b/src/posit/connect/oauth/oauth.py
@@ -49,7 +49,7 @@ def _get_content_session_token() -> Optional[str]:
         except FileNotFoundError:
             pass
 
-    return os.environ.get("CONNECT_CONTENT_SESSION_TOKEN") or None
+    return os.environ.get("CONNECT_CONTENT_SESSION_TOKEN")
 
 
 class OAuth(Resources):

--- a/src/posit/connect/oauth/oauth.py
+++ b/src/posit/connect/oauth/oauth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 
 from typing_extensions import TYPE_CHECKING, Optional, TypedDict
@@ -19,40 +20,36 @@ GRANT_TYPE = types.GRANT_TYPE
 OAuthTokenType = types.OAuthTokenType
 
 
-def _get_content_session_token() -> str:
-    """Return the content session token.
+logger = logging.getLogger(__name__)
+
+
+def _get_content_session_token() -> Optional[str]:
+    """Return the content session token, if available.
 
     Reads the token from the file specified by the environment variable
     'CONNECT_CONTENT_SESSION_TOKEN_FILE' if set, otherwise falls back to the
     environment variable 'CONNECT_CONTENT_SESSION_TOKEN'.
 
-    Raises
-    ------
-        ValueError: If neither environment variable is set or the token is invalid
-
     Returns
     -------
-        str
+    Optional[str]
+        The content session token, or None if not available.
     """
     token_file = os.environ.get("CONNECT_CONTENT_SESSION_TOKEN_FILE")
     if token_file:
         try:
             with open(token_file) as f:
                 value = f.read().strip()
-            if not value:
-                raise ValueError(
-                    "Invalid value for 'CONNECT_CONTENT_SESSION_TOKEN_FILE': File must contain a non-empty string."
-                )
-            return value
+            if value:
+                return value
+            logger.warning(
+                "CONNECT_CONTENT_SESSION_TOKEN_FILE is set to '%s', but the file is empty.",
+                token_file,
+            )
         except FileNotFoundError:
             pass
 
-    value = os.environ.get("CONNECT_CONTENT_SESSION_TOKEN")
-    if not value:
-        raise ValueError(
-            "Invalid value for 'CONNECT_CONTENT_SESSION_TOKEN': Must be a non-empty string."
-        )
-    return value
+    return os.environ.get("CONNECT_CONTENT_SESSION_TOKEN") or None
 
 
 class OAuth(Resources):
@@ -104,12 +101,25 @@ class OAuth(Resources):
         response = self._ctx.client.post(self._path, data=data)
         return Credentials(**response.json())
 
+    def has_content_credentials(self) -> bool:
+        """Check whether OAuth content credentials are available.
+
+        Returns True if a content session token is present in the environment,
+        indicating that this code is running on Posit Connect with OAuth
+        content credentials configured.
+
+        Returns
+        -------
+        bool
+        """
+        return _get_content_session_token() is not None
+
     def get_content_credentials(
         self,
         content_session_token: Optional[str] = None,
         requested_token_type: Optional[str | types.OAuthTokenType] = None,
         audience: Optional[str] = None,
-    ) -> Credentials:
+    ) -> Optional[Credentials]:
         """Perform an oauth credential exchange with a content-session-token.
 
         Parameters
@@ -123,15 +133,19 @@ class OAuth(Resources):
 
         Returns
         -------
-        Credentials
-            The credentials obtained from the exchange.
-
+        Optional[Credentials]
+            The credentials obtained from the exchange, or None if no content
+            session token is available.
         """
+        token = content_session_token or _get_content_session_token()
+        if token is None:
+            return None
+
         # craft a credential exchange request
         data = {}
         data["grant_type"] = types.GRANT_TYPE
         data["subject_token_type"] = types.OAuthTokenType.CONTENT_SESSION_TOKEN
-        data["subject_token"] = content_session_token or _get_content_session_token()
+        data["subject_token"] = token
         if requested_token_type:
             data["requested_token_type"] = requested_token_type
         if audience:

--- a/tests/posit/connect/oauth/test_oauth.py
+++ b/tests/posit/connect/oauth/test_oauth.py
@@ -83,7 +83,6 @@ class TestHasContentCredentials:
 
 
 class TestOAuthIntegrations:
-
     @responses.activate
     def test_get_credentials(self):
         responses.post(

--- a/tests/posit/connect/oauth/test_oauth.py
+++ b/tests/posit/connect/oauth/test_oauth.py
@@ -1,6 +1,6 @@
+import logging
 from unittest.mock import patch
 
-import pytest
 import responses
 
 from posit.connect import Client
@@ -13,8 +13,7 @@ class TestGetContentSessionToken:
         assert _get_content_session_token() == "cit"
 
     def test_no_env_var(self):
-        with pytest.raises(ValueError, match="CONNECT_CONTENT_SESSION_TOKEN"):
-            _get_content_session_token()
+        assert _get_content_session_token() is None
 
     def test_token_file(self, tmp_path):
         token_file = tmp_path / "token"
@@ -45,12 +44,42 @@ class TestGetContentSessionToken:
         ):
             assert _get_content_session_token() == "env-token"
 
-    def test_token_file_empty(self, tmp_path):
+    def test_token_file_empty(self, tmp_path, caplog):
         token_file = tmp_path / "token"
         token_file.write_text("")
         with patch.dict("os.environ", {"CONNECT_CONTENT_SESSION_TOKEN_FILE": str(token_file)}):
-            with pytest.raises(ValueError, match="CONNECT_CONTENT_SESSION_TOKEN_FILE"):
-                _get_content_session_token()
+            with caplog.at_level(logging.WARNING):
+                assert _get_content_session_token() is None
+            assert "file is empty" in caplog.text
+
+
+class TestHasContentCredentials:
+    @patch.dict("os.environ", {"CONNECT_CONTENT_SESSION_TOKEN": "cit"})
+    def test_true_with_env_var(self):
+        c = Client(api_key="12345", url="https://connect.example/")
+        c._ctx.version = None
+        assert c.oauth.has_content_credentials() is True
+
+    def test_false_without_env_var(self):
+        c = Client(api_key="12345", url="https://connect.example/")
+        c._ctx.version = None
+        assert c.oauth.has_content_credentials() is False
+
+    def test_true_with_token_file(self, tmp_path):
+        token_file = tmp_path / "token"
+        token_file.write_text("file-token")
+        with patch.dict("os.environ", {"CONNECT_CONTENT_SESSION_TOKEN_FILE": str(token_file)}):
+            c = Client(api_key="12345", url="https://connect.example/")
+            c._ctx.version = None
+            assert c.oauth.has_content_credentials() is True
+
+    def test_false_with_empty_token_file(self, tmp_path):
+        token_file = tmp_path / "token"
+        token_file.write_text("")
+        with patch.dict("os.environ", {"CONNECT_CONTENT_SESSION_TOKEN_FILE": str(token_file)}):
+            c = Client(api_key="12345", url="https://connect.example/")
+            c._ctx.version = None
+            assert c.oauth.has_content_credentials() is False
 
 
 class TestOAuthIntegrations:
@@ -130,6 +159,7 @@ class TestOAuthIntegrations:
         c = Client(api_key="12345", url="https://connect.example/")
         c._ctx.version = None
         creds = c.oauth.get_content_credentials("cit")
+        assert creds is not None
         assert creds.get("access_token") == "content-token"
 
     @responses.activate
@@ -155,6 +185,7 @@ class TestOAuthIntegrations:
         c = Client(api_key="12345", url="https://connect.example/")
         c._ctx.version = None
         creds = c.oauth.get_content_credentials("cit", OAuthTokenType.AWS_CREDENTIALS)
+        assert creds is not None
         assert creds.get("access_token") == "encoded-aws-creds"
         assert creds.get("issued_token_type") == "urn:ietf:params:aws:token-type:credentials"
         assert creds.get("token_type") == "aws_credentials"
@@ -182,7 +213,13 @@ class TestOAuthIntegrations:
         c = Client(api_key="12345", url="https://connect.example/")
         c._ctx.version = None
         creds = c.oauth.get_content_credentials()
+        assert creds is not None
         assert creds.get("access_token") == "content-token"
+
+    def test_get_content_credentials_returns_none_without_token(self):
+        c = Client(api_key="12345", url="https://connect.example/")
+        c._ctx.version = None
+        assert c.oauth.get_content_credentials() is None
 
     @responses.activate
     def test_get_content_credentials_with_audience(self):
@@ -207,6 +244,7 @@ class TestOAuthIntegrations:
         c = Client(api_key="12345", url="https://connect.example/")
         c._ctx.version = None
         creds = c.oauth.get_content_credentials("cit", audience="integration-guid")
+        assert creds is not None
         assert creds.get("access_token") == "content-token"
         assert creds.get("issued_token_type") == "urn:ietf:params:oauth:token-type:access_token"
         assert creds.get("token_type") == "Bearer"


### PR DESCRIPTION
## Summary

- Adds `OAuth.has_content_credentials()` method so applications can check whether OAuth content credentials are available without manually inspecting `CONNECT_CONTENT_SESSION_TOKEN*` environment variables
- Changes `OAuth.get_content_credentials()` to return `None` instead of raising `ValueError` when no content session token is available
- Logs a warning when the token file exists but is empty

### Example usage

```python
from posit import connect

client = connect.Client()

if client.oauth.has_content_credentials():
    credentials = client.oauth.get_content_credentials()
    token = credentials["access_token"]

# Or simply:
credentials = client.oauth.get_content_credentials()
if credentials is not None:
    token = credentials["access_token"]
```

Closes #458

## Test plan

- [x] Existing tests updated for new return type (`None` instead of `ValueError`)
- [x] New tests for `has_content_credentials` (env var present, absent, token file present, empty token file)
- [x] New test for `get_content_credentials` returning `None` without token
- [x] Warning logged when token file is empty
- [x] All 398 tests pass