### PR TITLE
feat(connect): add bootstrap auth, TLS verify, python settings, content build

### DIFF
--- a/src/posit/connect/auth.py
+++ b/src/posit/connect/auth.py
@@ -16,3 +16,25 @@ class Auth(AuthBase):
         """Add authorization header to the request."""
         r.headers["Authorization"] = f"Key {self._config.api_key}"
         return r
+
+
+class BootstrapAuth(AuthBase):
+    """Handles bootstrap authentication for initial server setup.
+
+    Used with the ``v1/experimental/bootstrap`` endpoint to perform first-time
+    server configuration. After bootstrapping, use the returned API key with
+    the standard :class:`Auth` class.
+
+    Parameters
+    ----------
+    token : str
+        The bootstrap JWT token.
+    """
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def __call__(self, r: PreparedRequest) -> PreparedRequest:
+        """Add bootstrap authorization header to the request."""
+        r.headers["Authorization"] = f"Connect-Bootstrap {self._token}"
+        return r

--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from typing_extensions import TYPE_CHECKING, Optional, overload
+from typing_extensions import TYPE_CHECKING, Optional, Union, overload
 
-from . import hooks, me
-from .auth import Auth
+from . import hooks, me, urls
+from .auth import Auth, BootstrapAuth
 from .config import Config
 from .content import Content
 from .context import Context, ContextManager, requires
@@ -40,7 +40,11 @@ class Client(ContextManager):
     api_key : str, optional
         API key for authentication
     url : str, optional
-        Sever API URL
+        Server URL
+    verify : bool or str, optional
+        Controls TLS certificate verification. Pass ``False`` to disable
+        verification (not recommended for production), or a path string to a
+        CA bundle file or directory. Defaults to ``True``.
 
     Attributes
     ----------
@@ -58,6 +62,8 @@ class Client(ContextManager):
         OAuth resource.
     packages: Packages
         Packages resource.
+    python_settings: dict
+        Python installation settings from the server.
     system: System
         System resource.
     tags: Tags
@@ -73,7 +79,7 @@ class Client(ContextManager):
     """
 
     @overload
-    def __init__(self) -> None:
+    def __init__(self, *, verify: Union[bool, str] = ...) -> None:
         """Initialize a Client instance.
 
         Creates a client instance using credentials read from the environment.
@@ -89,7 +95,7 @@ class Client(ContextManager):
         """
 
     @overload
-    def __init__(self, url: str) -> None:
+    def __init__(self, url: str, *, verify: Union[bool, str] = ...) -> None:
         """Initialize a Client instance.
 
         Creates a client instance using a provided URL and API key credential read from the environment.
@@ -109,7 +115,7 @@ class Client(ContextManager):
         """
 
     @overload
-    def __init__(self, url: str, api_key: str) -> None:
+    def __init__(self, url: str, api_key: str, *, verify: Union[bool, str] = ...) -> None:
         """Initialize a Client instance.
 
         Parameters
@@ -146,7 +152,12 @@ class Client(ContextManager):
                     The API key credential for client authentication.
 
         **kwargs
-            Keyword arguments. Can include 'url' and 'api_key'.
+            Keyword arguments. Can include 'url', 'api_key', and 'verify'.
+
+        verify : bool or str, optional
+            Controls TLS certificate verification. Pass ``False`` to disable
+            verification, or a path to a CA bundle file/directory. Defaults
+            to ``True``.
 
         Examples
         --------
@@ -154,7 +165,10 @@ class Client(ContextManager):
         >>> Client("https://connect.example.com")
         >>> Client("https://connect.example.com", os.getenv("CONNECT_API_KEY"))
         >>> Client(api_key=os.getenv("CONNECT_API_KEY"), url="https://connect.example.com")
+        >>> Client(url="https://connect.example.com", verify=False)
+        >>> Client(url="https://connect.example.com", verify="/path/to/ca-bundle.crt")
         """
+        verify = kwargs.pop("verify", True)
         api_key = None
         url = None
         if len(args) == 1 and isinstance(args[0], str):
@@ -170,6 +184,7 @@ class Client(ContextManager):
 
         self.cfg = Config(api_key=api_key, url=url)
         session = Session()
+        session.verify = verify
         session.auth = Auth(config=self.cfg)
         session.hooks["response"].append(hooks.check_for_deprecation_header)
         session.hooks["response"].append(hooks.handle_errors)
@@ -288,6 +303,45 @@ class Client(ContextManager):
 
         return Client(url=self.cfg.url, api_key=visitor_api_key)
 
+    @staticmethod
+    def bootstrap(url: str, token: str, *, verify: Union[bool, str] = True) -> dict:
+        """Bootstrap a Connect server using a JWT token.
+
+        Calls the ``v1/experimental/bootstrap`` endpoint with bootstrap
+        authentication to perform first-time server initialization. Returns
+        the full response dict, which includes the ``api_key`` that can be
+        used to create a standard :class:`Client`.
+
+        Parameters
+        ----------
+        url : str
+            The Connect server URL.
+        token : str
+            The bootstrap JWT token.
+        verify : bool or str, optional
+            Controls TLS certificate verification. Pass ``False`` to disable
+            verification, or a path to a CA bundle. Defaults to ``True``.
+
+        Returns
+        -------
+        dict
+            The bootstrap response. The ``api_key`` field contains the API key
+            for subsequent authenticated requests.
+
+        Examples
+        --------
+        >>> result = Client.bootstrap("https://connect.example.com", jwt_token)
+        >>> client = Client("https://connect.example.com", result["api_key"])
+        """
+        session = Session()
+        session.verify = verify
+        session.auth = BootstrapAuth(token=token)
+        session.hooks["response"].append(hooks.handle_errors)
+        url_obj = urls.Url(url)
+        response = session.post(url_obj + "v1/experimental/bootstrap", json={})
+        session.close()
+        return response.json()
+
     @property
     def content(self) -> Content:
         """
@@ -375,6 +429,28 @@ class Client(ContextManager):
         return _PaginatedResourceSequence(
             self._ctx, "v1/packages", uid="name", page_size=1_000_000
         )
+
+    @property
+    def python_settings(self) -> dict:
+        """Python installation settings from the server.
+
+        Retrieves information about the Python installations available on the
+        Connect server, including version and path for each installation.
+
+        Returns
+        -------
+        dict
+            The server's Python settings. Contains an ``installations`` list
+            where each entry has ``version`` and ``path`` fields.
+
+        Examples
+        --------
+        >>> settings = client.python_settings
+        >>> for install in settings["installations"]:
+        ...     print(install["version"])
+        """
+        response = self.get("v1/server_settings/python")
+        return response.json()
 
     @property
     def system(self) -> System:

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -520,6 +520,54 @@ class ContentItem(Active, ContentItemRepositoryMixin, VanityMixin, BaseResource)
         ts = tasks.Tasks(self._ctx)
         return ts.get(result["task_id"])
 
+    def build(
+        self,
+        bundle_id: Optional[str] = None,
+        *,
+        activate: bool = True,
+    ) -> tasks.Task:
+        """Build the content from a bundle.
+
+        Spawns an asynchronous task that builds the content environment from
+        the specified bundle (or the active bundle if none is given). Unlike
+        :meth:`deploy`, this method allows rebuilding the environment without
+        necessarily activating the bundle.
+
+        Parameters
+        ----------
+        bundle_id : str, optional
+            The identifier of the bundle to build. If omitted, the active
+            bundle is used.
+        activate : bool, optional
+            Whether to activate the bundle after building. Defaults to
+            ``True``. Pass ``False`` to build the environment without
+            making the bundle active.
+
+        Returns
+        -------
+        tasks.Task
+            The task for the build operation.
+
+        Examples
+        --------
+        >>> task = content.build()
+        >>> task.wait_for()
+        None
+
+        Build without activating:
+        >>> task = content.build(activate=False)
+        >>> task.wait_for()
+        None
+        """
+        path = f"v1/content/{self['guid']}/build"
+        body: dict = {"bundle_id": bundle_id}
+        if not activate:
+            body["activate"] = False
+        response = self._ctx.client.post(path, json=body)
+        result = response.json()
+        ts = tasks.Tasks(self._ctx)
+        return ts.get(result["task_id"])
+
     def render(self) -> Task:
         """Render the content.
 

--- a/tests/posit/connect/test_auth.py
+++ b/tests/posit/connect/test_auth.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock, Mock, patch
 
-from posit.connect.auth import Auth
+from posit.connect.auth import Auth, BootstrapAuth
 
 
 class TestAuth:
@@ -13,3 +13,13 @@ class TestAuth:
         r.headers = {}
         auth(r)
         assert r.headers == {"Authorization": f"Key {config.api_key}"}
+
+
+class TestBootstrapAuth:
+    def test_auth_headers(self):
+        token = "my-bootstrap-jwt"
+        auth = BootstrapAuth(token=token)
+        r = Mock()
+        r.headers = {}
+        auth(r)
+        assert r.headers == {"Authorization": f"Connect-Bootstrap {token}"}

--- a/tests/posit/connect/test_client.py
+++ b/tests/posit/connect/test_client.py
@@ -70,6 +70,33 @@ class TestClientInit:
         Client(api_key=api_key, url=url)
         MockConfig.assert_called_once_with(api_key=api_key, url=url)
 
+    def test_verify_default(
+        self,
+        MockAuth: MagicMock,
+        MockConfig: MagicMock,
+        MockSession: MagicMock,
+    ):
+        Client(url="https://connect.example.com", api_key="12345")
+        assert MockSession.return_value.verify is True
+
+    def test_verify_false(
+        self,
+        MockAuth: MagicMock,
+        MockConfig: MagicMock,
+        MockSession: MagicMock,
+    ):
+        Client(url="https://connect.example.com", api_key="12345", verify=False)
+        assert MockSession.return_value.verify is False
+
+    def test_verify_ca_bundle(
+        self,
+        MockAuth: MagicMock,
+        MockConfig: MagicMock,
+        MockSession: MagicMock,
+    ):
+        Client(url="https://connect.example.com", api_key="12345", verify="/path/to/ca.crt")
+        assert MockSession.return_value.verify == "/path/to/ca.crt"
+
 
 class TestClient:
     def test_init(
@@ -578,6 +605,65 @@ class TestClient:
         MockSession.return_value.delete.assert_called_once_with(
             "https://connect.example.com/__api__/foo"
         )
+
+
+class TestClientBootstrap:
+    @responses.activate
+    def test_bootstrap(self):
+        url = "https://connect.example.com"
+        token = "my-jwt"
+        api_key = "returned-api-key"
+
+        mock_bootstrap = responses.post(
+            f"{url}/__api__/v1/experimental/bootstrap",
+            match=[responses.matchers.json_params_matcher({})],
+            json={"api_key": api_key},
+        )
+
+        result = Client.bootstrap(url, token)
+
+        assert result["api_key"] == api_key
+        assert mock_bootstrap.call_count == 1
+        # Verify the Authorization header uses Bootstrap scheme
+        assert mock_bootstrap.calls[0].request.headers["Authorization"] == f"Connect-Bootstrap {token}"
+
+    @responses.activate
+    def test_bootstrap_verify_false(self):
+        url = "https://connect.example.com"
+        token = "my-jwt"
+
+        responses.post(
+            f"{url}/__api__/v1/experimental/bootstrap",
+            json={"api_key": "key"},
+        )
+
+        # Should not raise even with verify=False
+        result = Client.bootstrap(url, token, verify=False)
+        assert "api_key" in result
+
+
+class TestClientPythonSettings:
+    @responses.activate
+    def test_python_settings(self):
+        url = "https://connect.example.com"
+        api_key = "12345"
+        python_settings = {
+            "installations": [
+                {"version": "3.9.0", "path": "/usr/bin/python3"},
+                {"version": "3.11.0", "path": "/usr/local/bin/python3"},
+            ]
+        }
+
+        responses.get(
+            f"{url}/__api__/v1/server_settings/python",
+            json=python_settings,
+        )
+
+        client = Client(url=url, api_key=api_key)
+        result = client.python_settings
+
+        assert result == python_settings
+        assert len(result["installations"]) == 2
 
 
 class TestClientOAuth:

--- a/tests/posit/connect/test_content.py
+++ b/tests/posit/connect/test_content.py
@@ -96,6 +96,95 @@ class TestContentDeploy:
         assert mock_tasks_get.call_count == 1
 
 
+class TestContentBuild:
+    @responses.activate
+    def test_build_default(self):
+        content_guid = "f2f37341-e21d-3d80-c698-a935ad614066"
+        task_id = "jXhOhdm5OOSkGhJw"
+
+        mock_content_get = responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid}",
+            json=load_mock(f"v1/content/{content_guid}.json"),
+        )
+
+        mock_content_build = responses.post(
+            f"https://connect.example/__api__/v1/content/{content_guid}/build",
+            match=[matchers.json_params_matcher({"bundle_id": None})],
+            json={"task_id": task_id},
+        )
+
+        mock_tasks_get = responses.get(
+            f"https://connect.example/__api__/v1/tasks/{task_id}",
+            json=load_mock(f"v1/tasks/{task_id}.json"),
+        )
+
+        c = Client("https://connect.example", "12345")
+        content = c.content.get(content_guid)
+        task = content.build()
+
+        assert task["id"] == task_id
+        assert mock_content_get.call_count == 1
+        assert mock_content_build.call_count == 1
+        assert mock_tasks_get.call_count == 1
+
+    @responses.activate
+    def test_build_specific_bundle(self):
+        content_guid = "f2f37341-e21d-3d80-c698-a935ad614066"
+        bundle_id = "42"
+        task_id = "jXhOhdm5OOSkGhJw"
+
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid}",
+            json=load_mock(f"v1/content/{content_guid}.json"),
+        )
+
+        mock_content_build = responses.post(
+            f"https://connect.example/__api__/v1/content/{content_guid}/build",
+            match=[matchers.json_params_matcher({"bundle_id": bundle_id})],
+            json={"task_id": task_id},
+        )
+
+        responses.get(
+            f"https://connect.example/__api__/v1/tasks/{task_id}",
+            json=load_mock(f"v1/tasks/{task_id}.json"),
+        )
+
+        c = Client("https://connect.example", "12345")
+        content = c.content.get(content_guid)
+        task = content.build(bundle_id=bundle_id)
+
+        assert task["id"] == task_id
+        assert mock_content_build.call_count == 1
+
+    @responses.activate
+    def test_build_no_activate(self):
+        content_guid = "f2f37341-e21d-3d80-c698-a935ad614066"
+        task_id = "jXhOhdm5OOSkGhJw"
+
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid}",
+            json=load_mock(f"v1/content/{content_guid}.json"),
+        )
+
+        mock_content_build = responses.post(
+            f"https://connect.example/__api__/v1/content/{content_guid}/build",
+            match=[matchers.json_params_matcher({"bundle_id": None, "activate": False})],
+            json={"task_id": task_id},
+        )
+
+        responses.get(
+            f"https://connect.example/__api__/v1/tasks/{task_id}",
+            json=load_mock(f"v1/tasks/{task_id}.json"),
+        )
+
+        c = Client("https://connect.example", "12345")
+        content = c.content.get(content_guid)
+        task = content.build(activate=False)
+
+        assert task["id"] == task_id
+        assert mock_content_build.call_count == 1
+
+
 class TestContentUpdate:
     @responses.activate
     def test_update(self):


### PR DESCRIPTION
## Summary
- Adds `Client.bootstrap()` + `BootstrapAuth` for exchanging a short-lived JWT for a Connect API key.
- Adds a `verify` parameter to `Client` so callers can point at a custom CA bundle (or, not recommended, disable TLS verification).
- Adds a custom `Session` class in `sessions.py` that preserves POST bodies across redirects (mimics libcurl's `CURLOPT_POSTREDIR`).
- Adds Python settings and a content build endpoint.

## Test plan
- [ ] CI
- [ ] Manual smoke test of bootstrap against a dev Connect instance