### PR TITLE
feat: support scheduling content

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -111,6 +111,7 @@ quartodoc:
         - connect.packages
         - connect.permissions
         - connect.repository
+        - connect.schedules
         - connect.system
         - connect.tags
         - connect.tasks

--- a/integration/tests/posit/connect/test_schedules.py
+++ b/integration/tests/posit/connect/test_schedules.py
@@ -39,7 +39,7 @@ class TestSchedules:
 
         assert schedules.find_one() is None
 
-        created = schedules.set(
+        created = schedules.create(
             type="dayofweek",
             days=["monday", "wednesday"],
             start_time="2026-01-01T09:00:00Z",
@@ -54,7 +54,7 @@ class TestSchedules:
         assert found["id"] == created["id"]
         assert found.rule == {"Days": [1, 3]}
 
-        updated = schedules.set(type="hour", n=2, email=True)
+        updated = schedules.create(type="hour", n=2, email=True)
         assert updated["id"] == created["id"]
         assert updated.rule == {"N": 2}
         assert updated["email"] is True
@@ -90,7 +90,7 @@ class TestSchedules:
         ]
         try:
             for kwargs, expected_rule in cases:
-                result = schedules.set(**kwargs)
+                result = schedules.create(**kwargs)
                 assert result.rule == expected_rule, kwargs
                 found = schedules.find_one()
                 assert found is not None

--- a/integration/tests/posit/connect/test_schedules.py
+++ b/integration/tests/posit/connect/test_schedules.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+
+import pytest
+from packaging import version
+from typing_extensions import Any, Dict, List, Tuple
+
+from posit import connect
+
+from . import CONNECT_VERSION
+
+
+@pytest.mark.skipif(
+    CONNECT_VERSION <= version.parse("2023.01.1"),
+    reason="Quarto not available",
+)
+class TestSchedules:
+    @classmethod
+    def setup_class(cls):
+        cls.client = connect.Client()
+        content = cls.client.content.create(name="example-quarto-minimal")
+
+        path = Path("../../../resources/connect/bundles/example-quarto-minimal/bundle.tar.gz")
+        path = Path(__file__).parent / path
+        bundle = content.bundles.create(str(path.resolve()))
+        task = bundle.deploy()
+        task.wait_for()
+
+        # Re-fetch so the content item reflects the deployed application mode
+        # (the record from `create` predates the deploy and still has app_mode
+        # "unknown", which content.schedule rejects).
+        cls.content = cls.client.content.get(content["guid"])
+
+    @classmethod
+    def teardown_class(cls):
+        cls.content.delete()
+        assert cls.client.content.count() == 0
+
+    def test_lifecycle(self):
+        schedules = self.content.schedule
+
+        assert schedules.find_one() is None
+
+        created = schedules.set(
+            type="dayofweek",
+            days=["monday", "wednesday"],
+            start_time="2026-01-01T09:00:00Z",
+            timezone="America/New_York",
+        )
+        assert created.rule == {"Days": [1, 3]}
+        assert created["activate"] is True
+        assert created["timezone"] == "America/New_York"
+
+        found = schedules.find_one()
+        assert found is not None
+        assert found["id"] == created["id"]
+        assert found.rule == {"Days": [1, 3]}
+
+        updated = schedules.set(type="hour", n=2, email=True)
+        assert updated["id"] == created["id"]
+        assert updated.rule == {"N": 2}
+        assert updated["email"] is True
+        assert updated["activate"] is True
+        # fields not specified in the update are preserved
+        assert updated["timezone"] == "America/New_York"
+        assert updated["start_time"] == "2026-01-01T09:00:00Z"
+
+        schedules.delete()
+        assert schedules.find_one() is None
+
+        # idempotent
+        schedules.delete()
+        assert schedules.find_one() is None
+
+    def test_every_schedule_type(self):
+        schedules = self.content.schedule
+        cases: List[Tuple[Dict[str, Any], dict]] = [
+            ({"type": "minute", "n": 15}, {"N": 15}),
+            ({"type": "hour", "n": 2}, {"N": 2}),
+            ({"type": "day", "n": 3}, {"N": 3}),
+            ({"type": "weekday"}, {}),
+            ({"type": "week", "n": 2}, {"N": 2}),
+            ({"type": "dayofweek", "days": [0, 1, 6]}, {"Days": [0, 1, 6]}),
+            ({"type": "semimonth", "first": True}, {"First": True}),
+            ({"type": "semimonth", "first": False}, {"First": False}),
+            ({"type": "dayofmonth", "n": 3, "day": 4}, {"N": 3, "Day": 4}),
+            (
+                {"type": "dayweekofmonth", "n": 3, "day": 1, "week": 4},
+                {"N": 3, "Day": 1, "Week": 4},
+            ),
+            ({"type": "year", "n": 2}, {"N": 2}),
+        ]
+        try:
+            for kwargs, expected_rule in cases:
+                result = schedules.set(**kwargs)
+                assert result.rule == expected_rule, kwargs
+                found = schedules.find_one()
+                assert found is not None
+                assert found.rule == expected_rule, kwargs
+        finally:
+            if schedules.find_one() is not None:
+                schedules.delete()
+
+    def test_interactive_content_not_schedulable(self):
+        content = self.client.content.create(name="unschedulable")
+        try:
+            with pytest.raises(ValueError):
+                content.schedule  # noqa: B018
+        finally:
+            content.delete()

--- a/integration/tests/posit/connect/test_schedules.py
+++ b/integration/tests/posit/connect/test_schedules.py
@@ -25,10 +25,9 @@ class TestSchedules:
         task = bundle.deploy()
         task.wait_for()
 
-        # Re-fetch so the content item reflects the deployed application mode
-        # (the record from `create` predates the deploy and still has app_mode
-        # "unknown", which content.schedule rejects).
-        cls.content = cls.client.content.get(content["guid"])
+        # `content` still has app_mode "unknown" because the record predates the
+        # deploy; content.schedule refreshes it automatically.
+        cls.content = content
 
     @classmethod
     def teardown_class(cls):
@@ -100,7 +99,9 @@ class TestSchedules:
             if schedules.find_one() is not None:
                 schedules.delete()
 
-    def test_interactive_content_not_schedulable(self):
+    def test_undeployed_content_not_schedulable(self):
+        # nothing is deployed, so app_mode remains "unknown" even after the
+        # refresh performed by content.schedule
         content = self.client.content.create(name="unschedulable")
         try:
             with pytest.raises(ValueError):

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -7,6 +7,7 @@ import posixpath
 import re
 import time
 from dataclasses import dataclass
+from functools import cached_property
 
 from typing_extensions import (
     TYPE_CHECKING,
@@ -29,9 +30,10 @@ from .oauth.associations import ContentItemAssociations
 from .permissions import Permissions
 from .repository import ContentItemRepositoryMixin
 from .resources import Active, BaseResource, Resources, _ResourceSequence
+from .schedules import Schedules
 from .tags import ContentItemTags
 from .vanities import VanityMixin
-from .variants import Variants
+from .variants import Variant, Variants
 
 if TYPE_CHECKING:
     from .context import Context
@@ -536,14 +538,7 @@ class ContentItem(Active, ContentItemRepositoryMixin, VanityMixin, BaseResource)
         self.update()  # pyright: ignore[reportCallIssue]
 
         if self.is_rendered:
-            variants = self._variants.find()
-            variants = [variant for variant in variants if variant["is_default"]]
-            if len(variants) != 1:
-                raise RuntimeError(
-                    f"Found {len(variants)} default variants. Expected 1. Without a single default variant, the content cannot be refreshed. This is indicative of a corrupted state.",
-                )
-            variant = variants[0]
-            return variant.render()
+            return self._default_variant.render()
         else:
             raise ValueError(
                 f"Render not supported for this application mode: {self['app_mode']}. Did you need to use the 'restart()' method instead? Note that some application modes do not support 'render()' or 'restart()'.",
@@ -674,6 +669,64 @@ class ContentItem(Active, ContentItemRepositoryMixin, VanityMixin, BaseResource)
     @property
     def _variants(self) -> Variants:
         return Variants(self._ctx, self["guid"])
+
+    @property
+    def _default_variant(self) -> Variant:
+        variants = [variant for variant in self._variants.find() if variant["is_default"]]
+        if len(variants) != 1:
+            raise RuntimeError(
+                f"Found {len(variants)} default variants. Expected 1. This is indicative of a corrupted state.",
+            )
+        return variants[0]
+
+    @cached_property
+    def schedule(self) -> Schedules:
+        """Manager for the render schedule of the content's default variant.
+
+        The first access resolves the content's default variant, which requires a
+        request to the server; the result is cached on this content item.
+
+        Warnings
+        --------
+        The schedule API is backed by unversioned Connect endpoints and is
+        experimental; it may change in future releases. `set()` and `delete()`
+        emit `FutureWarning`.
+
+        Returns
+        -------
+        Schedules
+
+        Raises
+        ------
+        ValueError
+            If the content's application mode does not support rendering, and
+            therefore cannot be scheduled.
+
+        Examples
+        --------
+        ```python
+        from posit import connect
+
+        client = connect.Client()
+        content = client.content.get("CONTENT_GUID_HERE")
+
+        # Read the current schedule, if any
+        schedule = content.schedule.find_one()
+
+        # Render every Monday and Wednesday
+        content.schedule.set(type="dayofweek", days=["monday", "wednesday"])
+
+        # Remove the schedule
+        content.schedule.delete()
+        ```
+        """
+        if not self.is_rendered:
+            raise ValueError(
+                f"Scheduling is not supported for this application mode: {self['app_mode']}. "
+                "Schedules require rendered content, such as R Markdown, Jupyter, or Quarto documents.",
+            )
+        variant = self._default_variant
+        return Schedules(self._ctx, app_id=variant["app_id"], variant_id=variant["id"])
 
     @property
     def is_interactive(self) -> bool:

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -6,6 +6,7 @@ import os
 import posixpath
 import re
 import time
+import warnings
 from dataclasses import dataclass
 from functools import cached_property
 
@@ -688,9 +689,8 @@ class ContentItem(Active, ContentItemRepositoryMixin, VanityMixin, BaseResource)
 
         Warnings
         --------
-        The schedule API is backed by unversioned Connect endpoints and is
-        experimental; it may change in future releases. `set()` and `delete()`
-        emit `FutureWarning`.
+        The schedule API is experimental and may change in future releases.
+        Accessing this property emits a `FutureWarning`.
 
         Returns
         -------
@@ -720,12 +720,22 @@ class ContentItem(Active, ContentItemRepositoryMixin, VanityMixin, BaseResource)
         content.schedule.delete()
         ```
         """
+        if self["app_mode"] == "unknown":
+            # "unknown" is the application mode until a deploy completes, so this
+            # record may predate its deploy; refresh before deciding.
+            response = self._ctx.client.get(f"v1/content/{self['guid']}")
+            super().update(**response.json())
         if not self.is_rendered:
             raise ValueError(
                 f"Scheduling is not supported for this application mode: {self['app_mode']}. "
                 "Schedules require rendered content, such as R Markdown, Jupyter, or Quarto documents.",
             )
         variant = self._default_variant
+        warnings.warn(
+            "The schedule API is experimental and may change in future releases.",
+            FutureWarning,
+            stacklevel=2,
+        )
         return Schedules(self._ctx, app_id=variant["app_id"], variant_id=variant["id"])
 
     @property

--- a/src/posit/connect/content.py
+++ b/src/posit/connect/content.py
@@ -714,7 +714,7 @@ class ContentItem(Active, ContentItemRepositoryMixin, VanityMixin, BaseResource)
         schedule = content.schedule.find_one()
 
         # Render every Monday and Wednesday
-        content.schedule.set(type="dayofweek", days=["monday", "wednesday"])
+        content.schedule.create(type="dayofweek", days=["monday", "wednesday"])
 
         # Remove the schedule
         content.schedule.delete()

--- a/src/posit/connect/schedules.py
+++ b/src/posit/connect/schedules.py
@@ -1,0 +1,446 @@
+"""Schedule resources."""
+
+from __future__ import annotations
+
+import json
+import warnings
+from datetime import datetime, timezone
+
+from typing_extensions import TYPE_CHECKING, List, Literal, Optional, Sequence, Union, overload
+
+from .errors import ClientError
+from .resources import BaseResource, Resources
+
+if TYPE_CHECKING:
+    from .context import Context
+
+# `datetime.timezone` under a distinct name; the `timezone` parameter of
+# `Schedules.set()` shadows the module-level import within its scope.
+_UTC = timezone.utc
+
+ScheduleType = Literal[
+    "minute",
+    "hour",
+    "day",
+    "weekday",
+    "week",
+    "dayofweek",
+    "semimonth",
+    "dayofmonth",
+    "dayweekofmonth",
+    "year",
+]
+
+_DAY_NAMES = {
+    "sunday": 0,
+    "monday": 1,
+    "tuesday": 2,
+    "wednesday": 3,
+    "thursday": 4,
+    "friday": 5,
+    "saturday": 6,
+}
+
+_INTERVAL_TYPES = ("minute", "hour", "day", "week", "year")
+
+
+def _normalize_days(days: Sequence[Union[int, str]]) -> List[int]:
+    """Normalize weekday values to integers where 0 is Sunday and 6 is Saturday."""
+    normalized = set()
+    for day in days:
+        if isinstance(day, str):
+            try:
+                normalized.add(_DAY_NAMES[day.lower()])
+            except KeyError:
+                raise ValueError(
+                    f"Invalid day name: {day!r}. Expected one of {sorted(_DAY_NAMES)}."
+                ) from None
+        elif isinstance(day, bool) or not isinstance(day, int):
+            raise TypeError(f"Invalid day: {day!r}. Expected an int (0-6) or a day name.")
+        elif not 0 <= day <= 6:
+            raise ValueError(f"Invalid day: {day}. Expected an int between 0 (Sunday) and 6.")
+        else:
+            normalized.add(day)
+    if not normalized:
+        raise ValueError("At least one day is required.")
+    return sorted(normalized)
+
+
+def _build_schedule_json(
+    type: ScheduleType,  # noqa: A002
+    *,
+    n: Optional[int] = None,
+    days: Optional[Sequence[Union[int, str]]] = None,
+    day: Optional[int] = None,
+    week: Optional[int] = None,
+    first: Optional[bool] = None,
+) -> str:
+    """Encode the per-type schedule parameters as the JSON string Connect expects."""
+    provided = {
+        name: value
+        for name, value in (
+            ("n", n),
+            ("days", days),
+            ("day", day),
+            ("week", week),
+            ("first", first),
+        )
+        if value is not None
+    }
+    allowed = {
+        "weekday": set(),
+        "dayofweek": {"days"},
+        "semimonth": {"first"},
+        "dayofmonth": {"n", "day"},
+        "dayweekofmonth": {"n", "day", "week"},
+        **{interval: {"n"} for interval in _INTERVAL_TYPES},
+    }
+    try:
+        extraneous = set(provided) - allowed[type]
+    except KeyError:
+        raise ValueError(
+            f"Invalid schedule type: {type!r}. Expected one of {sorted(allowed)}."
+        ) from None
+    if extraneous:
+        if allowed[type]:
+            raise ValueError(
+                f"Invalid parameters for schedule type {type!r}: {sorted(extraneous)}. "
+                f"Allowed parameters: {', '.join(sorted(allowed[type]))}."
+            )
+        raise ValueError(f"Schedule type {type!r} takes no parameters; got {sorted(extraneous)}.")
+    for name, value in (("n", n), ("day", day), ("week", week)):
+        if value is not None and (isinstance(value, bool) or not isinstance(value, int)):
+            raise TypeError(f"Invalid {name}: {value!r}. Expected an int.")
+
+    if type in _INTERVAL_TYPES:
+        if n is None:
+            raise ValueError(f"Schedule type {type!r} requires 'n'.")
+        if n < 1:
+            raise ValueError(f"Invalid n: {n}. Expected an int greater than or equal to 1.")
+        return json.dumps({"N": n})
+    if type == "weekday":
+        return json.dumps({})
+    if type == "dayofweek":
+        if days is None:
+            raise ValueError("Schedule type 'dayofweek' requires 'days'.")
+        return json.dumps({"Days": _normalize_days(days)})
+    if type == "semimonth":
+        return json.dumps({"First": True if first is None else first})
+    # 'dayofmonth' and 'dayweekofmonth'
+    if day is None:
+        raise ValueError(f"Schedule type {type!r} requires 'day'.")
+    n = 1 if n is None else n
+    if n < 1:
+        raise ValueError(f"Invalid n: {n}. Expected an int greater than or equal to 1.")
+    if type == "dayofmonth":
+        if not 1 <= day <= 31:
+            raise ValueError(f"Invalid day: {day}. Expected an int between 1 and 31.")
+        return json.dumps({"N": n, "Day": day})
+    if week is None:
+        raise ValueError("Schedule type 'dayweekofmonth' requires 'week'.")
+    if not 0 <= day <= 6:
+        raise ValueError(f"Invalid day: {day}. Expected an int between 0 (Sunday) and 6.")
+    if not 0 <= week <= 5:
+        raise ValueError(f"Invalid week: {week}. Expected an int between 0 and 5.")
+    return json.dumps({"N": n, "Day": day, "Week": week})
+
+
+def _format_start_time(start_time: Union[datetime, str]) -> str:
+    """Format a start time as the UTC RFC 3339 timestamp Connect expects.
+
+    Naive datetimes are assumed to be UTC.
+    """
+    if isinstance(start_time, str):
+        return start_time
+    if start_time.tzinfo is None:
+        start_time = start_time.replace(tzinfo=timezone.utc)
+    return start_time.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class Schedule(BaseResource):
+    """A schedule for rendering a variant of a content item.
+
+    Warnings
+    --------
+    This API is backed by unversioned Connect endpoints and is experimental; it may
+    change in future releases.
+    """
+
+    @property
+    def rule(self) -> dict:
+        """The decoded per-type schedule parameters.
+
+        The server returns the `"schedule"` field as a JSON-encoded string (e.g.
+        `'{"N":3}'`). This property returns it decoded.
+
+        Returns
+        -------
+        dict
+        """
+        return json.loads(self["schedule"])
+
+    def destroy(self) -> None:
+        """Destroy the schedule.
+
+        Warnings
+        --------
+        This operation is backed by an unversioned Connect endpoint and is experimental.
+        """
+        warnings.warn(
+            "destroy() is experimental and may change in future releases.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        self._ctx.client.delete(f"schedules/{self['id']}")
+
+
+class Schedules(Resources):
+    """Manager for the render schedule of a single variant.
+
+    A variant has at most one schedule.
+
+    Warnings
+    --------
+    This API is backed by unversioned Connect endpoints and is experimental; it may
+    change in future releases. `set()` and `delete()` emit `FutureWarning`.
+    """
+
+    def __init__(self, ctx: Context, *, app_id: int, variant_id: int) -> None:
+        super().__init__(ctx)
+        self.app_id = app_id
+        self.variant_id = variant_id
+
+    def find_one(self) -> Schedule | None:
+        """Find the schedule for this variant.
+
+        Returns
+        -------
+        Schedule | None
+            The current schedule, or `None` if the variant is not scheduled.
+        """
+        response = self._ctx.client.get(f"variants/{self.variant_id}/schedules")
+        results = response.json() or []
+        return next((Schedule(self._ctx, **result) for result in results), None)
+
+    @overload
+    def set(
+        self,
+        *,
+        type: Literal["minute", "hour", "day", "week", "year"],
+        n: int,
+        start_time: Union[datetime, str, None] = None,
+        timezone: Optional[str] = None,
+        email: Optional[bool] = None,
+    ) -> Schedule: ...
+
+    @overload
+    def set(
+        self,
+        *,
+        type: Literal["weekday"],
+        start_time: Union[datetime, str, None] = None,
+        timezone: Optional[str] = None,
+        email: Optional[bool] = None,
+    ) -> Schedule: ...
+
+    @overload
+    def set(
+        self,
+        *,
+        type: Literal["dayofweek"],
+        days: Sequence[Union[int, str]],
+        start_time: Union[datetime, str, None] = None,
+        timezone: Optional[str] = None,
+        email: Optional[bool] = None,
+    ) -> Schedule: ...
+
+    @overload
+    def set(
+        self,
+        *,
+        type: Literal["semimonth"],
+        first: bool = True,
+        start_time: Union[datetime, str, None] = None,
+        timezone: Optional[str] = None,
+        email: Optional[bool] = None,
+    ) -> Schedule: ...
+
+    @overload
+    def set(
+        self,
+        *,
+        type: Literal["dayofmonth"],
+        day: int,
+        n: int = 1,
+        start_time: Union[datetime, str, None] = None,
+        timezone: Optional[str] = None,
+        email: Optional[bool] = None,
+    ) -> Schedule: ...
+
+    @overload
+    def set(
+        self,
+        *,
+        type: Literal["dayweekofmonth"],
+        day: int,
+        week: int,
+        n: int = 1,
+        start_time: Union[datetime, str, None] = None,
+        timezone: Optional[str] = None,
+        email: Optional[bool] = None,
+    ) -> Schedule: ...
+
+    def set(
+        self,
+        *,
+        type: ScheduleType,  # noqa: A002
+        start_time: Union[datetime, str, None] = None,
+        timezone: Optional[str] = None,
+        email: Optional[bool] = None,
+        **kwargs,
+    ) -> Schedule:
+        """Create or update the schedule for this variant.
+
+        If the variant is not scheduled, a new schedule is created. Otherwise, the
+        provided fields are merged over the existing schedule.
+
+        New schedules are created with activation enabled (matching the Connect
+        dashboard): each successful render is published as the variant's current
+        rendering, making it what viewers see. Updates preserve the schedule's
+        existing activation setting.
+
+        Parameters
+        ----------
+        type : str
+            The recurrence type. One of `"minute"`, `"hour"`, `"day"`, `"weekday"`
+            (every Monday through Friday), `"week"`, `"dayofweek"`, `"semimonth"`,
+            `"dayofmonth"`, `"dayweekofmonth"`, or `"year"`.
+        n : int
+            Render every `n` minutes/hours/days/weeks/months/years, depending on
+            `type`. Required for `"minute"`, `"hour"`, `"day"`, `"week"`, and
+            `"year"`; optional (default `1`) for `"dayofmonth"` and
+            `"dayweekofmonth"`.
+        days : Sequence[int | str]
+            For `"dayofweek"`: the days of the week on which to render. Integers
+            between `0` (Sunday) and `6` (Saturday), or case-insensitive day names
+            (e.g. `"monday"`). Note the integer encoding differs from Python's
+            `datetime.weekday()`, where 0 is Monday.
+        first : bool
+            For `"semimonth"`: `True` to render on the 1st and 15th of the month,
+            `False` to render on the 14th and the last day of the month. Default
+            `True`.
+        day : int
+            For `"dayofmonth"`: the day of the month, between 1 and 31. For
+            `"dayweekofmonth"`: the day of the week, between `0` (Sunday) and `6`.
+        week : int
+            For `"dayweekofmonth"`: the week of the month, between 0 and 5.
+        start_time : datetime | str, optional
+            When the schedule takes effect. Strings are passed through unchanged and
+            must be RFC 3339 timestamps; datetimes are converted to UTC, with naive
+            datetimes assumed to be UTC. When creating a schedule, defaults to the
+            current time; when updating, the existing value is kept.
+        timezone : str, optional
+            The IANA timezone in which the schedule is interpreted (e.g.
+            `"America/New_York"`). When creating a schedule, defaults to `"UTC"`;
+            when updating, the existing value is kept. See `GET v1/timezones` for
+            valid values.
+        email : bool, optional
+            Whether to send an email upon rendering. When creating a schedule,
+            defaults to `False`; when updating, the existing value is kept.
+
+        Returns
+        -------
+        Schedule
+
+        Warnings
+        --------
+        This operation is backed by an unversioned Connect endpoint and is experimental.
+
+        Examples
+        --------
+        ```python
+        from posit import connect
+
+        client = connect.Client()
+        content = client.content.get("CONTENT_GUID_HERE")
+
+        # Render every Monday and Wednesday at the current time of day
+        content.schedule.set(
+            type="dayofweek",
+            days=["monday", "wednesday"],
+            timezone="America/New_York",
+        )
+
+        # Render every 2 hours
+        content.schedule.set(type="hour", n=2)
+
+        # Render on the 1st and 15th of each month
+        content.schedule.set(type="semimonth", first=True)
+        ```
+        """
+        warnings.warn(
+            "set() is experimental and may change in future releases.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        schedule = _build_schedule_json(type, **kwargs)
+        body: dict = {"type": type, "schedule": schedule}
+        if start_time is not None:
+            body["start_time"] = _format_start_time(start_time)
+        if timezone is not None:
+            body["timezone"] = timezone
+        if email is not None:
+            body["email"] = email
+
+        existing = self.find_one()
+        if existing is None:
+            body.setdefault("start_time", _format_start_time(datetime.now(tz=_UTC)))
+            body.setdefault("timezone", "UTC")
+            body.setdefault("email", False)
+            # `activate` controls whether a scheduled render is published as the
+            # variant's current rendering and whether the success email is sent;
+            # the server stores false when omitted, which makes the schedule run
+            # without any visible effect. The Connect dashboard always sends true
+            # on create; do the same. Updates preserve the existing value via the
+            # merge below.
+            body["activate"] = True
+            body["app_id"] = self.app_id
+            body["variant_id"] = self.variant_id
+            response = self._ctx.client.post("schedules", json=body)
+        else:
+            # The update endpoint has full-replace semantics: `id`, `app_id`,
+            # `variant_id`, `start_time`, and `timezone` are required in the body,
+            # and omitted writable fields (e.g. `activate`) are reset to zero
+            # values. Extra fields are ignored, so send the complete existing
+            # record with the changes merged over it.
+            merged = dict(existing)
+            merged.pop("next_run", None)
+            merged.update(body)
+            response = self._ctx.client.post(f"schedules/{existing['id']}", json=merged)
+        return Schedule(self._ctx, **response.json())
+
+    def delete(self) -> None:
+        """Delete the schedule for this variant.
+
+        Idempotent: does nothing if the variant is not scheduled.
+
+        Warnings
+        --------
+        This operation is backed by an unversioned Connect endpoint and is experimental.
+        """
+        warnings.warn(
+            "delete() is experimental and may change in future releases.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        existing = self.find_one()
+        if existing is None:
+            return
+        try:
+            self._ctx.client.delete(f"schedules/{existing['id']}")
+        except ClientError as e:
+            # The schedule can disappear between the lookup and the delete (e.g.
+            # removed in the dashboard or by a concurrent pipeline); that still
+            # counts as successfully unscheduled.
+            if e.http_status != 404:
+                raise

--- a/src/posit/connect/schedules.py
+++ b/src/posit/connect/schedules.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from .context import Context
 
 # `datetime.timezone` under a distinct name; the `timezone` parameter of
-# `Schedules.set()` shadows the module-level import within its scope.
+# `Schedules.create()` shadows the module-level import within its scope.
 _UTC = timezone.utc
 
 ScheduleType = Literal[
@@ -73,7 +73,7 @@ def _build_schedule_json(
     day: Optional[int] = None,
     week: Optional[int] = None,
     # `object` rather than `Optional[bool]` because values arrive untyped via
-    # `Schedules.set(**kwargs)`; the isinstance check below is the real gate.
+    # `Schedules.create(**kwargs)`; the isinstance check below is the real gate.
     first: object = None,
 ) -> str:
     """Encode the per-type schedule parameters as the JSON string Connect expects."""
@@ -220,7 +220,7 @@ class Schedules(Resources):
         return next((Schedule(self._ctx, **result) for result in results), None)
 
     @overload
-    def set(
+    def create(
         self,
         *,
         type: Literal["minute", "hour", "day", "week", "year"],
@@ -231,7 +231,7 @@ class Schedules(Resources):
     ) -> Schedule: ...
 
     @overload
-    def set(
+    def create(
         self,
         *,
         type: Literal["weekday"],
@@ -241,7 +241,7 @@ class Schedules(Resources):
     ) -> Schedule: ...
 
     @overload
-    def set(
+    def create(
         self,
         *,
         type: Literal["dayofweek"],
@@ -252,7 +252,7 @@ class Schedules(Resources):
     ) -> Schedule: ...
 
     @overload
-    def set(
+    def create(
         self,
         *,
         type: Literal["semimonth"],
@@ -263,7 +263,7 @@ class Schedules(Resources):
     ) -> Schedule: ...
 
     @overload
-    def set(
+    def create(
         self,
         *,
         type: Literal["dayofmonth"],
@@ -275,7 +275,7 @@ class Schedules(Resources):
     ) -> Schedule: ...
 
     @overload
-    def set(
+    def create(
         self,
         *,
         type: Literal["dayweekofmonth"],
@@ -287,7 +287,7 @@ class Schedules(Resources):
         email: Optional[bool] = None,
     ) -> Schedule: ...
 
-    def set(
+    def create(
         self,
         *,
         type: ScheduleType,  # noqa: A002
@@ -362,17 +362,17 @@ class Schedules(Resources):
         content = client.content.get("CONTENT_GUID_HERE")
 
         # Render every Monday and Wednesday at the current time of day
-        content.schedule.set(
+        content.schedule.create(
             type="dayofweek",
             days=["monday", "wednesday"],
             timezone="America/New_York",
         )
 
         # Render every 2 hours
-        content.schedule.set(type="hour", n=2)
+        content.schedule.create(type="hour", n=2)
 
         # Render on the 1st and 15th of each month
-        content.schedule.set(type="semimonth", first=True)
+        content.schedule.create(type="semimonth", first=True)
         ```
         """
         schedule = _build_schedule_json(type, **kwargs)

--- a/src/posit/connect/schedules.py
+++ b/src/posit/connect/schedules.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import warnings
 from datetime import datetime, timezone
 
 from typing_extensions import TYPE_CHECKING, List, Literal, Optional, Sequence, Union, overload
@@ -73,7 +72,9 @@ def _build_schedule_json(
     days: Optional[Sequence[Union[int, str]]] = None,
     day: Optional[int] = None,
     week: Optional[int] = None,
-    first: Optional[bool] = None,
+    # `object` rather than `Optional[bool]` because values arrive untyped via
+    # `Schedules.set(**kwargs)`; the isinstance check below is the real gate.
+    first: object = None,
 ) -> str:
     """Encode the per-type schedule parameters as the JSON string Connect expects."""
     provided = {
@@ -125,6 +126,8 @@ def _build_schedule_json(
             raise ValueError("Schedule type 'dayofweek' requires 'days'.")
         return json.dumps({"Days": _normalize_days(days)})
     if type == "semimonth":
+        if first is not None and not isinstance(first, bool):
+            raise TypeError(f"Invalid first: {first!r}. Expected a bool.")
         return json.dumps({"First": True if first is None else first})
     # 'dayofmonth' and 'dayweekofmonth'
     if day is None:
@@ -162,8 +165,7 @@ class Schedule(BaseResource):
 
     Warnings
     --------
-    This API is backed by unversioned Connect endpoints and is experimental; it may
-    change in future releases.
+    The schedule API is experimental and may change in future releases.
     """
 
     @property
@@ -184,13 +186,8 @@ class Schedule(BaseResource):
 
         Warnings
         --------
-        This operation is backed by an unversioned Connect endpoint and is experimental.
+        This operation is experimental and may change in future releases.
         """
-        warnings.warn(
-            "destroy() is experimental and may change in future releases.",
-            FutureWarning,
-            stacklevel=2,
-        )
         self._ctx.client.delete(f"schedules/{self['id']}")
 
 
@@ -201,8 +198,8 @@ class Schedules(Resources):
 
     Warnings
     --------
-    This API is backed by unversioned Connect endpoints and is experimental; it may
-    change in future releases. `set()` and `delete()` emit `FutureWarning`.
+    The schedule API is experimental and may change in future releases. Accessing
+    it via `ContentItem.schedule` or `Variant.schedules` emits a `FutureWarning`.
     """
 
     def __init__(self, ctx: Context, *, app_id: int, variant_id: int) -> None:
@@ -354,7 +351,7 @@ class Schedules(Resources):
 
         Warnings
         --------
-        This operation is backed by an unversioned Connect endpoint and is experimental.
+        This operation is experimental and may change in future releases.
 
         Examples
         --------
@@ -378,11 +375,6 @@ class Schedules(Resources):
         content.schedule.set(type="semimonth", first=True)
         ```
         """
-        warnings.warn(
-            "set() is experimental and may change in future releases.",
-            FutureWarning,
-            stacklevel=2,
-        )
         schedule = _build_schedule_json(type, **kwargs)
         body: dict = {"type": type, "schedule": schedule}
         if start_time is not None:
@@ -426,13 +418,8 @@ class Schedules(Resources):
 
         Warnings
         --------
-        This operation is backed by an unversioned Connect endpoint and is experimental.
+        This operation is experimental and may change in future releases.
         """
-        warnings.warn(
-            "delete() is experimental and may change in future releases.",
-            FutureWarning,
-            stacklevel=2,
-        )
         existing = self.find_one()
         if existing is None:
             return

--- a/src/posit/connect/variants.py
+++ b/src/posit/connect/variants.py
@@ -16,7 +16,14 @@ class Variant(BaseResource):
         Warnings
         --------
         The schedule API is experimental and may change in future releases.
+
+        Accessing this property emits a `FutureWarning`.
         """
+        warnings.warn(
+            "The schedule API is experimental and may change in future releases.",
+            FutureWarning,
+            stacklevel=2,
+        )
         return Schedules(self._ctx, app_id=self["app_id"], variant_id=self["id"])
 
     def render(self) -> Task:

--- a/src/posit/connect/variants.py
+++ b/src/posit/connect/variants.py
@@ -4,10 +4,22 @@ from typing_extensions import List, Literal
 
 from .context import Context
 from .resources import BaseResource, Resources
+from .schedules import Schedules
 from .tasks import Task
 
 
 class Variant(BaseResource):
+    @property
+    def schedules(self) -> Schedules:
+        """Manager for this variant's render schedule.
+
+        Warnings
+        --------
+        The schedule API is backed by unversioned Connect endpoints and is
+        experimental; it may change in future releases.
+        """
+        return Schedules(self._ctx, app_id=self["app_id"], variant_id=self["id"])
+
     def render(self) -> Task:
         path = f"variants/{self['id']}/render"
         response = self._ctx.client.post(path)

--- a/src/posit/connect/variants.py
+++ b/src/posit/connect/variants.py
@@ -15,8 +15,7 @@ class Variant(BaseResource):
 
         Warnings
         --------
-        The schedule API is backed by unversioned Connect endpoints and is
-        experimental; it may change in future releases.
+        The schedule API is experimental and may change in future releases.
         """
         return Schedules(self._ctx, app_id=self["app_id"], variant_id=self["id"])
 

--- a/tests/posit/connect/__api__/schedules.json
+++ b/tests/posit/connect/__api__/schedules.json
@@ -1,0 +1,12 @@
+{
+    "id": 24,
+    "app_id": 50941,
+    "variant_id": 6627,
+    "type": "dayofweek",
+    "schedule": "{\"Days\": [1, 3]}",
+    "start_time": "2026-01-01T12:00:00Z",
+    "next_run": "2026-01-05T12:00:00Z",
+    "timezone": "America/New_York",
+    "activate": true,
+    "email": false
+}

--- a/tests/posit/connect/__api__/schedules/24.json
+++ b/tests/posit/connect/__api__/schedules/24.json
@@ -1,0 +1,12 @@
+{
+    "id": 24,
+    "app_id": 50941,
+    "variant_id": 6627,
+    "type": "hour",
+    "schedule": "{\"N\": 2}",
+    "start_time": "2026-01-01T12:00:00Z",
+    "next_run": "2026-01-01T14:00:00Z",
+    "timezone": "UTC",
+    "activate": true,
+    "email": false
+}

--- a/tests/posit/connect/__api__/variants/6627/schedules.json
+++ b/tests/posit/connect/__api__/variants/6627/schedules.json
@@ -1,0 +1,14 @@
+[
+    {
+        "id": 24,
+        "app_id": 50941,
+        "variant_id": 6627,
+        "type": "day",
+        "schedule": "{\"N\":1}",
+        "start_time": "2026-01-01T12:00:00Z",
+        "next_run": "2026-01-02T12:00:00Z",
+        "timezone": "UTC",
+        "activate": false,
+        "email": false
+    }
+]

--- a/tests/posit/connect/test_schedules.py
+++ b/tests/posit/connect/test_schedules.py
@@ -155,7 +155,7 @@ class TestSchedulesFindOne:
         assert schedule.rule == {"N": 1}
 
 
-class TestSchedulesSet:
+class TestSchedulesCreate:
     @responses.activate
     def test_create(self):
         responses.get(
@@ -184,7 +184,7 @@ class TestSchedulesSet:
         c = Client("https://connect.example.com", "12345")
         schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
 
-        schedule = schedules.set(
+        schedule = schedules.create(
             type="dayofweek",
             days=["monday", "wednesday"],
             start_time="2026-01-01T12:00:00Z",
@@ -208,7 +208,7 @@ class TestSchedulesSet:
         c = Client("https://connect.example.com", "12345")
         schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
 
-        schedules.set(type="day", n=1)
+        schedules.create(type="day", n=1)
 
         body = json.loads(mock_post.calls[0].request.body)  # pyright: ignore[reportArgumentType]
         assert body["start_time"].endswith("Z")
@@ -250,7 +250,7 @@ class TestSchedulesSet:
         c = Client("https://connect.example.com", "12345")
         schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
 
-        schedule = schedules.set(type="hour", n=2, email=True)
+        schedule = schedules.create(type="hour", n=2, email=True)
 
         assert schedule["type"] == "hour"
         assert mock_post.call_count == 1
@@ -261,7 +261,7 @@ class TestSchedulesSet:
         schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
 
         with pytest.raises(ValueError, match="Invalid parameters"):
-            schedules.set(type="hour", n=1, days=[1])  # pyright: ignore[reportCallIssue]
+            schedules.create(type="hour", n=1, days=[1])  # pyright: ignore[reportCallIssue]
 
 
 class TestSchedulesDelete:

--- a/tests/posit/connect/test_schedules.py
+++ b/tests/posit/connect/test_schedules.py
@@ -1,0 +1,464 @@
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import responses
+from responses import matchers
+
+from posit.connect.client import Client
+from posit.connect.errors import ClientError
+from posit.connect.schedules import (
+    Schedule,
+    Schedules,
+    _build_schedule_json,
+    _format_start_time,
+    _normalize_days,
+)
+from posit.connect.variants import Variant
+
+from .api import load_mock
+
+
+class TestNormalizeDays:
+    def test_names_and_ints(self):
+        assert _normalize_days([0, 3, 6]) == [0, 3, 6]
+        assert _normalize_days(["monday", "wednesday"]) == [1, 3]
+        assert _normalize_days(["Saturday", 0, "monday"]) == [0, 1, 6]
+
+    def test_dedupe_and_sort(self):
+        assert _normalize_days(["sunday", 0, 6, "saturday"]) == [0, 6]
+
+    def test_invalid_name(self):
+        with pytest.raises(ValueError, match="Invalid day name"):
+            _normalize_days(["mondayy"])
+
+    def test_out_of_range(self):
+        with pytest.raises(ValueError, match="Invalid day"):
+            _normalize_days([7])
+
+    def test_bool_rejected(self):
+        with pytest.raises(TypeError, match="Invalid day"):
+            _normalize_days([True])
+
+    def test_empty(self):
+        with pytest.raises(ValueError, match="At least one day"):
+            _normalize_days([])
+
+
+class TestBuildScheduleJson:
+    @pytest.mark.parametrize(
+        ("schedule_type", "kwargs", "expected"),
+        [
+            ("minute", {"n": 15}, {"N": 15}),
+            ("hour", {"n": 2}, {"N": 2}),
+            ("day", {"n": 3}, {"N": 3}),
+            ("week", {"n": 2}, {"N": 2}),
+            ("year", {"n": 1}, {"N": 1}),
+            ("weekday", {}, {}),
+            ("dayofweek", {"days": [1, 3]}, {"Days": [1, 3]}),
+            ("dayofweek", {"days": ["monday", "wednesday"]}, {"Days": [1, 3]}),
+            ("semimonth", {"first": True}, {"First": True}),
+            ("semimonth", {"first": False}, {"First": False}),
+            ("semimonth", {}, {"First": True}),
+            ("dayofmonth", {"n": 3, "day": 4}, {"N": 3, "Day": 4}),
+            ("dayofmonth", {"day": 4}, {"N": 1, "Day": 4}),
+            ("dayweekofmonth", {"n": 3, "day": 1, "week": 4}, {"N": 3, "Day": 1, "Week": 4}),
+            ("dayweekofmonth", {"day": 0, "week": 0}, {"N": 1, "Day": 0, "Week": 0}),
+        ],
+    )
+    def test_encoding(self, schedule_type, kwargs, expected):
+        result = _build_schedule_json(schedule_type, **kwargs)
+        assert isinstance(result, str)
+        assert json.loads(result) == expected
+
+    @pytest.mark.parametrize(
+        ("schedule_type", "kwargs", "match"),
+        [
+            ("minute", {}, "requires 'n'"),
+            ("day", {"n": 0}, "Invalid n"),
+            ("hour", {"n": 1, "days": [1]}, "Invalid parameters"),
+            ("weekday", {"n": 1}, "takes no parameters"),
+            ("dayofweek", {}, "requires 'days'"),
+            ("dayofweek", {"days": []}, "At least one day"),
+            ("dayofmonth", {}, "requires 'day'"),
+            ("dayofmonth", {"day": 0}, "Invalid day"),
+            ("dayofmonth", {"day": 32}, "Invalid day"),
+            ("dayofmonth", {"day": 1, "n": 0}, "Invalid n"),
+            ("dayweekofmonth", {"day": 1}, "requires 'week'"),
+            ("dayweekofmonth", {"day": 7, "week": 1}, "Invalid day"),
+            ("dayweekofmonth", {"day": 1, "week": 6}, "Invalid week"),
+            ("fortnight", {}, "Invalid schedule type"),
+        ],
+    )
+    def test_validation(self, schedule_type, kwargs, match):
+        with pytest.raises(ValueError, match=match):
+            _build_schedule_json(schedule_type, **kwargs)
+
+    @pytest.mark.parametrize(
+        ("schedule_type", "kwargs", "match"),
+        [
+            ("hour", {"n": True}, "Invalid n"),
+            ("hour", {"n": 2.5}, "Invalid n"),
+            ("dayofmonth", {"day": True}, "Invalid day"),
+            ("dayweekofmonth", {"day": 1, "week": "1"}, "Invalid week"),
+        ],
+    )
+    def test_non_int_params_rejected(self, schedule_type, kwargs, match):
+        with pytest.raises(TypeError, match=match):
+            _build_schedule_json(schedule_type, **kwargs)
+
+
+class TestFormatStartTime:
+    def test_string_passthrough(self):
+        assert _format_start_time("2026-01-01T09:00:00Z") == "2026-01-01T09:00:00Z"
+
+    def test_aware_datetime_converted_to_utc(self):
+        eastern = timezone(timedelta(hours=-5))
+        start_time = datetime(2026, 1, 1, 7, 0, 0, tzinfo=eastern)
+        assert _format_start_time(start_time) == "2026-01-01T12:00:00Z"
+
+    def test_naive_datetime_assumed_utc(self):
+        start_time = datetime(2026, 1, 1, 12, 0, 0)
+        assert _format_start_time(start_time) == "2026-01-01T12:00:00Z"
+
+
+class TestSchedulesFindOne:
+    @responses.activate
+    def test_none_when_unscheduled(self):
+        responses.get(
+            "https://connect.example.com/__api__/variants/6627/schedules",
+            json=[],
+        )
+
+        c = Client("https://connect.example.com", "12345")
+        schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
+
+        assert schedules.find_one() is None
+
+    @responses.activate
+    def test_returns_schedule(self):
+        responses.get(
+            "https://connect.example.com/__api__/variants/6627/schedules",
+            json=load_mock("variants/6627/schedules.json"),
+        )
+
+        c = Client("https://connect.example.com", "12345")
+        schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
+
+        schedule = schedules.find_one()
+        assert schedule is not None
+        assert schedule["id"] == 24
+        assert schedule["type"] == "day"
+        assert schedule["schedule"] == '{"N":1}'
+        assert schedule.rule == {"N": 1}
+
+
+class TestSchedulesSet:
+    @responses.activate
+    def test_create(self):
+        responses.get(
+            "https://connect.example.com/__api__/variants/6627/schedules",
+            json=[],
+        )
+        mock_post = responses.post(
+            "https://connect.example.com/__api__/schedules",
+            json=load_mock("schedules.json"),
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "type": "dayofweek",
+                        "schedule": json.dumps({"Days": [1, 3]}),
+                        "activate": True,
+                        "start_time": "2026-01-01T12:00:00Z",
+                        "timezone": "America/New_York",
+                        "email": False,
+                        "app_id": 50941,
+                        "variant_id": 6627,
+                    }
+                )
+            ],
+        )
+
+        c = Client("https://connect.example.com", "12345")
+        schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
+
+        with pytest.warns(FutureWarning, match="set.*experimental"):
+            schedule = schedules.set(
+                type="dayofweek",
+                days=["monday", "wednesday"],
+                start_time="2026-01-01T12:00:00Z",
+                timezone="America/New_York",
+            )
+
+        assert schedule["id"] == 24
+        assert mock_post.call_count == 1
+
+    @responses.activate
+    def test_create_defaults(self):
+        responses.get(
+            "https://connect.example.com/__api__/variants/6627/schedules",
+            json=[],
+        )
+        mock_post = responses.post(
+            "https://connect.example.com/__api__/schedules",
+            json=load_mock("schedules.json"),
+        )
+
+        c = Client("https://connect.example.com", "12345")
+        schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
+
+        with pytest.warns(FutureWarning, match="set.*experimental"):
+            schedules.set(type="day", n=1)
+
+        body = json.loads(mock_post.calls[0].request.body)  # pyright: ignore[reportArgumentType]
+        assert body["start_time"].endswith("Z")
+        assert body["timezone"] == "UTC"
+        assert body["email"] is False
+        assert body["activate"] is True
+        assert body["app_id"] == 50941
+        assert body["variant_id"] == 6627
+
+    @responses.activate
+    def test_update_merges_over_existing(self):
+        responses.get(
+            "https://connect.example.com/__api__/variants/6627/schedules",
+            json=load_mock("variants/6627/schedules.json"),
+        )
+        mock_post = responses.post(
+            "https://connect.example.com/__api__/schedules/24",
+            json=load_mock("schedules/24.json"),
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        # updated fields
+                        "type": "hour",
+                        "schedule": json.dumps({"N": 2}),
+                        "email": True,
+                        # fields preserved from the existing schedule, including a
+                        # non-default "activate"; "next_run" is stripped
+                        "id": 24,
+                        "app_id": 50941,
+                        "variant_id": 6627,
+                        "start_time": "2026-01-01T12:00:00Z",
+                        "timezone": "UTC",
+                        "activate": False,
+                    }
+                )
+            ],
+        )
+
+        c = Client("https://connect.example.com", "12345")
+        schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
+
+        with pytest.warns(FutureWarning, match="set.*experimental"):
+            schedule = schedules.set(type="hour", n=2, email=True)
+
+        assert schedule["type"] == "hour"
+        assert mock_post.call_count == 1
+
+    @responses.activate
+    def test_invalid_params_raise_before_any_request(self):
+        c = Client("https://connect.example.com", "12345")
+        schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
+
+        with pytest.warns(FutureWarning), pytest.raises(ValueError, match="Invalid parameters"):
+            schedules.set(type="hour", n=1, days=[1])  # pyright: ignore[reportCallIssue]
+
+
+class TestSchedulesDelete:
+    @responses.activate
+    def test_delete(self):
+        responses.get(
+            "https://connect.example.com/__api__/variants/6627/schedules",
+            json=load_mock("variants/6627/schedules.json"),
+        )
+        mock_delete = responses.delete(
+            "https://connect.example.com/__api__/schedules/24",
+            body="",
+        )
+
+        c = Client("https://connect.example.com", "12345")
+        schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
+
+        with pytest.warns(FutureWarning, match="delete.*experimental"):
+            schedules.delete()
+
+        assert mock_delete.call_count == 1
+
+    @responses.activate
+    def test_delete_without_schedule_is_noop(self):
+        # no DELETE endpoint is registered; an attempted DELETE would error
+        responses.get(
+            "https://connect.example.com/__api__/variants/6627/schedules",
+            json=[],
+        )
+
+        c = Client("https://connect.example.com", "12345")
+        schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
+
+        with pytest.warns(FutureWarning):
+            schedules.delete()
+
+    @responses.activate
+    def test_delete_tolerates_races(self):
+        # the schedule disappears between the lookup and the DELETE
+        responses.get(
+            "https://connect.example.com/__api__/variants/6627/schedules",
+            json=load_mock("variants/6627/schedules.json"),
+        )
+        mock_delete = responses.delete(
+            "https://connect.example.com/__api__/schedules/24",
+            json={"code": 24, "error": "not found"},
+            status=404,
+        )
+
+        c = Client("https://connect.example.com", "12345")
+        schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
+
+        with pytest.warns(FutureWarning):
+            schedules.delete()
+
+        assert mock_delete.call_count == 1
+
+    @responses.activate
+    def test_delete_raises_on_other_errors(self):
+        responses.get(
+            "https://connect.example.com/__api__/variants/6627/schedules",
+            json=load_mock("variants/6627/schedules.json"),
+        )
+        responses.delete(
+            "https://connect.example.com/__api__/schedules/24",
+            json={"code": 1, "error": "boom"},
+            status=500,
+        )
+
+        c = Client("https://connect.example.com", "12345")
+        schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
+
+        with pytest.warns(FutureWarning), pytest.raises(ClientError):
+            schedules.delete()
+
+
+class TestScheduleDestroy:
+    @responses.activate
+    def test(self):
+        mock_delete = responses.delete(
+            "https://connect.example.com/__api__/schedules/24",
+            body="",
+        )
+
+        c = Client("https://connect.example.com", "12345")
+        schedule = Schedule(c._ctx, id=24, app_id=50941, variant_id=6627)
+
+        with pytest.warns(FutureWarning, match="destroy.*experimental"):
+            schedule.destroy()
+
+        assert mock_delete.call_count == 1
+
+
+class TestVariantSchedules:
+    def test(self):
+        c = Client("https://connect.example.com", "12345")
+        variant = Variant(c._ctx, id=6627, app_id=50941, key="txvRW8SG", is_default=True)
+
+        schedules = variant.schedules
+        assert isinstance(schedules, Schedules)
+        assert schedules.app_id == 50941
+        assert schedules.variant_id == 6627
+
+
+class TestContentItemSchedule:
+    @responses.activate
+    def test_resolves_default_variant(self):
+        guid = "f2f37341-e21d-3d80-c698-a935ad614066"
+        responses.get(
+            f"https://connect.example.com/__api__/v1/content/{guid}",
+            json=load_mock(f"v1/content/{guid}.json"),
+        )
+        responses.get(
+            f"https://connect.example.com/__api__/applications/{guid}/variants",
+            json=load_mock(f"applications/{guid}/variants.json"),
+        )
+
+        c = Client("https://connect.example.com", "12345")
+        content = c.content.get(guid)
+
+        schedules = content.schedule
+        assert isinstance(schedules, Schedules)
+        assert schedules.app_id == 50941
+        assert schedules.variant_id == 6627
+
+    @responses.activate
+    def test_caches_default_variant(self):
+        guid = "f2f37341-e21d-3d80-c698-a935ad614066"
+        responses.get(
+            f"https://connect.example.com/__api__/v1/content/{guid}",
+            json=load_mock(f"v1/content/{guid}.json"),
+        )
+        get_variants = responses.get(
+            f"https://connect.example.com/__api__/applications/{guid}/variants",
+            json=load_mock(f"applications/{guid}/variants.json"),
+        )
+
+        c = Client("https://connect.example.com", "12345")
+        content = c.content.get(guid)
+
+        first = content.schedule
+        second = content.schedule
+        assert first is second
+        assert get_variants.call_count == 1
+
+    @responses.activate
+    def test_interactive_content_raises(self):
+        guid = "f2f37341-e21d-3d80-c698-a935ad614066"
+        content_json = load_mock(f"v1/content/{guid}.json")
+        content_json["app_mode"] = "shiny"
+        responses.get(
+            f"https://connect.example.com/__api__/v1/content/{guid}",
+            json=content_json,
+        )
+
+        c = Client("https://connect.example.com", "12345")
+        content = c.content.get(guid)
+
+        with pytest.raises(ValueError, match="Scheduling is not supported"):
+            content.schedule  # noqa: B018
+
+    @responses.activate
+    def test_no_default_variant_raises(self):
+        guid = "f2f37341-e21d-3d80-c698-a935ad614066"
+        responses.get(
+            f"https://connect.example.com/__api__/v1/content/{guid}",
+            json=load_mock(f"v1/content/{guid}.json"),
+        )
+        responses.get(
+            f"https://connect.example.com/__api__/applications/{guid}/variants",
+            json=[],
+        )
+
+        c = Client("https://connect.example.com", "12345")
+        content = c.content.get(guid)
+
+        with pytest.raises(RuntimeError, match="Found 0 default variants"):
+            content.schedule  # noqa: B018
+
+    @responses.activate
+    def test_multiple_default_variants_raise(self):
+        guid = "f2f37341-e21d-3d80-c698-a935ad614066"
+        responses.get(
+            f"https://connect.example.com/__api__/v1/content/{guid}",
+            json=load_mock(f"v1/content/{guid}.json"),
+        )
+        responses.get(
+            f"https://connect.example.com/__api__/applications/{guid}/variants",
+            json=[
+                {"id": 6627, "app_id": 50941, "is_default": True},
+                {"id": 6628, "app_id": 50941, "is_default": True},
+            ],
+        )
+
+        c = Client("https://connect.example.com", "12345")
+        content = c.content.get(guid)
+
+        with pytest.raises(RuntimeError, match="Found 2 default variants"):
+            content.schedule  # noqa: B018

--- a/tests/posit/connect/test_schedules.py
+++ b/tests/posit/connect/test_schedules.py
@@ -101,9 +101,11 @@ class TestBuildScheduleJson:
             ("hour", {"n": 2.5}, "Invalid n"),
             ("dayofmonth", {"day": True}, "Invalid day"),
             ("dayweekofmonth", {"day": 1, "week": "1"}, "Invalid week"),
+            ("semimonth", {"first": 1}, "Invalid first"),
+            ("semimonth", {"first": "true"}, "Invalid first"),
         ],
     )
-    def test_non_int_params_rejected(self, schedule_type, kwargs, match):
+    def test_invalid_param_types_rejected(self, schedule_type, kwargs, match):
         with pytest.raises(TypeError, match=match):
             _build_schedule_json(schedule_type, **kwargs)
 
@@ -182,13 +184,12 @@ class TestSchedulesSet:
         c = Client("https://connect.example.com", "12345")
         schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
 
-        with pytest.warns(FutureWarning, match="set.*experimental"):
-            schedule = schedules.set(
-                type="dayofweek",
-                days=["monday", "wednesday"],
-                start_time="2026-01-01T12:00:00Z",
-                timezone="America/New_York",
-            )
+        schedule = schedules.set(
+            type="dayofweek",
+            days=["monday", "wednesday"],
+            start_time="2026-01-01T12:00:00Z",
+            timezone="America/New_York",
+        )
 
         assert schedule["id"] == 24
         assert mock_post.call_count == 1
@@ -207,8 +208,7 @@ class TestSchedulesSet:
         c = Client("https://connect.example.com", "12345")
         schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
 
-        with pytest.warns(FutureWarning, match="set.*experimental"):
-            schedules.set(type="day", n=1)
+        schedules.set(type="day", n=1)
 
         body = json.loads(mock_post.calls[0].request.body)  # pyright: ignore[reportArgumentType]
         assert body["start_time"].endswith("Z")
@@ -250,8 +250,7 @@ class TestSchedulesSet:
         c = Client("https://connect.example.com", "12345")
         schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
 
-        with pytest.warns(FutureWarning, match="set.*experimental"):
-            schedule = schedules.set(type="hour", n=2, email=True)
+        schedule = schedules.set(type="hour", n=2, email=True)
 
         assert schedule["type"] == "hour"
         assert mock_post.call_count == 1
@@ -261,7 +260,7 @@ class TestSchedulesSet:
         c = Client("https://connect.example.com", "12345")
         schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
 
-        with pytest.warns(FutureWarning), pytest.raises(ValueError, match="Invalid parameters"):
+        with pytest.raises(ValueError, match="Invalid parameters"):
             schedules.set(type="hour", n=1, days=[1])  # pyright: ignore[reportCallIssue]
 
 
@@ -280,8 +279,7 @@ class TestSchedulesDelete:
         c = Client("https://connect.example.com", "12345")
         schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
 
-        with pytest.warns(FutureWarning, match="delete.*experimental"):
-            schedules.delete()
+        schedules.delete()
 
         assert mock_delete.call_count == 1
 
@@ -296,8 +294,7 @@ class TestSchedulesDelete:
         c = Client("https://connect.example.com", "12345")
         schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
 
-        with pytest.warns(FutureWarning):
-            schedules.delete()
+        schedules.delete()
 
     @responses.activate
     def test_delete_tolerates_races(self):
@@ -315,8 +312,7 @@ class TestSchedulesDelete:
         c = Client("https://connect.example.com", "12345")
         schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
 
-        with pytest.warns(FutureWarning):
-            schedules.delete()
+        schedules.delete()
 
         assert mock_delete.call_count == 1
 
@@ -335,7 +331,7 @@ class TestSchedulesDelete:
         c = Client("https://connect.example.com", "12345")
         schedules = Schedules(c._ctx, app_id=50941, variant_id=6627)
 
-        with pytest.warns(FutureWarning), pytest.raises(ClientError):
+        with pytest.raises(ClientError):
             schedules.delete()
 
 
@@ -350,8 +346,7 @@ class TestScheduleDestroy:
         c = Client("https://connect.example.com", "12345")
         schedule = Schedule(c._ctx, id=24, app_id=50941, variant_id=6627)
 
-        with pytest.warns(FutureWarning, match="destroy.*experimental"):
-            schedule.destroy()
+        schedule.destroy()
 
         assert mock_delete.call_count == 1
 
@@ -361,7 +356,8 @@ class TestVariantSchedules:
         c = Client("https://connect.example.com", "12345")
         variant = Variant(c._ctx, id=6627, app_id=50941, key="txvRW8SG", is_default=True)
 
-        schedules = variant.schedules
+        with pytest.warns(FutureWarning, match="experimental"):
+            schedules = variant.schedules
         assert isinstance(schedules, Schedules)
         assert schedules.app_id == 50941
         assert schedules.variant_id == 6627
@@ -383,7 +379,8 @@ class TestContentItemSchedule:
         c = Client("https://connect.example.com", "12345")
         content = c.content.get(guid)
 
-        schedules = content.schedule
+        with pytest.warns(FutureWarning, match="experimental"):
+            schedules = content.schedule
         assert isinstance(schedules, Schedules)
         assert schedules.app_id == 50941
         assert schedules.variant_id == 6627
@@ -403,10 +400,59 @@ class TestContentItemSchedule:
         c = Client("https://connect.example.com", "12345")
         content = c.content.get(guid)
 
-        first = content.schedule
+        with pytest.warns(FutureWarning):
+            first = content.schedule
         second = content.schedule
         assert first is second
         assert get_variants.call_count == 1
+
+    @responses.activate
+    def test_refreshes_unknown_app_mode(self):
+        # the record predates the deploy: the first GET reports app_mode
+        # "unknown", and the refresh triggered by `content.schedule` reports the
+        # deployed app_mode
+        guid = "f2f37341-e21d-3d80-c698-a935ad614066"
+        stale_json = load_mock(f"v1/content/{guid}.json")
+        stale_json["app_mode"] = "unknown"
+        responses.get(
+            f"https://connect.example.com/__api__/v1/content/{guid}",
+            json=stale_json,
+        )
+        get_refresh = responses.get(
+            f"https://connect.example.com/__api__/v1/content/{guid}",
+            json=load_mock(f"v1/content/{guid}.json"),
+        )
+        responses.get(
+            f"https://connect.example.com/__api__/applications/{guid}/variants",
+            json=load_mock(f"applications/{guid}/variants.json"),
+        )
+
+        c = Client("https://connect.example.com", "12345")
+        content = c.content.get(guid)
+
+        with pytest.warns(FutureWarning):
+            schedules = content.schedule
+        assert isinstance(schedules, Schedules)
+        assert content["app_mode"] == "quarto-static"
+        assert get_refresh.call_count == 1
+
+    @responses.activate
+    def test_undeployed_content_raises(self):
+        # app_mode is still "unknown" after the refresh (nothing is deployed)
+        guid = "f2f37341-e21d-3d80-c698-a935ad614066"
+        content_json = load_mock(f"v1/content/{guid}.json")
+        content_json["app_mode"] = "unknown"
+        get_content = responses.get(
+            f"https://connect.example.com/__api__/v1/content/{guid}",
+            json=content_json,
+        )
+
+        c = Client("https://connect.example.com", "12345")
+        content = c.content.get(guid)
+
+        with pytest.raises(ValueError, match="Scheduling is not supported"):
+            content.schedule  # noqa: B018
+        assert get_content.call_count == 2
 
     @responses.activate
     def test_interactive_content_raises(self):


### PR DESCRIPTION
This adds a way to manage schedules for content on Connect. Closes #484.

The default variant's schedule can be managed with `content.schedule`, which supports looking up the schedule (`find_one()`), creating/updating a schedule (`set()`), and removing a schedule (`delete()`). `variant.schedules` does the same for a specific variant. `set()` creates or updates as needed and has per-type overloads, so pyright catches invalid parameter combinations.

Because this is backed by unversioned endpoints, `set()` and `delete()` emit `FutureWarning` similar to how we do for `send_mail`: https://github.com/posit-dev/posit-sdk-py/blob/286d6041a92233ec338bad1f16be38f55a1ee093/src/posit/connect/variants.py#L34-L38

I'm a little on the fence about these warnings and am open to removing them. I do think it's good to convey that this functionality relies on unversioned endpoints that Connect may change or remove.
