### PR TITLE
feat: add bundle storage endpoints to SDK

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -111,6 +111,7 @@ quartodoc:
         - connect.packages
         - connect.permissions
         - connect.repository
+        - connect.storage
         - connect.system
         - connect.tags
         - connect.tasks

--- a/integration/tests/posit/connect/test_system.py
+++ b/integration/tests/posit/connect/test_system.py
@@ -4,6 +4,11 @@ import pytest
 from packaging import version
 
 from posit.connect import Client
+from posit.connect.storage import (
+    ContentStorageDetail,
+    ContentStorageItem,
+    ServerStorage,
+)
 from posit.connect.system import SystemRuntimeCache
 from posit.connect.tasks import Task
 
@@ -58,3 +63,45 @@ class TestSystem:
         # Verify cache was removed
         runtimes_after_destroy = self.client.system.caches.runtime.find()
         assert len(runtimes_after_destroy) == len(runtimes) - 1
+
+
+@pytest.mark.skipif(
+    CONNECT_VERSION < version.parse("2026.06.0"),
+    reason="Bundle storage endpoints not implemented",
+)
+class TestStorage:
+    @classmethod
+    def setup_class(cls):
+        cls.client = Client()
+        cls.content = cls.client.content.create(name=cls.__name__)
+        path = Path("../../../resources/connect/bundles/example-flask-minimal/bundle.tar.gz")
+        path = (Path(__file__).parent / path).resolve()
+        bundle = cls.content.bundles.create(str(path))
+        task = bundle.deploy()
+        task.wait_for()
+
+    @classmethod
+    def teardown_class(cls):
+        cls.content.delete()
+
+    def test_system_storage(self):
+        storage = self.client.system.storage.find()
+        assert isinstance(storage, ServerStorage)
+        assert storage["bundles"]["count"] > 0
+
+    def test_content_storage(self):
+        items = self.client.content.storage.find()
+        assert len(items) > 0
+        for item in items:
+            assert isinstance(item, ContentStorageItem)
+
+        # The deployed content should appear in the list.
+        guids = [item["content_guid"] for item in items]
+        assert self.content["guid"] in guids
+
+    def test_content_item_storage(self):
+        storage = self.content.storage.find()
+        assert isinstance(storage, ContentStorageDetail)
+        assert storage["content_guid"] == self.content["guid"]
+        assert storage["bundle_count"] > 0
+        assert len(storage["bundles"]) > 0

--- a/integration/tests/posit/connect/test_system.py
+++ b/integration/tests/posit/connect/test_system.py
@@ -85,7 +85,7 @@ class TestStorage:
         cls.content.delete()
 
     def test_system_storage(self):
-        storage = self.client.system.storage.find()
+        storage = self.client.system.storage
         assert isinstance(storage, ServerStorage)
         assert storage["bundles"]["count"] > 0
 
@@ -100,7 +100,7 @@ class TestStorage:
         assert self.content["guid"] in guids
 
     def test_content_item_storage(self):
-        storage = self.content.storage.find()
+        storage = self.content.storage
         assert isinstance(storage, ContentStorageDetail)
         assert storage["content_guid"] == self.content["guid"]
         assert storage["bundle_count"] > 0

--- a/integration/tests/posit/connect/test_system.py
+++ b/integration/tests/posit/connect/test_system.py
@@ -67,7 +67,7 @@ class TestSystem:
 
 @pytest.mark.skipif(
     CONNECT_VERSION < version.parse("2026.06.0"),
-    reason="Bundle storage endpoints not implemented",
+    reason="Bundle storage endpoints not available",
 )
 class TestStorage:
     @classmethod

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -29,7 +29,7 @@ from .oauth.associations import ContentItemAssociations
 from .permissions import Permissions
 from .repository import ContentItemRepositoryMixin
 from .resources import Active, BaseResource, Resources, _ResourceSequence
-from .storage import ContentItemStorage, ContentStorage
+from .storage import ContentStorage, ContentStorageDetail
 from .tags import ContentItemTags
 from .vanities import VanityMixin
 from .variants import Variants
@@ -723,23 +723,27 @@ class ContentItem(Active, ContentItemRepositoryMixin, VanityMixin, BaseResource)
         return _ResourceSequence(self._ctx, path, uid="name")
 
     @property
-    def storage(self) -> ContentItemStorage:
+    @requires(version="2026.06.0")
+    def storage(self) -> ContentStorageDetail:
         """Bundle storage usage for this content item.
 
         This information is available only to administrators.
 
         Returns
         -------
-        ContentItemStorage
-            Helper class for the content item's bundle storage.
+        ContentStorageDetail
+            Detailed bundle storage information, including per-bundle details.
 
         Examples
         --------
         >>> content = client.content.get(guid)
-        >>> storage = content.storage.find()
+        >>> storage = content.storage
+        >>> for bundle in storage["bundles"]:
+        ...     print(bundle["id"], bundle["size_bytes"], bundle["is_active"])
         """
         path = posixpath.join(self._path, "storage")
-        return ContentItemStorage(self._ctx, path)
+        response = self._ctx.client.get(path)
+        return ContentStorageDetail(self._ctx, **response.json())
 
     @requires(version="2025.12.0")
     def get_lockfile(self) -> Lockfile:

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -29,6 +29,7 @@ from .oauth.associations import ContentItemAssociations
 from .permissions import Permissions
 from .repository import ContentItemRepositoryMixin
 from .resources import Active, BaseResource, Resources, _ResourceSequence
+from .storage import ContentItemStorage, ContentStorage
 from .tags import ContentItemTags
 from .vanities import VanityMixin
 from .variants import Variants
@@ -721,6 +722,25 @@ class ContentItem(Active, ContentItemRepositoryMixin, VanityMixin, BaseResource)
         path = posixpath.join(self._path, "packages")
         return _ResourceSequence(self._ctx, path, uid="name")
 
+    @property
+    def storage(self) -> ContentItemStorage:
+        """Bundle storage usage for this content item.
+
+        This information is available only to administrators.
+
+        Returns
+        -------
+        ContentItemStorage
+            Helper class for the content item's bundle storage.
+
+        Examples
+        --------
+        >>> content = client.content.get(guid)
+        >>> storage = content.storage.find()
+        """
+        path = posixpath.join(self._path, "storage")
+        return ContentItemStorage(self._ctx, path)
+
     @requires(version="2025.12.0")
     def get_lockfile(self) -> Lockfile:
         """Get the Python lockfile for the content's active bundle.
@@ -797,6 +817,23 @@ class Content(Resources):
         int
         """
         return len(self.find())
+
+    @property
+    def storage(self) -> ContentStorage:
+        """Bundle storage usage across all content items.
+
+        This information is available only to administrators.
+
+        Returns
+        -------
+        ContentStorage
+            Helper class for per-content bundle storage.
+
+        Examples
+        --------
+        >>> items = client.content.storage.find()
+        """
+        return ContentStorage(self._ctx, "v1/content/storage")
 
     def create(
         self,

--- a/src/posit/connect/storage.py
+++ b/src/posit/connect/storage.py
@@ -19,6 +19,15 @@ from .resources import BaseResource
 if TYPE_CHECKING:
     from .context import Context
 
+# Fields accepted by the `sort` query parameter on GET /v1/content/storage.
+# The server rejects any other value with an HTTP 400.
+ContentStorageSortField = Literal[
+    "bundle_bytes_total",
+    "bundle_bytes_active",
+    "bundle_bytes_inactive",
+    "bundle_count",
+]
+
 
 class ServerStorage(BaseResource):
     """Aggregate bundle storage metrics for the Connect server.
@@ -102,7 +111,7 @@ class ContentStorage(ContextManager):
     def find(
         self,
         *,
-        sort: Optional[str] = None,
+        sort: Optional[ContentStorageSortField] = None,
         order: Optional[Literal["asc", "desc"]] = None,
     ) -> List[ContentStorageItem]:
         """List bundle storage usage for every content item.
@@ -113,10 +122,10 @@ class ContentStorage(ContextManager):
 
         Parameters
         ----------
-        sort : str, optional
-            The field to sort by.
+        sort : Literal['bundle_bytes_total', 'bundle_bytes_active', 'bundle_bytes_inactive', 'bundle_count'], optional
+            The field to sort by. Defaults to ``bundle_bytes_total`` on the server.
         order : Literal['asc', 'desc'], optional
-            The sort order.
+            The sort order. Defaults to ``desc`` on the server.
 
         Returns
         -------

--- a/src/posit/connect/storage.py
+++ b/src/posit/connect/storage.py
@@ -1,0 +1,239 @@
+"""Bundle storage resources.
+
+These resources expose the admin-only bundle storage usage endpoints added in
+Connect 2026.06.0:
+
+- ``GET /v1/system/storage`` — server-wide bundle storage totals.
+- ``GET /v1/content/storage`` — per-content bundle storage usage.
+- ``GET /v1/content/{guid}/storage`` — bundle storage details for one content item.
+"""
+
+from __future__ import annotations
+
+from typing_extensions import TYPE_CHECKING, List, Literal, Optional
+
+from .context import ContextManager, requires
+from .resources import BaseResource
+
+if TYPE_CHECKING:
+    from .context import Context
+
+# The maximum page size supported by the API.
+_MAX_PAGE_SIZE = 500
+
+
+class ServerStorage(BaseResource):
+    """Aggregate bundle storage metrics for the Connect server.
+
+    Attributes
+    ----------
+    bundles : dict
+        Bundle storage metrics with the following keys:
+
+        - ``bytes_total`` (int): Total bytes across all bundle archives with recorded sizes.
+        - ``bytes_active`` (int): Bytes used by currently active (deployed) bundles.
+        - ``bytes_inactive`` (int): Bytes used by inactive (historical) bundles.
+        - ``count`` (int): Total number of bundles with recorded sizes.
+        - ``content_count`` (int): Number of distinct content items with bundles.
+    """
+
+
+class ContentStorageItem(BaseResource):
+    """Bundle storage metrics for a single content item.
+
+    Attributes
+    ----------
+    content_guid : str
+        The unique identifier of the content item.
+    content_name : str
+        The URL-safe name of the content item.
+    content_title : str | None
+        The human-friendly title of the content item, or ``None``.
+    owner_guid : str | None
+        The unique identifier of the content owner, or ``None``.
+    owner_username : str | None
+        The username of the content owner, or ``None``.
+    app_mode : str
+        The type of content (e.g., ``shiny``, ``rmd``, ``python-api``).
+    bundles : dict
+        Bundle storage metrics with ``count``, ``bytes_total``, ``bytes_active``, and
+        ``bytes_inactive`` keys.
+    """
+
+
+class ContentStorageDetail(BaseResource):
+    """Detailed bundle storage information for a content item.
+
+    Attributes
+    ----------
+    content_guid : str
+        The unique identifier of the content item.
+    content_name : str
+        The name of the content item.
+    owner_guid : str | None
+        The unique identifier of the content owner, or ``None``.
+    owner_username : str | None
+        The username of the content owner, or ``None``.
+    bundle_count : int
+        The number of bundles for this content item.
+    bundle_bytes_total : int
+        Total bytes across all bundles for this content.
+    bundle_bytes_active : int
+        Bytes used by the currently active (deployed) bundle.
+    bundle_bytes_inactive : int
+        Bytes used by inactive (historical) bundles.
+    bundles : list of dict
+        Per-bundle storage details, sorted by creation time (newest first). Each entry
+        has ``id``, ``created_time``, ``size_bytes``, and ``is_active`` keys.
+    """
+
+
+class SystemStorage(ContextManager):
+    """Server-wide bundle storage usage.
+
+    This information is available only to administrators.
+    """
+
+    def __init__(self, ctx: Context, path: str) -> None:
+        super().__init__()
+        self._ctx: Context = ctx
+        # v1/system/storage
+        self._path: str = path
+
+    @requires(version="2026.06.0")
+    def find(self) -> ServerStorage:
+        """Get aggregate bundle storage metrics for the Connect server.
+
+        This information is available only to administrators.
+
+        Returns
+        -------
+        ServerStorage
+            Server-wide bundle storage totals.
+
+        Examples
+        --------
+        ```python
+        from posit.connect import Client
+
+        client = Client()
+
+        storage = client.system.storage.find()
+        print(storage["bundles"]["bytes_total"])
+        ```
+        """
+        response = self._ctx.client.get(self._path)
+        return ServerStorage(self._ctx, **response.json())
+
+
+class ContentStorage(ContextManager):
+    """Bundle storage usage across all content items.
+
+    This information is available only to administrators.
+    """
+
+    def __init__(self, ctx: Context, path: str) -> None:
+        super().__init__()
+        self._ctx: Context = ctx
+        # v1/content/storage
+        self._path: str = path
+
+    @requires(version="2026.06.0")
+    def find(
+        self,
+        *,
+        sort: Optional[str] = None,
+        order: Optional[Literal["asc", "desc"]] = None,
+    ) -> List[ContentStorageItem]:
+        """List bundle storage usage for every content item.
+
+        Results are paginated by the server; this method fetches and returns all pages.
+
+        This information is available only to administrators.
+
+        Parameters
+        ----------
+        sort : str, optional
+            The field to sort by.
+        order : Literal['asc', 'desc'], optional
+            The sort order.
+
+        Returns
+        -------
+        List[ContentStorageItem]
+            Bundle storage metrics for each content item.
+
+        Examples
+        --------
+        ```python
+        from posit.connect import Client
+
+        client = Client()
+
+        items = client.content.storage.find()
+        for item in items:
+            print(item["content_name"], item["bundles"]["bytes_total"])
+        ```
+        """
+        params = {}
+        if sort is not None:
+            params["sort"] = sort
+        if order is not None:
+            params["order"] = order
+
+        results: List[ContentStorageItem] = []
+        page_number = 1
+        while True:
+            response = self._ctx.client.get(
+                self._path,
+                params={**params, "page_number": page_number, "page_size": _MAX_PAGE_SIZE},
+            )
+            body = response.json()
+            page_results = body["results"]
+            results.extend(ContentStorageItem(self._ctx, **result) for result in page_results)
+
+            if not page_results or page_number >= body["total_pages"]:
+                break
+            page_number += 1
+
+        return results
+
+
+class ContentItemStorage(ContextManager):
+    """Bundle storage usage for a single content item.
+
+    This information is available only to administrators.
+    """
+
+    def __init__(self, ctx: Context, path: str) -> None:
+        super().__init__()
+        self._ctx: Context = ctx
+        # v1/content/{guid}/storage
+        self._path: str = path
+
+    @requires(version="2026.06.0")
+    def find(self) -> ContentStorageDetail:
+        """Get bundle storage details for the content item.
+
+        This information is available only to administrators.
+
+        Returns
+        -------
+        ContentStorageDetail
+            Bundle storage details, including per-bundle information.
+
+        Examples
+        --------
+        ```python
+        from posit.connect import Client
+
+        client = Client()
+
+        content = client.content.get("8c8b3a8c-3b3e-4f1c-9c8e-1f2b3c4d5e6f")
+        storage = content.storage.find()
+        for bundle in storage["bundles"]:
+            print(bundle["id"], bundle["size_bytes"], bundle["is_active"])
+        ```
+        """
+        response = self._ctx.client.get(self._path)
+        return ContentStorageDetail(self._ctx, **response.json())

--- a/src/posit/connect/storage.py
+++ b/src/posit/connect/storage.py
@@ -88,44 +88,6 @@ class ContentStorageDetail(BaseResource):
     """
 
 
-class SystemStorage(ContextManager):
-    """Server-wide bundle storage usage.
-
-    This information is available only to administrators.
-    """
-
-    def __init__(self, ctx: Context, path: str) -> None:
-        super().__init__()
-        self._ctx: Context = ctx
-        # v1/system/storage
-        self._path: str = path
-
-    @requires(version="2026.06.0")
-    def find(self) -> ServerStorage:
-        """Get aggregate bundle storage metrics for the Connect server.
-
-        This information is available only to administrators.
-
-        Returns
-        -------
-        ServerStorage
-            Server-wide bundle storage totals.
-
-        Examples
-        --------
-        ```python
-        from posit.connect import Client
-
-        client = Client()
-
-        storage = client.system.storage.find()
-        print(storage["bundles"]["bytes_total"])
-        ```
-        """
-        response = self._ctx.client.get(self._path)
-        return ServerStorage(self._ctx, **response.json())
-
-
 class ContentStorage(ContextManager):
     """Bundle storage usage across all content items.
 
@@ -197,43 +159,3 @@ class ContentStorage(ContextManager):
             page_number += 1
 
         return results
-
-
-class ContentItemStorage(ContextManager):
-    """Bundle storage usage for a single content item.
-
-    This information is available only to administrators.
-    """
-
-    def __init__(self, ctx: Context, path: str) -> None:
-        super().__init__()
-        self._ctx: Context = ctx
-        # v1/content/{guid}/storage
-        self._path: str = path
-
-    @requires(version="2026.06.0")
-    def find(self) -> ContentStorageDetail:
-        """Get bundle storage details for the content item.
-
-        This information is available only to administrators.
-
-        Returns
-        -------
-        ContentStorageDetail
-            Bundle storage details, including per-bundle information.
-
-        Examples
-        --------
-        ```python
-        from posit.connect import Client
-
-        client = Client()
-
-        content = client.content.get("8c8b3a8c-3b3e-4f1c-9c8e-1f2b3c4d5e6f")
-        storage = content.storage.find()
-        for bundle in storage["bundles"]:
-            print(bundle["id"], bundle["size_bytes"], bundle["is_active"])
-        ```
-        """
-        response = self._ctx.client.get(self._path)
-        return ContentStorageDetail(self._ctx, **response.json())

--- a/src/posit/connect/storage.py
+++ b/src/posit/connect/storage.py
@@ -13,13 +13,11 @@ from __future__ import annotations
 from typing_extensions import TYPE_CHECKING, List, Literal, Optional
 
 from .context import ContextManager, requires
+from .paginator import _MAX_PAGE_SIZE
 from .resources import BaseResource
 
 if TYPE_CHECKING:
     from .context import Context
-
-# The maximum page size supported by the API.
-_MAX_PAGE_SIZE = 500
 
 
 class ServerStorage(BaseResource):

--- a/src/posit/connect/system.py
+++ b/src/posit/connect/system.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing_extensions import TYPE_CHECKING, List, Literal, TypedDict, Unpack, overload
 
-from .context import ContextManager
+from .context import ContextManager, requires
 from .resources import Active
-from .storage import SystemStorage
+from .storage import ServerStorage
 
 if TYPE_CHECKING:
     from .context import Context
@@ -47,7 +47,8 @@ class System(ContextManager):
         return SystemCaches(self._ctx, path)
 
     @property
-    def storage(self) -> SystemStorage:
+    @requires(version="2026.06.0")
+    def storage(self) -> ServerStorage:
         """
         Server-wide bundle storage usage.
 
@@ -55,8 +56,8 @@ class System(ContextManager):
 
         Returns
         -------
-        SystemStorage
-            Helper class for server bundle storage.
+        ServerStorage
+            Aggregate bundle storage metrics for the Connect server.
 
         Examples
         --------
@@ -65,11 +66,13 @@ class System(ContextManager):
 
         client = Client()
 
-        storage = client.system.storage.find()
+        storage = client.system.storage
+        print(storage["bundles"]["bytes_total"])
         ```
         """
         path = self._path + "/storage"
-        return SystemStorage(self._ctx, path)
+        response = self._ctx.client.get(path)
+        return ServerStorage(self._ctx, **response.json())
 
 
 class SystemCaches(ContextManager):

--- a/src/posit/connect/system.py
+++ b/src/posit/connect/system.py
@@ -6,6 +6,7 @@ from typing_extensions import TYPE_CHECKING, List, Literal, TypedDict, Unpack, o
 
 from .context import ContextManager
 from .resources import Active
+from .storage import SystemStorage
 
 if TYPE_CHECKING:
     from .context import Context
@@ -44,6 +45,31 @@ class System(ContextManager):
         """
         path = self._path + "/caches"
         return SystemCaches(self._ctx, path)
+
+    @property
+    def storage(self) -> SystemStorage:
+        """
+        Server-wide bundle storage usage.
+
+        This information is available only to administrators.
+
+        Returns
+        -------
+        SystemStorage
+            Helper class for server bundle storage.
+
+        Examples
+        --------
+        ```python
+        from posit.connect import Client
+
+        client = Client()
+
+        storage = client.system.storage.find()
+        ```
+        """
+        path = self._path + "/storage"
+        return SystemStorage(self._ctx, path)
 
 
 class SystemCaches(ContextManager):

--- a/tests/posit/connect/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066/storage.json
+++ b/tests/posit/connect/__api__/v1/content/f2f37341-e21d-3d80-c698-a935ad614066/storage.json
@@ -1,0 +1,30 @@
+{
+  "content_guid": "f2f37341-e21d-3d80-c698-a935ad614066",
+  "content_name": "example-shiny-app",
+  "owner_guid": "20a79ce3-6e87-4522-9faf-be24228800a4",
+  "owner_username": "carlos12",
+  "bundle_count": 3,
+  "bundle_bytes_total": 524288,
+  "bundle_bytes_active": 262144,
+  "bundle_bytes_inactive": 262144,
+  "bundles": [
+    {
+      "id": "103",
+      "created_time": "2026-06-25T18:00:00Z",
+      "size_bytes": 262144,
+      "is_active": true
+    },
+    {
+      "id": "102",
+      "created_time": "2026-06-24T18:00:00Z",
+      "size_bytes": 131072,
+      "is_active": false
+    },
+    {
+      "id": "101",
+      "created_time": "2026-06-23T18:00:00Z",
+      "size_bytes": 131072,
+      "is_active": false
+    }
+  ]
+}

--- a/tests/posit/connect/__api__/v1/content/storage-page1.json
+++ b/tests/posit/connect/__api__/v1/content/storage-page1.json
@@ -1,0 +1,21 @@
+{
+  "results": [
+    {
+      "content_guid": "f2f37341-e21d-3d80-c698-a935ad614066",
+      "content_name": "example-shiny-app",
+      "content_title": "Example Shiny App",
+      "owner_guid": "20a79ce3-6e87-4522-9faf-be24228800a4",
+      "owner_username": "carlos12",
+      "app_mode": "shiny",
+      "bundles": {
+        "count": 3,
+        "bytes_total": 524288,
+        "bytes_active": 262144,
+        "bytes_inactive": 262144
+      }
+    }
+  ],
+  "current_page": 1,
+  "total": 2,
+  "total_pages": 2
+}

--- a/tests/posit/connect/__api__/v1/content/storage-page2.json
+++ b/tests/posit/connect/__api__/v1/content/storage-page2.json
@@ -1,0 +1,21 @@
+{
+  "results": [
+    {
+      "content_guid": "8f9e2c9b-1a3d-4e5f-9c8e-1f2b3c4d5e6f",
+      "content_name": "example-report",
+      "content_title": null,
+      "owner_guid": null,
+      "owner_username": null,
+      "app_mode": "rmd-static",
+      "bundles": {
+        "count": 1,
+        "bytes_total": 131072,
+        "bytes_active": 131072,
+        "bytes_inactive": 0
+      }
+    }
+  ],
+  "current_page": 2,
+  "total": 2,
+  "total_pages": 2
+}

--- a/tests/posit/connect/__api__/v1/content/storage.json
+++ b/tests/posit/connect/__api__/v1/content/storage.json
@@ -1,0 +1,35 @@
+{
+  "results": [
+    {
+      "content_guid": "f2f37341-e21d-3d80-c698-a935ad614066",
+      "content_name": "example-shiny-app",
+      "content_title": "Example Shiny App",
+      "owner_guid": "20a79ce3-6e87-4522-9faf-be24228800a4",
+      "owner_username": "carlos12",
+      "app_mode": "shiny",
+      "bundles": {
+        "count": 3,
+        "bytes_total": 524288,
+        "bytes_active": 262144,
+        "bytes_inactive": 262144
+      }
+    },
+    {
+      "content_guid": "8f9e2c9b-1a3d-4e5f-9c8e-1f2b3c4d5e6f",
+      "content_name": "example-report",
+      "content_title": null,
+      "owner_guid": null,
+      "owner_username": null,
+      "app_mode": "rmd-static",
+      "bundles": {
+        "count": 1,
+        "bytes_total": 131072,
+        "bytes_active": 131072,
+        "bytes_inactive": 0
+      }
+    }
+  ],
+  "current_page": 1,
+  "total": 2,
+  "total_pages": 1
+}

--- a/tests/posit/connect/__api__/v1/system/storage.json
+++ b/tests/posit/connect/__api__/v1/system/storage.json
@@ -1,0 +1,9 @@
+{
+  "bundles": {
+    "bytes_total": 1048576,
+    "bytes_active": 786432,
+    "bytes_inactive": 262144,
+    "count": 12,
+    "content_count": 4
+  }
+}

--- a/tests/posit/connect/test_storage.py
+++ b/tests/posit/connect/test_storage.py
@@ -84,7 +84,7 @@ class TestContentStorage:
             match=[
                 responses.matchers.query_param_matcher(
                     {
-                        "sort": "bytes_total",
+                        "sort": "bundle_bytes_total",
                         "order": "desc",
                         "page_number": 1,
                         "page_size": 500,
@@ -96,7 +96,7 @@ class TestContentStorage:
         client = Client("https://connect.example", "12345")
         client._ctx.version = None
 
-        items = client.content.storage.find(sort="bytes_total", order="desc")
+        items = client.content.storage.find(sort="bundle_bytes_total", order="desc")
 
         assert len(items) == 2
         assert mock_get.call_count == 1

--- a/tests/posit/connect/test_storage.py
+++ b/tests/posit/connect/test_storage.py
@@ -12,7 +12,7 @@ from .api import load_mock_dict
 
 class TestSystemStorage:
     @responses.activate
-    def test_find(self):
+    def test_storage(self):
         mock_get = responses.get(
             "https://connect.example/__api__/v1/system/storage",
             json=load_mock_dict("v1/system/storage.json"),
@@ -21,7 +21,7 @@ class TestSystemStorage:
         client = Client("https://connect.example", "12345")
         client._ctx.version = None
 
-        storage = client.system.storage.find()
+        storage = client.system.storage
 
         assert isinstance(storage, ServerStorage)
         assert storage["bundles"]["count"] == 12
@@ -119,7 +119,7 @@ class TestContentItemStorage:
         client._ctx.version = None
 
         content = client.content.get(guid)
-        storage = content.storage.find()
+        storage = content.storage
 
         assert isinstance(storage, ContentStorageDetail)
         assert storage["content_guid"] == guid

--- a/tests/posit/connect/test_storage.py
+++ b/tests/posit/connect/test_storage.py
@@ -77,6 +77,22 @@ class TestContentStorage:
         assert mock_page2.call_count == 1
 
     @responses.activate
+    def test_find_returns_empty_list_when_no_content(self):
+        mock_get = responses.get(
+            "https://connect.example/__api__/v1/content/storage",
+            json={"results": [], "current_page": 1, "total": 0, "total_pages": 0},
+        )
+
+        client = Client("https://connect.example", "12345")
+        client._ctx.version = None
+
+        items = client.content.storage.find()
+
+        # No content: a single request returns an empty page and the loop stops.
+        assert items == []
+        assert mock_get.call_count == 1
+
+    @responses.activate
     def test_find_with_sort_and_order(self):
         mock_get = responses.get(
             "https://connect.example/__api__/v1/content/storage",

--- a/tests/posit/connect/test_storage.py
+++ b/tests/posit/connect/test_storage.py
@@ -52,6 +52,31 @@ class TestContentStorage:
         assert mock_get.call_count == 1
 
     @responses.activate
+    def test_find_paginates_all_pages(self):
+        mock_page1 = responses.get(
+            "https://connect.example/__api__/v1/content/storage",
+            json=load_mock_dict("v1/content/storage-page1.json"),
+            match=[responses.matchers.query_param_matcher({"page_number": 1, "page_size": 500})],
+        )
+        mock_page2 = responses.get(
+            "https://connect.example/__api__/v1/content/storage",
+            json=load_mock_dict("v1/content/storage-page2.json"),
+            match=[responses.matchers.query_param_matcher({"page_number": 2, "page_size": 500})],
+        )
+
+        client = Client("https://connect.example", "12345")
+        client._ctx.version = None
+
+        items = client.content.storage.find()
+
+        # Results from both pages are concatenated, in page order.
+        assert len(items) == 2
+        assert items[0]["content_guid"] == "f2f37341-e21d-3d80-c698-a935ad614066"
+        assert items[1]["content_guid"] == "8f9e2c9b-1a3d-4e5f-9c8e-1f2b3c4d5e6f"
+        assert mock_page1.call_count == 1
+        assert mock_page2.call_count == 1
+
+    @responses.activate
     def test_find_with_sort_and_order(self):
         mock_get = responses.get(
             "https://connect.example/__api__/v1/content/storage",

--- a/tests/posit/connect/test_storage.py
+++ b/tests/posit/connect/test_storage.py
@@ -1,0 +1,105 @@
+import responses
+
+from posit.connect.client import Client
+from posit.connect.storage import (
+    ContentStorageDetail,
+    ContentStorageItem,
+    ServerStorage,
+)
+
+from .api import load_mock_dict
+
+
+class TestSystemStorage:
+    @responses.activate
+    def test_find(self):
+        mock_get = responses.get(
+            "https://connect.example/__api__/v1/system/storage",
+            json=load_mock_dict("v1/system/storage.json"),
+        )
+
+        client = Client("https://connect.example", "12345")
+        client._ctx.version = None
+
+        storage = client.system.storage.find()
+
+        assert isinstance(storage, ServerStorage)
+        assert storage["bundles"]["count"] == 12
+        assert storage["bundles"]["content_count"] == 4
+        assert storage["bundles"]["bytes_total"] == 1048576
+        assert mock_get.call_count == 1
+
+
+class TestContentStorage:
+    @responses.activate
+    def test_find(self):
+        mock_get = responses.get(
+            "https://connect.example/__api__/v1/content/storage",
+            json=load_mock_dict("v1/content/storage.json"),
+        )
+
+        client = Client("https://connect.example", "12345")
+        client._ctx.version = None
+
+        items = client.content.storage.find()
+
+        assert len(items) == 2
+        for item in items:
+            assert isinstance(item, ContentStorageItem)
+        assert items[0]["content_name"] == "example-shiny-app"
+        assert items[0]["bundles"]["bytes_total"] == 524288
+        assert items[1]["content_title"] is None
+        assert mock_get.call_count == 1
+
+    @responses.activate
+    def test_find_with_sort_and_order(self):
+        mock_get = responses.get(
+            "https://connect.example/__api__/v1/content/storage",
+            json=load_mock_dict("v1/content/storage.json"),
+            match=[
+                responses.matchers.query_param_matcher(
+                    {
+                        "sort": "bytes_total",
+                        "order": "desc",
+                        "page_number": 1,
+                        "page_size": 500,
+                    }
+                )
+            ],
+        )
+
+        client = Client("https://connect.example", "12345")
+        client._ctx.version = None
+
+        items = client.content.storage.find(sort="bytes_total", order="desc")
+
+        assert len(items) == 2
+        assert mock_get.call_count == 1
+
+
+class TestContentItemStorage:
+    @responses.activate
+    def test_find(self):
+        guid = "f2f37341-e21d-3d80-c698-a935ad614066"
+        mock_get_content = responses.get(
+            f"https://connect.example/__api__/v1/content/{guid}",
+            json=load_mock_dict(f"v1/content/{guid}.json"),
+        )
+        mock_get_storage = responses.get(
+            f"https://connect.example/__api__/v1/content/{guid}/storage",
+            json=load_mock_dict(f"v1/content/{guid}/storage.json"),
+        )
+
+        client = Client("https://connect.example", "12345")
+        client._ctx.version = None
+
+        content = client.content.get(guid)
+        storage = content.storage.find()
+
+        assert isinstance(storage, ContentStorageDetail)
+        assert storage["content_guid"] == guid
+        assert storage["bundle_count"] == 3
+        assert len(storage["bundles"]) == 3
+        assert storage["bundles"][0]["is_active"] is True
+        assert mock_get_content.call_count == 1
+        assert mock_get_storage.call_count == 1


### PR DESCRIPTION
Closes #479

Adds SDK support for the three admin-only bundle storage usage endpoints introduced in Connect **2026.06.0**. All access is version-gated with `@requires(version="2026.06.0")`.

## Endpoints

| Endpoint | SDK access | Returns |
|---|---|---|
| `GET /v1/system/storage` | `client.system.storage` | `ServerStorage` |
| `GET /v1/content/storage` | `client.content.storage.find(sort=, order=)` | `List[ContentStorageItem]` |
| `GET /v1/content/{guid}/storage` | `content_item.storage` | `ContentStorageDetail` |

The singular endpoints are exposed as properties that return the resource directly, and `find()` is reserved for the collection endpoint — mirroring the existing `client.me` (singleton) vs `client.users.find()` (collection) convention.

## Changes

- **New module `src/posit/connect/storage.py`** with the `ServerStorage`, `ContentStorageItem`, and `ContentStorageDetail` resource types plus the `ContentStorage` collection helper. Resource fields are documented from the OpenAPI spec with NumPy-style docstrings.
- `client.content.storage.find()` paginates through all pages. The list response uses `current_page`/`total`/`total_pages`, which the existing `Paginator` can't consume directly, so pagination is handled in the helper.
- Wired into `System`, `Content`, and `ContentItem`.
- Registered `connect.storage` in `docs/_quarto.yml`.

## Usage

```python
client.system.storage["bundles"]["bytes_total"]
client.content.storage.find(sort="bytes_total", order="desc")
client.content.get(guid).storage["bundles"]
```

## Testing

- Unit tests in `tests/posit/connect/test_storage.py` with mock fixtures under `__api__/`, including multi-page pagination coverage.
- Integration tests in `integration/tests/posit/connect/test_system.py` (new `TestStorage` class, skipped below 2026.06.0).
- Response schemas verified against the live OpenAPI spec at `docs.posit.co/connect/api/openapi.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)