### PR TITLE
fix: import DefaultCredentials from databricks.sdk.credentials_provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ _dev/
 
 # license files should not be commited to this repository
 *.lic
+
+# Claude
+.claude/worktrees/

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ it: $(UV_LOCK)
 
 lint: dev
 	$(UV) run ruff check
-	$(UV) run pyright
+	PYRIGHT_PYTHON_FORCE_VERSION=latest $(UV) run pyright
 
 test: dev
 	$(UV) run coverage run --source=src -m pytest tests

--- a/src/posit/connect/external/databricks.py
+++ b/src/posit/connect/external/databricks.py
@@ -18,10 +18,11 @@ from .._utils import is_connect, is_connect_cloud, is_workbench
 from ..client import Client
 
 try:
-    from databricks.sdk.core import Config, DefaultCredentials
+    from databricks.sdk.core import Config
     from databricks.sdk.credentials_provider import (
         CredentialsProvider,
         CredentialsStrategy,
+        DefaultCredentials,
     )
 except ImportError as e:
     raise ImportError("The 'databricks-sdk' package is required to use this module.") from e

--- a/tests/posit/connect/external/test_databricks.py
+++ b/tests/posit/connect/external/test_databricks.py
@@ -18,10 +18,11 @@ from posit.connect.external.databricks import (
 from posit.connect.oauth import Credentials
 
 try:
-    from databricks.sdk.core import Config, DefaultCredentials
+    from databricks.sdk.core import Config
     from databricks.sdk.credentials_provider import (
         CredentialsProvider,
         CredentialsStrategy,
+        DefaultCredentials,
     )
 
     # construct a DefaultCredentials CredentialsStrategy


### PR DESCRIPTION
## Summary
- Newer versions of `databricks-sdk` removed `DefaultCredentials` from `databricks.sdk.core`; import it from `databricks.sdk.credentials_provider` instead so the `posit.connect.external.databricks` module loads against current SDK releases.
- Force latest `pyright` in the `lint` Makefile target.
- Ignore `.claude/worktrees/` in `.gitignore`.

## Test plan
- [x] `make lint`
- [x] `make test`
- [x] Verify import succeeds against current `databricks-sdk`