### PR TITLE
feat: add user/permission management utilities

### DIFF
--- a/integration/tests/posit/connect/test_admin.py
+++ b/integration/tests/posit/connect/test_admin.py
@@ -1,0 +1,201 @@
+from posit import connect
+from posit.connect.admin import MergeResult, merge_users
+from posit.connect.permissions import Permission, PermissionRole
+
+
+class TestMergeUsers:
+    @classmethod
+    def setup_class(cls):
+        cls.client = client = connect.Client()
+
+        cls.source = client.users.create(
+            username="merge_source",
+            email="merge_source@example.com",
+            password="s3cur3p@ssword",
+        )
+        cls.target = client.users.create(
+            username="merge_target",
+            email="merge_target@example.com",
+            password="s3cur3p@ssword",
+        )
+
+        # Create content owned by admin (me) and grant source a permission
+        cls.content_shared = client.content.create(
+            name="merge-shared",
+            access_type="acl",
+        )
+        cls.content_shared.permissions.create(
+            cls.source, role="viewer",
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        cls.content_shared.delete()
+
+        # Unlock source if locked
+        try:
+            cls.source.unlock()
+        except Exception:
+            pass
+
+    def test_dry_run(self):
+        result = merge_users(
+            self.client,
+            source=self.source,
+            target=self.target,
+            dry_run=True,
+        )
+
+        assert isinstance(result, MergeResult)
+        # Source has viewer permission on shared content
+        assert len(result.permissions_added) == 1
+        assert result.permissions_added[0]["role"] == "viewer"
+        assert result.source_locked is True
+
+        # Verify nothing actually changed
+        assert not self.source["locked"]
+        source_perms = self.content_shared.permissions.find(
+            principal_guid=self.source["guid"],
+        )
+        assert len(source_perms) == 1
+        target_perms = self.content_shared.permissions.find(
+            principal_guid=self.target["guid"],
+        )
+        assert len(target_perms) == 0
+
+    def test_merge(self):
+        result = merge_users(
+            self.client,
+            source=self.source,
+            target=self.target,
+        )
+
+        assert isinstance(result, MergeResult)
+        assert len(result.errors) == 0
+        assert result.source_locked is True
+
+        # Source permission should be removed
+        source_perms = self.content_shared.permissions.find(
+            principal_guid=self.source["guid"],
+        )
+        assert len(source_perms) == 0
+
+        # Target should have the permission
+        target_perms = self.content_shared.permissions.find(
+            principal_guid=self.target["guid"],
+        )
+        assert len(target_perms) == 1
+        assert target_perms[0]["role"] == "viewer"
+
+
+class TestMergeUsersOwnership:
+    @classmethod
+    def setup_class(cls):
+        cls.client = client = connect.Client()
+        cls.me = client.me
+
+        cls.source = client.users.create(
+            username="merge_own_source",
+            email="merge_own_source@example.com",
+            password="s3cur3p@ssword",
+        )
+        cls.target = client.users.create(
+            username="merge_own_target",
+            email="merge_own_target@example.com",
+            password="s3cur3p@ssword",
+        )
+
+        # Create content owned by source (via admin transferring ownership)
+        cls.content_owned = client.content.create(
+            name="merge-owned",
+            access_type="acl",
+        )
+        cls.content_owned.update(owner_guid=cls.source["guid"])
+
+    @classmethod
+    def teardown_class(cls):
+        # Take back ownership so we can delete
+        try:
+            cls.content_owned.update(owner_guid=cls.me["guid"])
+        except Exception:
+            pass
+        cls.content_owned.delete()
+
+        try:
+            cls.source.unlock()
+        except Exception:
+            pass
+
+    def test_transfers_ownership(self):
+        result = merge_users(
+            self.client,
+            source=self.source,
+            target=self.target,
+        )
+
+        assert len(result.errors) == 0
+        assert self.content_owned["guid"] in result.ownership_transferred
+        assert result.source_locked is True
+
+        # Verify ownership transferred
+        refreshed = self.client.content.get(self.content_owned["guid"])
+        assert refreshed["owner_guid"] == self.target["guid"]
+
+
+class TestMergeUsersRoleUpgrade:
+    @classmethod
+    def setup_class(cls):
+        cls.client = client = connect.Client()
+
+        cls.source = client.users.create(
+            username="merge_upg_source",
+            email="merge_upg_source@example.com",
+            password="s3cur3p@ssword",
+        )
+        cls.target = client.users.create(
+            username="merge_upg_target",
+            email="merge_upg_target@example.com",
+            password="s3cur3p@ssword",
+        )
+
+        # Create content and give both users permissions (source=owner, target=viewer)
+        cls.content = client.content.create(
+            name="merge-upgrade",
+            access_type="acl",
+        )
+        cls.content.permissions.create(cls.source, role="owner")
+        cls.content.permissions.create(cls.target, role="viewer")
+
+    @classmethod
+    def teardown_class(cls):
+        cls.content.delete()
+
+        try:
+            cls.source.unlock()
+        except Exception:
+            pass
+
+    def test_upgrades_role(self):
+        result = merge_users(
+            self.client,
+            source=self.source,
+            target=self.target,
+        )
+
+        assert len(result.errors) == 0
+        assert len(result.permissions_upgraded) == 1
+        assert result.permissions_upgraded[0]["old_role"] == "viewer"
+        assert result.permissions_upgraded[0]["new_role"] == "owner"
+
+        # Verify target now has owner role
+        target_perms = self.content.permissions.find(
+            principal_guid=self.target["guid"],
+        )
+        assert len(target_perms) == 1
+        assert target_perms[0]["role"] == "owner"
+
+        # Verify source permission removed
+        source_perms = self.content.permissions.find(
+            principal_guid=self.source["guid"],
+        )
+        assert len(source_perms) == 0

--- a/integration/tests/posit/connect/test_permission_role.py
+++ b/integration/tests/posit/connect/test_permission_role.py
@@ -1,0 +1,25 @@
+from posit.connect.permissions import PermissionRole
+
+
+class TestPermissionRole:
+    def test_ordering(self):
+        assert PermissionRole.viewer < PermissionRole.owner
+        assert PermissionRole.owner > PermissionRole.viewer
+        assert PermissionRole.viewer == PermissionRole.viewer
+        assert PermissionRole.owner == PermissionRole.owner
+
+    def test_from_string(self):
+        assert PermissionRole("viewer") == PermissionRole.viewer
+        assert PermissionRole("owner") == PermissionRole.owner
+
+    def test_max_min(self):
+        assert max(PermissionRole.viewer, PermissionRole.owner) == PermissionRole.owner
+        assert min(PermissionRole.viewer, PermissionRole.owner) == PermissionRole.viewer
+
+    def test_comparison_from_permission_data(self):
+        """Simulate comparing roles from actual permission dicts."""
+        source_role = PermissionRole("owner")
+        target_role = PermissionRole("viewer")
+        assert source_role > target_role
+        stronger = max(source_role, target_role)
+        assert stronger == PermissionRole.owner

--- a/integration/tests/posit/connect/test_user_features.py
+++ b/integration/tests/posit/connect/test_user_features.py
@@ -1,0 +1,157 @@
+from posit import connect
+from posit.connect.content import ContentItem
+from posit.connect.permissions import Permission
+
+
+class TestUserExactUsername:
+    @classmethod
+    def setup_class(cls):
+        cls.client = client = connect.Client()
+        cls.user_a = client.users.create(
+            username="exact_kaia",
+            email="exact_kaia@example.com",
+            password="s3cur3p@ssword",
+        )
+        cls.user_b = client.users.create(
+            username="exact_kaia_test",
+            email="exact_kaia_test@example.com",
+            password="s3cur3p@ssword",
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        cls.user_a.lock()
+        cls.user_b.lock()
+
+    def test_find_username_exact(self):
+        users = self.client.users.find(username="exact_kaia")
+        assert len(users) == 1
+        assert users[0]["username"] == "exact_kaia"
+
+    def test_find_one_username_exact(self):
+        user = self.client.users.find_one(username="exact_kaia")
+        assert user is not None
+        assert user["username"] == "exact_kaia"
+
+    def test_find_username_no_match(self):
+        users = self.client.users.find(username="exact_kaia_nonexistent")
+        assert len(users) == 0
+
+    def test_find_one_username_no_match(self):
+        user = self.client.users.find_one(username="exact_kaia_nonexistent")
+        assert user is None
+
+    def test_prefix_still_returns_both(self):
+        users = self.client.users.find(prefix="exact_kaia")
+        usernames = {u["username"] for u in users}
+        assert "exact_kaia" in usernames
+        assert "exact_kaia_test" in usernames
+
+
+class TestUsersGetBatch:
+    @classmethod
+    def setup_class(cls):
+        cls.client = client = connect.Client()
+        cls.user_a = client.users.create(
+            username="batch_alice",
+            email="batch_alice@example.com",
+            password="s3cur3p@ssword",
+        )
+        cls.user_b = client.users.create(
+            username="batch_bob",
+            email="batch_bob@example.com",
+            password="s3cur3p@ssword",
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        cls.user_a.lock()
+        cls.user_b.lock()
+
+    def test_get_batch(self):
+        guids = [self.user_a["guid"], self.user_b["guid"]]
+        users = self.client.users.get_batch(guids)
+        assert len(users) == 2
+        assert users[0]["guid"] == self.user_a["guid"]
+        assert users[1]["guid"] == self.user_b["guid"]
+
+    def test_get_batch_empty(self):
+        users = self.client.users.get_batch([])
+        assert users == []
+
+
+class TestUserPermissions:
+    @classmethod
+    def setup_class(cls):
+        cls.client = client = connect.Client()
+        cls.user = client.users.create(
+            username="uperm_user",
+            email="uperm_user@example.com",
+            password="s3cur3p@ssword",
+        )
+
+        cls.content_a = client.content.create(
+            name="uperm-content-a",
+            access_type="acl",
+        )
+        cls.content_b = client.content.create(
+            name="uperm-content-b",
+            access_type="acl",
+        )
+
+        # Grant user permissions on both content items
+        cls.content_a.permissions.create(cls.user, role="viewer")
+        cls.content_b.permissions.create(cls.user, role="owner")
+
+    @classmethod
+    def teardown_class(cls):
+        cls.content_a.delete()
+        cls.content_b.delete()
+        cls.user.lock()
+
+    def test_find_permissions(self):
+        perms = self.user.permissions.find()
+        assert len(perms) >= 2
+        assert all(isinstance(p, Permission) for p in perms)
+
+        # Verify our specific permissions are in the results
+        content_guids = {p["content_guid"] for p in perms}
+        assert self.content_a["guid"] in content_guids
+        assert self.content_b["guid"] in content_guids
+
+    def test_find_permissions_roles(self):
+        perms = self.user.permissions.find()
+        perm_map = {p["content_guid"]: p["role"] for p in perms}
+        assert perm_map[self.content_a["guid"]] == "viewer"
+        assert perm_map[self.content_b["guid"]] == "owner"
+
+
+class TestPermissionContentBackRef:
+    @classmethod
+    def setup_class(cls):
+        cls.client = client = connect.Client()
+        cls.user = client.users.create(
+            username="backref_user",
+            email="backref_user@example.com",
+            password="s3cur3p@ssword",
+        )
+        cls.content = client.content.create(
+            name="backref-content",
+            access_type="acl",
+        )
+        cls.content.permissions.create(cls.user, role="viewer")
+
+    @classmethod
+    def teardown_class(cls):
+        cls.content.delete()
+        cls.user.lock()
+
+    def test_permission_content_property(self):
+        perms = self.content.permissions.find()
+        assert len(perms) >= 1
+
+        perm = perms[0]
+        content_item = perm.content
+        assert isinstance(content_item, ContentItem)
+        assert content_item["guid"] == self.content["guid"]
+        assert content_item["name"] == "backref-content"

--- a/src/posit/connect/admin.py
+++ b/src/posit/connect/admin.py
@@ -1,0 +1,225 @@
+"""Admin utilities for Posit Connect."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from typing_extensions import TYPE_CHECKING, List
+
+from .permissions import PermissionRole
+
+if TYPE_CHECKING:
+    from .client import Client
+    from .users import User
+
+
+@dataclass
+class MergeResult:
+    """Result of a user merge operation.
+
+    Attributes
+    ----------
+    permissions_added : list[dict]
+        Permissions created on the target user. Each entry contains
+        ``content_guid`` and ``role``.
+    permissions_upgraded : list[dict]
+        Permissions upgraded on the target user. Each entry contains
+        ``content_guid``, ``old_role``, and ``new_role``.
+    permissions_skipped : list[dict]
+        Permissions that were not transferred because the target already
+        had an equal or stronger role. Each entry contains
+        ``content_guid``, ``role``, and ``reason``.
+    ownership_transferred : list[str]
+        Content GUIDs whose ownership was transferred from source to target.
+    source_locked : bool
+        Whether the source user was locked.
+    errors : list[dict]
+        Any errors encountered during the merge. Each entry contains
+        ``content_guid``, ``action``, and ``error``.
+    """
+
+    permissions_added: list[dict] = field(default_factory=list)
+    permissions_upgraded: list[dict] = field(default_factory=list)
+    permissions_skipped: list[dict] = field(default_factory=list)
+    ownership_transferred: list[str] = field(default_factory=list)
+    source_locked: bool = False
+    errors: list[dict] = field(default_factory=list)
+
+
+def merge_users(
+    client: Client,
+    source: User | str,
+    target: User | str,
+    *,
+    dry_run: bool = False,
+    lock_source: bool = True,
+) -> MergeResult:
+    """Merge two user accounts by transferring content and permissions.
+
+    Transfers all content ownership and permission grants from the
+    ``source`` user to the ``target`` user, then optionally locks the
+    source account.
+
+    When both users have permissions on the same content item, the
+    stronger role is kept on the target (using :class:`PermissionRole`
+    for comparison).
+
+    Parameters
+    ----------
+    client : Client
+        An authenticated Posit Connect client.
+    source : User | str
+        The user to merge *from* (will be locked afterwards). Accepts a
+        :class:`User` object or a GUID string.
+    target : User | str
+        The user to merge *into* (will receive content and permissions).
+        Accepts a :class:`User` object or a GUID string.
+    dry_run : bool
+        If ``True``, compute what would happen without making any
+        changes. Default is ``False``.
+    lock_source : bool
+        If ``True``, lock the source user account after transferring
+        content and permissions. Default is ``True``.
+
+    Returns
+    -------
+    MergeResult
+        A summary of all actions taken (or planned, if ``dry_run``).
+
+    Examples
+    --------
+    ```python
+    from posit.connect import Client
+    from posit.connect.admin import merge_users
+
+    client = Client()
+
+    # Preview what would happen
+    result = merge_users(client, source="stale-guid", target="active-guid", dry_run=True)
+    print(result)
+
+    # Execute the merge
+    result = merge_users(client, source="stale-guid", target="active-guid")
+    ```
+    """
+    from .users import User
+
+    # Resolve GUIDs to User objects
+    if isinstance(source, str):
+        source = client.users.get(source)
+    if isinstance(target, str):
+        target = client.users.get(target)
+
+    result = MergeResult()
+
+    # Step 1: Transfer content ownership
+    _transfer_ownership(source, target, result, dry_run=dry_run)
+
+    # Step 2: Transfer permissions
+    _transfer_permissions(source, target, result, dry_run=dry_run)
+
+    # Step 3: Lock the source user
+    if lock_source and not dry_run:
+        try:
+            source.lock(force=True)
+            result.source_locked = True
+        except Exception as e:
+            result.errors.append({
+                "action": "lock_source",
+                "error": str(e),
+            })
+    elif lock_source and dry_run:
+        result.source_locked = True
+
+    return result
+
+
+def _transfer_ownership(
+    source: User,
+    target: User,
+    result: MergeResult,
+    *,
+    dry_run: bool,
+) -> None:
+    """Transfer content ownership from source to target."""
+    owned_content = source.content.find()
+
+    for content_item in owned_content:
+        content_guid = content_item["guid"]
+        try:
+            if not dry_run:
+                content_item.update(owner_guid=target["guid"])
+            result.ownership_transferred.append(content_guid)
+        except Exception as e:
+            result.errors.append({
+                "content_guid": content_guid,
+                "action": "transfer_ownership",
+                "error": str(e),
+            })
+
+
+def _transfer_permissions(
+    source: User,
+    target: User,
+    result: MergeResult,
+    *,
+    dry_run: bool,
+) -> None:
+    """Transfer permission grants from source to target."""
+    source_perms = source.permissions.find()
+
+    for source_perm in source_perms:
+        content_guid = source_perm["content_guid"]
+        source_role = PermissionRole(source_perm["role"])
+
+        try:
+            # Check if target already has a permission on this content
+            target_perm = None
+            content_perms = source_perm.content.permissions.find(
+                principal_guid=target["guid"],
+            )
+            if content_perms:
+                target_perm = content_perms[0]
+
+            if target_perm is None:
+                # Target has no permission — add it
+                if not dry_run:
+                    source_perm.content.permissions.create(
+                        principal_guid=target["guid"],
+                        principal_type="user",
+                        role=source_perm["role"],
+                    )
+                result.permissions_added.append({
+                    "content_guid": content_guid,
+                    "role": source_perm["role"],
+                })
+            else:
+                old_role = target_perm["role"]
+                target_role = PermissionRole(old_role)
+                if source_role > target_role:
+                    # Source role is stronger — upgrade target
+                    if not dry_run:
+                        target_perm.update(role=source_perm["role"])
+                    result.permissions_upgraded.append({
+                        "content_guid": content_guid,
+                        "old_role": old_role,
+                        "new_role": source_perm["role"],
+                    })
+                else:
+                    # Target already has equal or stronger role — skip
+                    result.permissions_skipped.append({
+                        "content_guid": content_guid,
+                        "role": source_perm["role"],
+                        "reason": f"target already has role '{target_perm['role']}'",
+                    })
+
+            # Remove source's permission
+            if not dry_run:
+                source_perm.destroy()
+
+        except Exception as e:
+            result.errors.append({
+                "content_guid": content_guid,
+                "action": "transfer_permission",
+                "error": str(e),
+            })

--- a/src/posit/connect/permissions.py
+++ b/src/posit/connect/permissions.py
@@ -2,18 +2,68 @@
 
 from __future__ import annotations
 
+from enum import IntEnum
+
 from requests.sessions import Session as Session
 from typing_extensions import TYPE_CHECKING, List, Optional, overload
 
 from .resources import BaseResource, Resources
 
+
+class PermissionRole(IntEnum):
+    """Permission role hierarchy for content items.
+
+    Supports natural comparisons for determining role precedence::
+
+        PermissionRole("owner") > PermissionRole("viewer")  # True
+        max(PermissionRole("viewer"), PermissionRole("owner"))  # PermissionRole.owner
+
+    Examples
+    --------
+    Compare roles from permission objects:
+
+    >>> PermissionRole(source_perm["role"]) >= PermissionRole(target_perm["role"])
+    """
+
+    viewer = 0
+    owner = 1
+
+    @classmethod
+    def _missing_(cls, value: object) -> PermissionRole | None:
+        if isinstance(value, str):
+            try:
+                return cls[value]
+            except KeyError:
+                return None
+        return None
+
 if TYPE_CHECKING:
+    from .content import ContentItem
     from .context import Context
     from .groups import Group
     from .users import User
 
 
 class Permission(BaseResource):
+    @property
+    def content(self) -> "ContentItem":
+        """The content item associated with this permission.
+
+        Returns
+        -------
+        ContentItem
+            The content item.
+
+        Examples
+        --------
+        >>> perm = content_item.permissions.find_one()
+        >>> perm.content["name"]
+        'my-app'
+        """
+        from .content import Content
+
+        return Content(self._ctx).get(self["content_guid"])
+
     def destroy(self) -> None:
         """Destroy the permission."""
         path = f"v1/content/{self['content_guid']}/permissions/{self['id']}"

--- a/src/posit/connect/users.py
+++ b/src/posit/connect/users.py
@@ -20,12 +20,32 @@ from .resources import BaseResource, Resources
 if TYPE_CHECKING:
     from .context import Context
     from .groups import Group
+    from .permissions import Permission
 
 
 class User(BaseResource):
     @property
     def content(self) -> Content:
         return Content(self._ctx, owner_guid=self["guid"])
+
+    @property
+    def permissions(self) -> UserPermissions:
+        """
+        Retrieve all permissions for this user across all content items.
+
+        Returns
+        -------
+        UserPermissions
+            Helper class with a ``find()`` method that returns permissions.
+
+        Examples
+        --------
+        ```python
+        user = client.users.get("USER_GUID_HERE")
+        permissions = user.permissions.find()
+        ```
+        """
+        return UserPermissions(self._ctx, self["guid"])
 
     def lock(self, *, force: bool = False):
         """
@@ -159,6 +179,43 @@ class User(BaseResource):
         ```
         """
         return UserGroups(self._ctx, self["guid"])
+
+
+class UserPermissions(Resources):
+    """Permissions for a specific user across all content items."""
+
+    def __init__(self, ctx: Context, user_guid: str) -> None:
+        super().__init__(ctx)
+        self._user_guid = user_guid
+
+    def find(self) -> List["Permission"]:
+        """Find all permissions for this user across all content items.
+
+        Iterates all content items and checks permissions on each one,
+        resulting in O(N) API calls where N is the total content count.
+
+        Returns
+        -------
+        List[Permission]
+            A list of permissions for this user.
+
+        Examples
+        --------
+        ```python
+        user = client.users.get("USER_GUID_HERE")
+        permissions = user.permissions.find()
+        for perm in permissions:
+            print(perm["content_guid"], perm["role"])
+        ```
+        """
+        from .permissions import Permission  # noqa: F811
+
+        all_content = Content(self._ctx).find()
+        user_permissions: list[Permission] = []
+        for content_item in all_content:
+            perms = content_item.permissions.find(principal_guid=self._user_guid)
+            user_permissions.extend(perms)
+        return user_permissions
 
 
 class UserGroups(Resources):
@@ -389,6 +446,7 @@ class Users(Resources):
         """Find user request."""
 
         prefix: NotRequired[str]
+        username: NotRequired[str]
         user_role: NotRequired[Literal["administrator", "publisher", "viewer"] | str]
         account_status: NotRequired[Literal["locked", "licensed", "inactive"] | str]
 
@@ -400,6 +458,8 @@ class Users(Resources):
         ----------
         prefix : str, not required
             Filter users by prefix (username, first name, or last name). The filter is case-insensitive.
+        username : str, not required
+            Filter by exact username match. Uses the server's prefix search to narrow results, then post-filters for an exact match on the ``username`` field.
         user_role : Literal["administrator", "publisher", "viewer"], not required
             Filter by user role. Options are `'administrator'`, `'publisher'`, `'viewer'`. Use `'|'` to represent logical OR (e.g., `'viewer|publisher'`).
         account_status : Literal["locked", "licensed", "inactive"], not required
@@ -416,6 +476,10 @@ class Users(Resources):
 
         >>> users = client.find(prefix="jo")
 
+        Find a user by exact username:
+
+        >>> users = client.find(username="kaia")
+
         Find all users who are either viewers or publishers:
 
         >>> users = client.find(user_role="viewer|publisher")
@@ -428,16 +492,30 @@ class Users(Resources):
         --------
         * https://docs.posit.co/connect/api/#get-/v1/users
         """
+        # Extract client-side filter before sending to server
+        conditions = dict(conditions)  # type: ignore[assignment]
+        exact_username = conditions.pop("username", None)
+
+        # Use exact username as prefix to narrow server results
+        if exact_username is not None and "prefix" not in conditions:
+            conditions["prefix"] = exact_username
+
         path = "v1/users"
         paginator = Paginator(self._ctx, path, params={**conditions})
         results = paginator.fetch_results()
-        return [
+        users = [
             User(
                 self._ctx,
                 **user,
             )
             for user in results
         ]
+
+        # Post-filter for exact username match
+        if exact_username is not None:
+            users = [u for u in users if u["username"] == exact_username]
+
+        return users
 
     def find_one(self, **conditions: Unpack[FindUser]) -> User | None:
         """
@@ -447,6 +525,8 @@ class Users(Resources):
         ----------
         prefix : str, optional
             Filter users by prefix (username, first name, or last name). The filter is case-insensitive. Default is `None`.
+        username : str, optional
+            Filter by exact username match. Uses the server's prefix search to narrow results, then post-filters for an exact match on the ``username`` field. Default is `None`.
         user_role : Literal["administrator", "publisher", "viewer"], optional
             Filter by user role. Options are `'administrator'`, `'publisher'`, `'viewer'`. Use `'|'` to represent logical OR (e.g., `'viewer|publisher'`). Default is `None`.
         account_status : Literal["locked", "licensed", "inactive"], optional
@@ -463,6 +543,10 @@ class Users(Resources):
 
         >>> user = client.find_one(prefix="jo")
 
+        Find a user by exact username:
+
+        >>> user = client.find_one(username="kaia")
+
         Find a user who is either a viewer or publisher:
 
         >>> user = client.find_one(user_role="viewer|publisher")
@@ -475,6 +559,14 @@ class Users(Resources):
         --------
         * https://docs.posit.co/connect/api/#get-/v1/users
         """
+        # Extract client-side filter before sending to server
+        conditions = dict(conditions)  # type: ignore[assignment]
+        exact_username = conditions.pop("username", None)
+
+        # Use exact username as prefix to narrow server results
+        if exact_username is not None and "prefix" not in conditions:
+            conditions["prefix"] = exact_username
+
         path = "v1/users"
         paginator = Paginator(self._ctx, path, params={**conditions})
         pages = paginator.fetch_pages()
@@ -486,6 +578,11 @@ class Users(Resources):
             )
             for result in results
         )
+
+        # Post-filter for exact username match
+        if exact_username is not None:
+            return next((u for u in users if u["username"] == exact_username), None)
+
         return next(users, None)
 
     def get(self, uid: str) -> User:
@@ -514,6 +611,30 @@ class Users(Resources):
             self._ctx,
             **response.json(),
         )
+
+    def get_batch(self, uids: List[str]) -> List[User]:
+        """
+        Retrieve multiple users by their unique identifiers (guids).
+
+        Parameters
+        ----------
+        uids : List[str]
+            A list of unique identifiers (guids) of the users to retrieve.
+
+        Returns
+        -------
+        List[User]
+            A list of User objects in the same order as the input guids.
+
+        Examples
+        --------
+        >>> users = client.users.get_batch(["guid-1", "guid-2"])
+
+        See Also
+        --------
+        * https://docs.posit.co/connect/api/#get-/v1/users/-guid-
+        """
+        return [self.get(uid) for uid in uids]
 
     def count(self) -> int:
         """

--- a/tests/posit/connect/test_admin.py
+++ b/tests/posit/connect/test_admin.py
@@ -1,0 +1,431 @@
+import responses
+from responses import matchers
+
+from posit.connect.admin import MergeResult, merge_users
+from posit.connect.client import Client
+from posit.connect.users import User
+
+
+class TestMergeUsersOwnership:
+    @responses.activate
+    def test_transfers_ownership(self):
+        source_guid = "source-guid"
+        target_guid = "target-guid"
+        content_guid_1 = "content-guid-1"
+        content_guid_2 = "content-guid-2"
+
+        # Resolve users
+        responses.get(
+            f"https://connect.example/__api__/v1/users/{source_guid}",
+            json={"guid": source_guid, "username": "source"},
+        )
+        responses.get(
+            f"https://connect.example/__api__/v1/users/{target_guid}",
+            json={"guid": target_guid, "username": "target"},
+        )
+
+        # Source owns 2 content items
+        responses.get(
+            "https://connect.example/__api__/v1/content",
+            json=[
+                {"guid": content_guid_1, "name": "app-1", "owner_guid": source_guid},
+                {"guid": content_guid_2, "name": "app-2", "owner_guid": source_guid},
+            ],
+            match=[matchers.query_param_matcher({"owner_guid": source_guid}, strict_match=False)],
+        )
+
+        # Ownership transfer patches
+        mock_patch_1 = responses.patch(
+            f"https://connect.example/__api__/v1/content/{content_guid_1}",
+            json={"guid": content_guid_1, "name": "app-1", "owner_guid": target_guid},
+            match=[matchers.json_params_matcher({"owner_guid": target_guid})],
+        )
+        mock_patch_2 = responses.patch(
+            f"https://connect.example/__api__/v1/content/{content_guid_2}",
+            json={"guid": content_guid_2, "name": "app-2", "owner_guid": target_guid},
+            match=[matchers.json_params_matcher({"owner_guid": target_guid})],
+        )
+
+        # Source has no permissions (empty content listing for permission scan)
+        responses.get(
+            "https://connect.example/__api__/v1/content",
+            json=[],
+        )
+
+        # Lock source
+        responses.get(
+            "https://connect.example/__api__/v1/user",
+            json={"guid": "admin-guid"},
+        )
+        responses.post(
+            f"https://connect.example/__api__/v1/users/{source_guid}/lock",
+            match=[matchers.json_params_matcher({"locked": True})],
+        )
+
+        c = Client(api_key="12345", url="https://connect.example/")
+        result = merge_users(c, source=source_guid, target=target_guid)
+
+        assert mock_patch_1.call_count == 1
+        assert mock_patch_2.call_count == 1
+        assert set(result.ownership_transferred) == {content_guid_1, content_guid_2}
+        assert result.source_locked is True
+
+
+class TestMergeUsersPermissions:
+    @responses.activate
+    def test_add_permission(self):
+        """Source has viewer permission, target has none — should add."""
+        source_guid = "source-guid"
+        target_guid = "target-guid"
+        content_guid = "content-guid-1"
+
+        responses.get(
+            f"https://connect.example/__api__/v1/users/{source_guid}",
+            json={"guid": source_guid, "username": "source"},
+        )
+        responses.get(
+            f"https://connect.example/__api__/v1/users/{target_guid}",
+            json={"guid": target_guid, "username": "target"},
+        )
+
+        # No owned content
+        responses.get(
+            "https://connect.example/__api__/v1/content",
+            json=[],
+            match=[matchers.query_param_matcher({"owner_guid": source_guid}, strict_match=False)],
+        )
+
+        # Source permissions: viewer on content-guid-1
+        responses.get(
+            "https://connect.example/__api__/v1/content",
+            json=[{"guid": content_guid, "name": "app-1", "owner_guid": "someone-else"}],
+        )
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid}/permissions",
+            json=[
+                {"id": 1, "content_guid": content_guid, "principal_guid": source_guid, "principal_type": "user", "role": "viewer"},
+            ],
+        )
+
+        # Check target permissions (none)
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid}",
+            json={"guid": content_guid, "name": "app-1", "owner_guid": "someone-else"},
+        )
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid}/permissions",
+            json=[],
+        )
+
+        # Create permission for target
+        mock_create = responses.post(
+            f"https://connect.example/__api__/v1/content/{content_guid}/permissions",
+            json={"id": 2, "content_guid": content_guid, "principal_guid": target_guid, "principal_type": "user", "role": "viewer"},
+            match=[matchers.json_params_matcher({"principal_guid": target_guid, "principal_type": "user", "role": "viewer"})],
+        )
+
+        # Destroy source permission
+        mock_destroy = responses.delete(
+            f"https://connect.example/__api__/v1/content/{content_guid}/permissions/1",
+        )
+
+        # Lock source
+        responses.get(
+            "https://connect.example/__api__/v1/user",
+            json={"guid": "admin-guid"},
+        )
+        responses.post(
+            f"https://connect.example/__api__/v1/users/{source_guid}/lock",
+            match=[matchers.json_params_matcher({"locked": True})],
+        )
+
+        c = Client(api_key="12345", url="https://connect.example/")
+        result = merge_users(c, source=source_guid, target=target_guid)
+
+        assert mock_create.call_count == 1
+        assert mock_destroy.call_count == 1
+        assert len(result.permissions_added) == 1
+        assert result.permissions_added[0]["content_guid"] == content_guid
+        assert result.permissions_added[0]["role"] == "viewer"
+
+    @responses.activate
+    def test_upgrade_permission(self):
+        """Source has owner, target has viewer — should upgrade target."""
+        source_guid = "source-guid"
+        target_guid = "target-guid"
+        content_guid = "content-guid-1"
+
+        responses.get(
+            f"https://connect.example/__api__/v1/users/{source_guid}",
+            json={"guid": source_guid, "username": "source"},
+        )
+        responses.get(
+            f"https://connect.example/__api__/v1/users/{target_guid}",
+            json={"guid": target_guid, "username": "target"},
+        )
+
+        # No owned content
+        responses.get(
+            "https://connect.example/__api__/v1/content",
+            json=[],
+            match=[matchers.query_param_matcher({"owner_guid": source_guid}, strict_match=False)],
+        )
+
+        # Source permissions: owner on content
+        responses.get(
+            "https://connect.example/__api__/v1/content",
+            json=[{"guid": content_guid, "name": "app-1", "owner_guid": "someone"}],
+        )
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid}/permissions",
+            json=[
+                {"id": 1, "content_guid": content_guid, "principal_guid": source_guid, "principal_type": "user", "role": "owner"},
+            ],
+        )
+
+        # Check target permissions (viewer)
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid}",
+            json={"guid": content_guid, "name": "app-1", "owner_guid": "someone"},
+        )
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid}/permissions",
+            json=[
+                {"id": 2, "content_guid": content_guid, "principal_guid": target_guid, "principal_type": "user", "role": "viewer"},
+            ],
+        )
+
+        # Upgrade target permission
+        mock_upgrade = responses.put(
+            f"https://connect.example/__api__/v1/content/{content_guid}/permissions/2",
+            json={"id": 2, "content_guid": content_guid, "principal_guid": target_guid, "principal_type": "user", "role": "owner"},
+        )
+
+        # Destroy source permission
+        mock_destroy = responses.delete(
+            f"https://connect.example/__api__/v1/content/{content_guid}/permissions/1",
+        )
+
+        # Lock source
+        responses.get(
+            "https://connect.example/__api__/v1/user",
+            json={"guid": "admin-guid"},
+        )
+        responses.post(
+            f"https://connect.example/__api__/v1/users/{source_guid}/lock",
+            match=[matchers.json_params_matcher({"locked": True})],
+        )
+
+        c = Client(api_key="12345", url="https://connect.example/")
+        result = merge_users(c, source=source_guid, target=target_guid)
+
+        assert mock_upgrade.call_count == 1
+        assert mock_destroy.call_count == 1
+        assert len(result.permissions_upgraded) == 1
+        assert result.permissions_upgraded[0]["old_role"] == "viewer"
+        assert result.permissions_upgraded[0]["new_role"] == "owner"
+
+    @responses.activate
+    def test_skip_permission(self):
+        """Source has viewer, target has owner — should skip."""
+        source_guid = "source-guid"
+        target_guid = "target-guid"
+        content_guid = "content-guid-1"
+
+        responses.get(
+            f"https://connect.example/__api__/v1/users/{source_guid}",
+            json={"guid": source_guid, "username": "source"},
+        )
+        responses.get(
+            f"https://connect.example/__api__/v1/users/{target_guid}",
+            json={"guid": target_guid, "username": "target"},
+        )
+
+        # No owned content
+        responses.get(
+            "https://connect.example/__api__/v1/content",
+            json=[],
+            match=[matchers.query_param_matcher({"owner_guid": source_guid}, strict_match=False)],
+        )
+
+        # Source permissions: viewer
+        responses.get(
+            "https://connect.example/__api__/v1/content",
+            json=[{"guid": content_guid, "name": "app-1", "owner_guid": "someone"}],
+        )
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid}/permissions",
+            json=[
+                {"id": 1, "content_guid": content_guid, "principal_guid": source_guid, "principal_type": "user", "role": "viewer"},
+            ],
+        )
+
+        # Target already has owner
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid}",
+            json={"guid": content_guid, "name": "app-1", "owner_guid": "someone"},
+        )
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid}/permissions",
+            json=[
+                {"id": 2, "content_guid": content_guid, "principal_guid": target_guid, "principal_type": "user", "role": "owner"},
+            ],
+        )
+
+        # Destroy source permission (still removed even when skipped)
+        mock_destroy = responses.delete(
+            f"https://connect.example/__api__/v1/content/{content_guid}/permissions/1",
+        )
+
+        # Lock source
+        responses.get(
+            "https://connect.example/__api__/v1/user",
+            json={"guid": "admin-guid"},
+        )
+        responses.post(
+            f"https://connect.example/__api__/v1/users/{source_guid}/lock",
+            match=[matchers.json_params_matcher({"locked": True})],
+        )
+
+        c = Client(api_key="12345", url="https://connect.example/")
+        result = merge_users(c, source=source_guid, target=target_guid)
+
+        assert mock_destroy.call_count == 1
+        assert len(result.permissions_skipped) == 1
+        assert result.permissions_skipped[0]["reason"] == "target already has role 'owner'"
+
+
+class TestMergeUsersDryRun:
+    @responses.activate
+    def test_no_mutations(self):
+        """In dry_run mode, no PUT/POST/DELETE/PATCH calls should be made."""
+        source_guid = "source-guid"
+        target_guid = "target-guid"
+        content_guid = "content-guid-1"
+
+        responses.get(
+            f"https://connect.example/__api__/v1/users/{source_guid}",
+            json={"guid": source_guid, "username": "source"},
+        )
+        responses.get(
+            f"https://connect.example/__api__/v1/users/{target_guid}",
+            json={"guid": target_guid, "username": "target"},
+        )
+
+        # Source owns 1 content item
+        responses.get(
+            "https://connect.example/__api__/v1/content",
+            json=[{"guid": content_guid, "name": "app-1", "owner_guid": source_guid}],
+            match=[matchers.query_param_matcher({"owner_guid": source_guid}, strict_match=False)],
+        )
+
+        # Source has viewer permission on that content
+        responses.get(
+            "https://connect.example/__api__/v1/content",
+            json=[{"guid": content_guid, "name": "app-1", "owner_guid": source_guid}],
+        )
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid}/permissions",
+            json=[
+                {"id": 1, "content_guid": content_guid, "principal_guid": source_guid, "principal_type": "user", "role": "viewer"},
+            ],
+        )
+
+        # Target has no permissions
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid}",
+            json={"guid": content_guid, "name": "app-1", "owner_guid": source_guid},
+        )
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid}/permissions",
+            json=[],
+        )
+
+        c = Client(api_key="12345", url="https://connect.example/")
+        result = merge_users(c, source=source_guid, target=target_guid, dry_run=True)
+
+        # Verify planned actions
+        assert len(result.ownership_transferred) == 1
+        assert len(result.permissions_added) == 1
+        assert result.source_locked is True
+
+        # Verify no mutation calls were made
+        for call in responses.calls:
+            assert call.request.method == "GET", (
+                f"Expected only GET calls in dry_run, got {call.request.method} to {call.request.url}"
+            )
+
+
+class TestMergeUsersLockSource:
+    @responses.activate
+    def test_lock_source_false(self):
+        """When lock_source=False, source should not be locked."""
+        source_guid = "source-guid"
+        target_guid = "target-guid"
+
+        responses.get(
+            f"https://connect.example/__api__/v1/users/{source_guid}",
+            json={"guid": source_guid, "username": "source"},
+        )
+        responses.get(
+            f"https://connect.example/__api__/v1/users/{target_guid}",
+            json={"guid": target_guid, "username": "target"},
+        )
+
+        # No owned content
+        responses.get(
+            "https://connect.example/__api__/v1/content",
+            json=[],
+            match=[matchers.query_param_matcher({"owner_guid": source_guid}, strict_match=False)],
+        )
+
+        # No permissions
+        responses.get(
+            "https://connect.example/__api__/v1/content",
+            json=[],
+        )
+
+        c = Client(api_key="12345", url="https://connect.example/")
+        result = merge_users(c, source=source_guid, target=target_guid, lock_source=False)
+
+        assert result.source_locked is False
+
+
+class TestMergeUsersWithUserObjects:
+    @responses.activate
+    def test_accepts_user_objects(self):
+        """merge_users should accept User objects directly, not just GUIDs."""
+        source_guid = "source-guid"
+        target_guid = "target-guid"
+
+        # No owned content
+        responses.get(
+            "https://connect.example/__api__/v1/content",
+            json=[],
+            match=[matchers.query_param_matcher({"owner_guid": source_guid}, strict_match=False)],
+        )
+
+        # No permissions
+        responses.get(
+            "https://connect.example/__api__/v1/content",
+            json=[],
+        )
+
+        # Lock source
+        responses.get(
+            "https://connect.example/__api__/v1/user",
+            json={"guid": "admin-guid"},
+        )
+        responses.post(
+            f"https://connect.example/__api__/v1/users/{source_guid}/lock",
+            match=[matchers.json_params_matcher({"locked": True})],
+        )
+
+        c = Client(api_key="12345", url="https://connect.example/")
+        source = User(c._ctx, guid=source_guid, username="source")
+        target = User(c._ctx, guid=target_guid, username="target")
+
+        result = merge_users(c, source=source, target=target)
+
+        assert result.source_locked is True
+        assert result.errors == []

--- a/tests/posit/connect/test_permissions.py
+++ b/tests/posit/connect/test_permissions.py
@@ -9,7 +9,8 @@ from posit import connect
 from posit.connect.client import Client
 from posit.connect.context import Context
 from posit.connect.groups import Group
-from posit.connect.permissions import Permission, Permissions
+from posit.connect.content import ContentItem
+from posit.connect.permissions import Permission, PermissionRole, Permissions
 from posit.connect.users import User
 
 from .api import load_mock, load_mock_dict, load_mock_list
@@ -431,3 +432,60 @@ class TestPermissionsDestroy:
             permissions.destroy(
                 42  # pyright: ignore[reportArgumentType]
             )
+
+
+class TestPermissionRole:
+    def test_ordering(self):
+        assert PermissionRole.viewer < PermissionRole.owner
+        assert PermissionRole.owner > PermissionRole.viewer
+        assert PermissionRole.viewer == PermissionRole.viewer
+        assert PermissionRole.owner == PermissionRole.owner
+
+    def test_max_min(self):
+        assert max(PermissionRole.viewer, PermissionRole.owner) == PermissionRole.owner
+        assert min(PermissionRole.viewer, PermissionRole.owner) == PermissionRole.viewer
+
+    def test_from_string(self):
+        assert PermissionRole("viewer") == PermissionRole.viewer
+        assert PermissionRole("owner") == PermissionRole.owner
+
+    def test_invalid_role(self):
+        with pytest.raises(ValueError):
+            PermissionRole("editor")
+
+    def test_name(self):
+        assert PermissionRole.viewer.name == "viewer"
+        assert PermissionRole.owner.name == "owner"
+
+
+class TestPermissionContent:
+    @responses.activate
+    def test(self):
+        content_guid = "f2f37341-e21d-3d80-c698-a935ad614066"
+        fake_content = {
+            "guid": content_guid,
+            "name": "my-content",
+            "title": "My Content",
+            "owner_guid": "owner-guid",
+        }
+
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid}",
+            json=fake_content,
+        )
+
+        c = connect.Client("https://connect.example", "12345")
+        permission = Permission(
+            c._ctx,
+            id=1,
+            content_guid=content_guid,
+            principal_guid="user-guid",
+            principal_type="user",
+            role="viewer",
+        )
+
+        content = permission.content
+
+        assert isinstance(content, ContentItem)
+        assert content["guid"] == content_guid
+        assert content["name"] == "my-content"

--- a/tests/posit/connect/test_users.py
+++ b/tests/posit/connect/test_users.py
@@ -7,6 +7,7 @@ from responses import matchers
 
 from posit.connect.client import Client
 from posit.connect.groups import Group
+from posit.connect.permissions import Permission
 from posit.connect.users import User
 
 from .api import load_mock, load_mock_dict
@@ -443,3 +444,186 @@ class TestUsersFind:
             con.users.find(
                 not_dict_like  # pyright: ignore[reportCallIssue]
             )
+
+    @responses.activate
+    def test_username_exact_match(self):
+        """Exact username filter returns only the exact match, not prefix matches."""
+        responses.get(
+            "https://connect.example/__api__/v1/users",
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"page_size": 500, "page_number": 1, "prefix": "kaia"},
+                ),
+            ],
+            json={
+                "results": [
+                    {"guid": "guid-1", "username": "kaia"},
+                    {"guid": "guid-2", "username": "kaia-test"},
+                ],
+                "current_page": 1,
+                "total": 2,
+            },
+        )
+        responses.get(
+            "https://connect.example/__api__/v1/users",
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"page_size": 500, "page_number": 2, "prefix": "kaia"},
+                ),
+            ],
+            json={"results": [], "current_page": 2, "total": 2},
+        )
+        con = Client(api_key="12345", url="https://connect.example/")
+        users = con.users.find(username="kaia")
+        assert len(users) == 1
+        assert users[0]["username"] == "kaia"
+        assert users[0]["guid"] == "guid-1"
+
+    @responses.activate
+    def test_username_no_match(self):
+        """Exact username filter returns empty list when no exact match."""
+        responses.get(
+            "https://connect.example/__api__/v1/users",
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"page_size": 500, "page_number": 1, "prefix": "nonexistent"},
+                ),
+            ],
+            json={"results": [], "current_page": 1, "total": 0},
+        )
+        con = Client(api_key="12345", url="https://connect.example/")
+        users = con.users.find(username="nonexistent")
+        assert len(users) == 0
+
+
+class TestUsersFindOneUsername:
+    @responses.activate
+    def test_username_exact_match(self):
+        """find_one with username returns the exact match."""
+        responses.get(
+            "https://connect.example/__api__/v1/users",
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"page_size": 500, "page_number": 1, "prefix": "kaia"},
+                ),
+            ],
+            json={
+                "results": [
+                    {"guid": "guid-1", "username": "kaia"},
+                    {"guid": "guid-2", "username": "kaia-test"},
+                ],
+                "current_page": 1,
+                "total": 2,
+            },
+        )
+        con = Client(api_key="12345", url="https://connect.example/")
+        user = con.users.find_one(username="kaia")
+        assert user is not None
+        assert user["username"] == "kaia"
+
+    @responses.activate
+    def test_username_no_match(self):
+        """find_one with username returns None when no exact match."""
+        responses.get(
+            "https://connect.example/__api__/v1/users",
+            json={"results": [], "current_page": 1, "total": 0},
+        )
+        con = Client(api_key="12345", url="https://connect.example/")
+        user = con.users.find_one(username="nonexistent")
+        assert user is None
+
+
+class TestUsersGetBatch:
+    @responses.activate
+    def test_get_batch(self):
+        guid1 = "20a79ce3-6e87-4522-9faf-be24228800a4"
+        guid2 = "87c12c08-11cd-4de1-8da3-12a7579c4998"
+        responses.get(
+            f"https://connect.example/__api__/v1/users/{guid1}",
+            json={"guid": guid1, "username": "carlos12"},
+        )
+        responses.get(
+            f"https://connect.example/__api__/v1/users/{guid2}",
+            json={"guid": guid2, "username": "bob"},
+        )
+        con = Client(api_key="12345", url="https://connect.example/")
+        users = con.users.get_batch([guid1, guid2])
+        assert len(users) == 2
+        assert users[0]["guid"] == guid1
+        assert users[1]["guid"] == guid2
+
+    def test_get_batch_empty(self):
+        con = Client(api_key="12345", url="https://connect.example/")
+        users = con.users.get_batch([])
+        assert users == []
+
+
+class TestUserPermissions:
+    @responses.activate
+    def test_find(self):
+        user_guid = "user-guid-1"
+        other_guid = "other-user-guid"
+        content_guid_1 = "content-guid-1"
+        content_guid_2 = "content-guid-2"
+
+        # Mock content listing
+        responses.get(
+            "https://connect.example/__api__/v1/content",
+            json=[
+                {"guid": content_guid_1, "name": "app-1", "owner_guid": "owner-1"},
+                {"guid": content_guid_2, "name": "app-2", "owner_guid": "owner-2"},
+            ],
+        )
+
+        # Mock permissions for content 1 - user has viewer
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid_1}/permissions",
+            json=[
+                {"id": 1, "content_guid": content_guid_1, "principal_guid": user_guid, "principal_type": "user", "role": "viewer"},
+                {"id": 2, "content_guid": content_guid_1, "principal_guid": other_guid, "principal_type": "user", "role": "owner"},
+            ],
+        )
+
+        # Mock permissions for content 2 - user has owner
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid_2}/permissions",
+            json=[
+                {"id": 3, "content_guid": content_guid_2, "principal_guid": user_guid, "principal_type": "user", "role": "owner"},
+            ],
+        )
+
+        c = Client(api_key="12345", url="https://connect.example/")
+        user = User(c._ctx, guid=user_guid)
+        perms = user.permissions.find()
+
+        assert len(perms) == 2
+        assert all(isinstance(p, Permission) for p in perms)
+        assert perms[0]["content_guid"] == content_guid_1
+        assert perms[0]["role"] == "viewer"
+        assert perms[1]["content_guid"] == content_guid_2
+        assert perms[1]["role"] == "owner"
+
+    @responses.activate
+    def test_find_no_permissions(self):
+        user_guid = "user-guid-1"
+        content_guid = "content-guid-1"
+
+        responses.get(
+            "https://connect.example/__api__/v1/content",
+            json=[
+                {"guid": content_guid, "name": "app-1", "owner_guid": "owner-1"},
+            ],
+        )
+
+        responses.get(
+            f"https://connect.example/__api__/v1/content/{content_guid}/permissions",
+            json=[
+                {"id": 1, "content_guid": content_guid, "principal_guid": "other-user", "principal_type": "user", "role": "viewer"},
+            ],
+        )
+
+        c = Client(api_key="12345", url="https://connect.example/")
+        user = User(c._ctx, guid=user_guid)
+        perms = user.permissions.find()
+
+        assert len(perms) == 0


### PR DESCRIPTION
## Summary

Adds 6 SDK improvements for user and permission management, motivated by the need to merge duplicate user records during auth provider migrations:

- **`PermissionRole` IntEnum** — role hierarchy comparison (`PermissionRole("owner") > PermissionRole("viewer")`)
- **Exact username filter** — `client.users.find(username="kaia")` with client-side post-filtering
- **`Permission.content` property** — lazy back-reference from a permission to its content item
- **`Users.get_batch()`** — retrieve multiple users by GUID list
- **`User.permissions.find()`** — query all permissions for a user across all content items
- **`merge_users()` admin utility** — transfers content ownership and permissions from one user to another, with `dry_run` support

## Test plan

- [ ] `pytest tests/posit/connect/test_permissions.py` — 17 tests (5 new)
- [ ] `pytest tests/posit/connect/test_users.py` — 27 tests (8 new)
- [ ] `pytest tests/posit/connect/test_admin.py` — 7 tests (all new)
- [ ] `pytest tests/` — full suite, 419 tests, no regressions