### PR TITLE
fix(connect): strip Authorization on cross-origin redirects in custom Session

### DIFF
--- a/src/posit/connect/sessions.py
+++ b/src/posit/connect/sessions.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import requests
 
@@ -85,6 +85,10 @@ class Session(requests.Session):
 
             redirect_url = urljoin(response.url, redirect_url)
 
+            parsed_redirect = urlparse(redirect_url)
+            if parsed_redirect.scheme not in ("http", "https"):
+                break
+
             # For 307 and 308 the HTTP spec mandates preserving the method and body.
             if response.status_code in (307, 308):
                 method = "POST"
@@ -96,8 +100,29 @@ class Session(requests.Session):
                     data = None
                     json = None
 
+            # Strip credentials on cross-origin redirects to prevent leaking
+            # the Authorization header / session auth to a different host.
+            request_kwargs = dict(kwargs)
+            parsed_current = urlparse(response.url)
+            same_origin = (
+                parsed_current.scheme == parsed_redirect.scheme
+                and parsed_current.hostname == parsed_redirect.hostname
+                and parsed_current.port == parsed_redirect.port
+            )
+            if not same_origin:
+                headers = dict(request_kwargs.get("headers") or {})
+                headers = {
+                    k: v for k, v in headers.items() if k.lower() != "authorization"
+                }
+                # Setting to None suppresses any matching session-level header.
+                headers["Authorization"] = None
+                request_kwargs["headers"] = headers
+                request_kwargs["auth"] = None
+
             # Perform the next request in the redirect chain.
-            response = self.request(method, redirect_url, data=data, json=json, **kwargs)
+            response = self.request(
+                method, redirect_url, data=data, json=json, **request_kwargs
+            )
             redirect_count += 1
 
         return response

--- a/tests/posit/connect/test_sessions.py
+++ b/tests/posit/connect/test_sessions.py
@@ -117,6 +117,84 @@ def test_post_redirect_no_location():
 
 
 @responses.activate
+def test_post_cross_origin_redirect_strips_authorization():
+    initial_url = "https://example.com/api"
+    attacker_url = "https://attacker.example/steal"
+
+    responses.add(
+        responses.POST, initial_url, status=302, headers={"location": attacker_url}
+    )
+    responses.add(responses.POST, attacker_url, json={"ok": True}, status=200)
+
+    session = Session()
+    session.headers["Authorization"] = "Key super-secret"
+
+    response = session.post(initial_url, data={"key": "value"}, preserve_post=True)
+
+    assert response.status_code == 200
+    assert len(responses.calls) == 2
+    assert responses.calls[0].request.headers.get("Authorization") == "Key super-secret"
+    assert "Authorization" not in responses.calls[1].request.headers
+
+
+@responses.activate
+def test_post_cross_origin_redirect_strips_header_kwarg_authorization():
+    initial_url = "https://example.com/api"
+    attacker_url = "https://attacker.example/steal"
+
+    responses.add(
+        responses.POST, initial_url, status=302, headers={"location": attacker_url}
+    )
+    responses.add(responses.POST, attacker_url, json={"ok": True}, status=200)
+
+    session = Session()
+    response = session.post(
+        initial_url,
+        data={"key": "value"},
+        headers={"Authorization": "Bearer jwt-token"},
+        preserve_post=True,
+    )
+
+    assert response.status_code == 200
+    assert "Authorization" not in responses.calls[1].request.headers
+
+
+@responses.activate
+def test_post_same_origin_redirect_preserves_authorization():
+    initial_url = "https://example.com/api"
+    redirect_url = "https://example.com/next"
+
+    responses.add(
+        responses.POST, initial_url, status=302, headers={"location": "/next"}
+    )
+    responses.add(responses.POST, redirect_url, json={"ok": True}, status=200)
+
+    session = Session()
+    session.headers["Authorization"] = "Key super-secret"
+
+    response = session.post(initial_url, data={"key": "value"}, preserve_post=True)
+
+    assert response.status_code == 200
+    assert len(responses.calls) == 2
+    assert responses.calls[1].request.headers.get("Authorization") == "Key super-secret"
+
+
+@responses.activate
+def test_post_redirect_rejects_non_http_scheme():
+    initial_url = "https://example.com/api"
+
+    responses.add(
+        responses.POST, initial_url, status=302, headers={"location": "file:///etc/passwd"}
+    )
+
+    session = Session()
+    response = session.post(initial_url, data={"key": "value"})
+
+    assert len(responses.calls) == 1
+    assert response.status_code == 302
+
+
+@responses.activate
 def test_post_redirect_location_none_explicit():
     url = "http://connect.example.com/api"
 


### PR DESCRIPTION
## Summary
The custom `Session.post` in `src/posit/connect/sessions.py` manually follows redirects with `allow_redirects=False`, bypassing `requests.SessionRedirectMixin.rebuild_auth`. On a cross-origin redirect, the session's `Authorization` header (Connect API key or bootstrap JWT) was forwarded to the attacker-controlled host named in `Location` — including protocol-relative `//attacker/...` resolved via `urljoin`.

- Adds a scheme/hostname/port same-origin check before re-dispatching.
- On a cross-origin hop: strips `Authorization` from the outgoing headers kwarg and passes `auth=None` for that request.
- Rejects redirects whose scheme is not `http`/`https`.
- 307/308 and `preserve_post` behavior unchanged.

## Test plan
- [x] New tests in `tests/posit/connect/test_sessions.py` (12 passing):
  - cross-origin strips session-level Authorization
  - cross-origin strips header-kwarg Authorization
  - same-origin preserves Authorization
  - non-http(s) scheme rejected
- [ ] CI