### PR TITLE
fix(connect): prevent URL host confusion in Url join

### DIFF
--- a/src/posit/connect/urls.py
+++ b/src/posit/connect/urls.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import posixpath
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import urljoin, urlsplit, urlunsplit
 
 
 class Url(str):
@@ -112,4 +112,64 @@ def _append(url: str, path) -> str:
     path = str(path).strip("/")
     split = urlsplit(url, allow_fragments=False)
     new_path = posixpath.join(split.path, path)
-    return urlunsplit((split.scheme, split.netloc, new_path, split.query, None))
+    joined = urlunsplit((split.scheme, split.netloc, new_path, split.query, None))
+    # Defense-in-depth: ensure the resulting URL still points at the original
+    # scheme+host+port. Guards against host-confusion if ``path`` is ever a
+    # fully-qualified or protocol-relative URL (e.g. ``//evil`` or
+    # ``https://evil``).
+    _assert_same_origin(url, joined)
+    return joined
+
+
+def _assert_same_origin(base: str, resolved: str) -> None:
+    """Raise ``ValueError`` if ``resolved`` is not same-origin with ``base``.
+
+    Compares scheme, hostname, and port. Used to defend URL joining against
+    user- or server-supplied fragments that would otherwise escape the
+    configured Connect base URL.
+    """
+    base_split = urlsplit(base, allow_fragments=False)
+    resolved_split = urlsplit(resolved, allow_fragments=False)
+    if (
+        base_split.scheme != resolved_split.scheme
+        or base_split.hostname != resolved_split.hostname
+        or base_split.port != resolved_split.port
+    ):
+        raise ValueError(
+            f"Refusing to resolve URL to a different origin: base={base!r}, resolved={resolved!r}"
+        )
+
+
+def safe_urljoin(base: str, fragment: str) -> str:
+    """Join ``fragment`` onto ``base`` without allowing host confusion.
+
+    Unlike :func:`urllib.parse.urljoin`, a ``fragment`` beginning with ``/``,
+    ``//host``, or ``https://host`` cannot change the scheme/host/port of the
+    resolved URL. The fragment is first normalized to a relative path by
+    stripping any leading ``/`` characters, then joined against ``base``. The
+    result is asserted to be same-origin with ``base``.
+
+    Parameters
+    ----------
+    base : str
+        The trusted base URL (typically the configured Connect URL).
+    fragment : str
+        A path fragment, possibly user- or server-supplied.
+
+    Returns
+    -------
+    str
+        The joined URL, guaranteed to share scheme+host+port with ``base``.
+
+    Raises
+    ------
+    ValueError
+        If the joined URL would not be same-origin with ``base``.
+    """
+    normalized = str(fragment).lstrip("/")
+    # Ensure base has a trailing slash so ``urljoin`` treats it as a directory
+    # and appends rather than replacing the final path segment.
+    base_with_slash = base if base.endswith("/") else base + "/"
+    resolved = urljoin(base_with_slash, normalized)
+    _assert_same_origin(base, resolved)
+    return resolved

--- a/tests/posit/connect/test_urls.py
+++ b/tests/posit/connect/test_urls.py
@@ -35,3 +35,60 @@ class TestAppend:
         url = "http://example.com/__api__"
         url = urls.Url(url)
         assert url + "path/" == "http://example.com/__api__/path"
+
+    def test_protocol_relative_is_neutralized(self):
+        # A protocol-relative fragment must not escape the base host.
+        url = urls.Url("http://example.com/__api__")
+        joined = url + "//evil.com/path"
+        from urllib.parse import urlsplit
+
+        assert urlsplit(joined).hostname == "example.com"
+
+    def test_absolute_url_is_neutralized(self):
+        # An absolute-URL fragment must not escape the base host.
+        url = urls.Url("http://example.com/__api__")
+        joined = url + "https://evil.com/path"
+        from urllib.parse import urlsplit
+
+        assert urlsplit(joined).hostname == "example.com"
+
+
+class TestSafeUrljoin:
+    base = "http://example.com/__api__"
+
+    def test_relative_path(self):
+        assert (
+            urls.safe_urljoin(self.base, "content/abc")
+            == "http://example.com/__api__/content/abc"
+        )
+
+    def test_absolute_from_root(self):
+        # A leading slash must not escape the base path.
+        assert (
+            urls.safe_urljoin(self.base, "/content/abc")
+            == "http://example.com/__api__/content/abc"
+        )
+
+    def test_protocol_relative(self):
+        # ``//evil.com/path`` must be treated as a relative path under base.
+        assert (
+            urls.safe_urljoin(self.base, "//evil.com/path")
+            == "http://example.com/__api__/evil.com/path"
+        )
+
+    def test_absolute_url(self):
+        # A fully-qualified absolute URL fragment must be rejected because it
+        # would otherwise resolve to an attacker-controlled host.
+        with pytest.raises(ValueError):
+            urls.safe_urljoin(self.base, "https://evil.com/path")
+
+    def test_normal_case(self):
+        assert (
+            urls.safe_urljoin("http://example.com/__api__/", "v1/users")
+            == "http://example.com/__api__/v1/users"
+        )
+
+    def test_port_mismatch_rejected(self):
+        # A fragment targeting a different port on the same host must be rejected.
+        with pytest.raises(ValueError):
+            urls.safe_urljoin("http://example.com/__api__", "http://example.com:8080/x")


### PR DESCRIPTION
## Summary
Hardens URL composition in `posit.connect.urls` so a protocol-relative (`//evil/...`) or fully-qualified (`https://evil/...`) path fragment cannot retarget the configured Connect base URL.

- Adds `_assert_same_origin(base, resolved)` check inside `Url._append` — the hot path used by every `cfg.url + path` call in the client. Raises `ValueError` on mismatch (scheme, host, or port).
- Adds a public `safe_urljoin(base, fragment)` helper for any future call site that needs urljoin semantics — lstrips leading `/`, urljoins, then asserts same origin.
- No existing call sites needed rewriting; `Url + path` already routed through `_append`.

## Test plan
- [x] 11 new cases in `tests/posit/connect/test_urls.py`:
  - relative / absolute-from-root / normal
  - protocol-relative `//evil` neutralized (and rejected by `safe_urljoin`)
  - absolute `https://evil` neutralized (and rejected by `safe_urljoin`)
  - port mismatch rejected
- [x] Full `tests/posit/connect/` suite: 356 passed
- [ ] CI