### PR TITLE
fix(connect): warn when TLS verification is disabled

### DIFF
--- a/src/posit/connect/client.py
+++ b/src/posit/connect/client.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
+import warnings
+
 from typing_extensions import TYPE_CHECKING, Optional, Union, overload
+
+_TLS_VERIFY_DISABLED_WARNING = (
+    "TLS certificate verification is disabled. This is insecure and should "
+    "not be used in production. Pass a path to a CA bundle via `verify=` "
+    "instead."
+)
 
 from . import hooks, me, urls
 from .auth import Auth, BootstrapAuth
@@ -169,6 +177,12 @@ class Client(ContextManager):
         >>> Client(url="https://connect.example.com", verify="/path/to/ca-bundle.crt")
         """
         verify = kwargs.pop("verify", True)
+        if verify is False:
+            warnings.warn(
+                _TLS_VERIFY_DISABLED_WARNING,
+                UserWarning,
+                stacklevel=2,
+            )
         api_key = None
         url = None
         if len(args) == 1 and isinstance(args[0], str):

--- a/tests/posit/connect/test_client.py
+++ b/tests/posit/connect/test_client.py
@@ -85,8 +85,42 @@ class TestClientInit:
         MockConfig: MagicMock,
         MockSession: MagicMock,
     ):
-        Client(url="https://connect.example.com", api_key="12345", verify=False)
+        with pytest.warns(UserWarning, match="TLS certificate verification is disabled"):
+            Client(url="https://connect.example.com", api_key="12345", verify=False)
         assert MockSession.return_value.verify is False
+
+    def test_verify_false_emits_warning(
+        self,
+        MockAuth: MagicMock,
+        MockConfig: MagicMock,
+        MockSession: MagicMock,
+    ):
+        with pytest.warns(UserWarning, match="TLS certificate verification is disabled"):
+            Client(url="https://connect.example.com", api_key="12345", verify=False)
+
+    def test_verify_true_no_warning(
+        self,
+        MockAuth: MagicMock,
+        MockConfig: MagicMock,
+        MockSession: MagicMock,
+    ):
+        import warnings as _warnings
+
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error")
+            Client(url="https://connect.example.com", api_key="12345", verify=True)
+
+    def test_verify_ca_bundle_no_warning(
+        self,
+        MockAuth: MagicMock,
+        MockConfig: MagicMock,
+        MockSession: MagicMock,
+    ):
+        import warnings as _warnings
+
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error")
+            Client(url="https://connect.example.com", api_key="12345", verify="/path/to/ca.crt")
 
     def test_verify_ca_bundle(
         self,


### PR DESCRIPTION
## Summary
`Client(verify=False)` silently disabled all TLS certificate validation. This change emits a prominent `UserWarning` at `Client` construction when `verify is False`, recommending a CA bundle path instead.

- Strict `verify is False` identity check — `verify=True` and string CA bundle paths are unaffected.
- Warning fires once at construction, not per request.

## Test plan
- [x] Existing `test_verify_false` wrapped in `pytest.warns`
- [x] New `test_verify_false_emits_warning`
- [x] New `test_verify_true_no_warning` + `test_verify_ca_bundle_no_warning` (using `warnings.simplefilter("error")`)
- [x] 34 tests in `tests/posit/connect/test_client.py` pass
- [ ] CI

> Targets `feat/bootstrap-auth-tls-verify-python-settings-content-build` — the `verify=` parameter was introduced there (#463).