### PR TITLE
test: run each integration test class against a fresh Connect container

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,13 +61,14 @@ jobs:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v7
       - run: uv python install
+      - name: Write Connect license file
+        env:
+          CONNECT_LICENSE: ${{ secrets.CONNECT_LICENSE }}
+        run: |
+          umask 077
+          printf '%s' "$CONNECT_LICENSE" > integration/license.lic
       - name: Run integration tests
-        uses: posit-dev/with-connect@main
-        with:
-          version: ${{ matrix.CONNECT_VERSION }}
-          license: ${{ secrets.CONNECT_LICENSE }}
-          command:
-            make -C ./integration test-${{ matrix.CONNECT_VERSION }}
+        run: make -C ./integration test-${{ matrix.CONNECT_VERSION }}
       - uses: actions/upload-artifact@v5
         if: always()
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ All development uses `uv` for package management and a `Makefile` for tasks. A `
 | `make lint` | Lint (`ruff check` + `pyright`) |
 | `make fmt` | Auto-format (`ruff check --fix` + `ruff format`) |
 | `make build` | Build wheel distribution |
-| `make it` | Run integration tests (requires Connect instance) |
+| `make it` | Run integration tests (requires Docker and a license at `integration/license.lic`; see `integration/README.md`) |
 | `make` | Run all: dev, test, lint, build |
 
 **Run a single test:**

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -2,20 +2,12 @@ include ../vars.mk
 
 # pytest settings
 PYTEST_ARGS ?= "-s"
+PYTEST_TARGET ?= tests
+
+# Posit Connect license file
+LICENSE ?= ./license.lic
 
 .DEFAULT_GOAL := latest
-
-define GET_PORT
-$(UV) run -- python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()'
-endef
-
-.PHONY: $(CONNECT_VERSIONS) \
-	all \
-	clean \
-	latest \
-	print-versions \
-	help \
-	test-%
 
 # Versions
 CONNECT_VERSIONS := \
@@ -54,25 +46,29 @@ CONNECT_VERSIONS := \
 	2022.12.0 \
 	2022.11.0
 
+.PHONY: $(CONNECT_VERSIONS) \
+	all \
+	clean \
+	latest \
+	print-versions \
+	help \
+	test-%
+
 clean:
 	rm -rf logs reports
 	find . -type d -empty -delete
 
-# Run pytest for a specific version (assumes Connect is already running).
+# Run the test suite against a specific Connect version.
 test-%:
 	@mkdir -p logs reports
-	$(UV) run pytest $(PYTEST_ARGS) \
-		--junitxml=reports/junit-$*.xml | tee logs/$*.log
+	CONNECT_VERSION=$* LICENSE=$(LICENSE) $(UV) run pytest $(PYTEST_TARGET) $(PYTEST_ARGS) \
+		--junitxml=reports/junit-$*.xml 2>&1 | tee logs/$*.log; \
+	exit $${PIPESTATUS[0]}
 
-# Spin up Connect for a specific version and run tests.
-$(CONNECT_VERSIONS): %:
-	PORT=$$($(GET_PORT)); \
-	uv run --with https://github.com/posit-dev/with-connect.git \
-		with-connect --version $* --port $$PORT \
-		-- $(MAKE) test-$*
+$(CONNECT_VERSIONS): %: test-%
 
 # Run test suite against all Connect versions.
-all: $(CONNECT_VERSIONS:%=%)
+all: $(CONNECT_VERSIONS)
 
 # Run test suite against latest Connect version.
 latest:
@@ -101,3 +97,5 @@ help:
 	@echo
 	@echo "Environment Variables:"
 	@echo "  PYTEST_ARGS      Arguments to pass to pytest. Default: \"-s\""
+	@echo "  PYTEST_TARGET    Test path/node-ID selection. Default: tests"
+	@echo "  LICENSE          Path to the Connect license file. Default: ./license.lic"

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,0 +1,32 @@
+# Integration Tests
+
+Runs the SDK test suite against real Posit Connect instances. Each test class runs
+against its own fresh Connect container, provisioned by the fixture in
+`tests/posit/connect/conftest.py`.
+
+## Prerequisites
+
+- Docker
+- uv
+- A Posit Connect license file at `integration/license.lic`, or set
+  `LICENSE=/path/to/file`. License files are gitignored; never commit one.
+
+## Running
+
+All commands below run from the repository root.
+
+Use `-C integration` to target this directory's `Makefile` (it defines its own
+`all` and per-version targets, distinct from the root `Makefile`):
+
+```bash
+make -C integration                  # latest Connect version
+make -C integration 2025.10.0        # a specific version
+make -C integration all              # every supported version
+make -C integration -j 4 all         # ... in parallel
+```
+
+Standard pytest selection also works; set `CONNECT_VERSION` and `LICENSE`:
+
+```bash
+CONNECT_VERSION=2026.01.0 LICENSE=integration/license.lic uv run pytest integration/tests/posit/connect/test_groups.py -v
+```

--- a/integration/tests/posit/connect/__init__.py
+++ b/integration/tests/posit/connect/__init__.py
@@ -1,8 +1,12 @@
-from packaging.version import parse
+import os
 
-from posit import connect
+from packaging.version import InvalidVersion, parse
 
-client = connect.Client()
-version = client.version
-assert version
-CONNECT_VERSION = parse(version)
+try:
+    CONNECT_VERSION = parse(os.environ["CONNECT_VERSION"])
+except (KeyError, InvalidVersion) as e:
+    raise RuntimeError(
+        "Set the CONNECT_VERSION environment variable to the Connect version "
+        "under test (e.g., `CONNECT_VERSION=2026.01.0 uv run pytest ...`), or "
+        "run the suite via the Makefile (e.g., `make -C integration 2026.01.0`)."
+    ) from e

--- a/integration/tests/posit/connect/conftest.py
+++ b/integration/tests/posit/connect/conftest.py
@@ -1,0 +1,101 @@
+"""Provision a fresh Posit Connect container for each test class.
+
+Prevents state from leaking between classes (posit-dev/posit-sdk-py#460).
+Standard pytest selection works: running a single test boots exactly the
+container(s) its class needs.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import warnings
+
+import pytest
+
+# with-connect requires Python >= 3.13; pin the source to avoid a stale
+# copy on PATH.
+_WITH_CONNECT = [
+    "uvx",
+    "--python",
+    "3.13",
+    "--from",
+    "git+https://github.com/posit-dev/with-connect.git",
+    "with-connect",
+]
+
+# Posit Connect license file to mount into each container (gitignored).
+_LICENSE = os.environ.get("LICENSE", "./license.lic")
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="class", autouse=True)
+def fresh_connect():
+    """Boot a fresh Connect container and expose it via the environment.
+
+    Setup runs before setup_class; the finalizer runs after teardown_class,
+    even if it raises.
+    """
+    version = os.environ["CONNECT_VERSION"]
+    port = _free_port()
+
+    result = subprocess.run(
+        [
+            *_WITH_CONNECT,
+            "--version",
+            version,
+            "--port",
+            str(port),
+            "--license",
+            _LICENSE,
+            "--quiet",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=900,  # the first invocation may pull the Connect image
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"with-connect failed to start Connect {version} on port {port}:\n{result.stderr}"
+        )
+
+    creds = dict(line.split("=", 1) for line in result.stdout.splitlines() if "=" in line)
+
+    # Fetch container_id before validating credentials, so a container is still
+    # cleaned up in `finally` even if with-connect's output is incomplete.
+    container_id = creds.get("CONTAINER_ID")
+    try:
+        missing = [
+            key
+            for key in ("CONNECT_SERVER", "CONNECT_API_KEY", "CONTAINER_ID")
+            if key not in creds
+        ]
+        if missing:
+            raise RuntimeError(
+                f"with-connect start-only output was missing expected credentials: {', '.join(missing)}"
+            )
+
+        os.environ["CONNECT_SERVER"] = creds["CONNECT_SERVER"]
+        os.environ["CONNECT_API_KEY"] = creds["CONNECT_API_KEY"]
+        yield
+    finally:
+        # `rm` (not `stop`) so per-class containers don't accumulate on disk.
+        if container_id is not None:
+            stop = subprocess.run(
+                ["docker", "rm", "--force", "--volumes", container_id],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            if stop.returncode != 0:
+                warnings.warn(
+                    f"failed to remove Connect container {container_id}: {stop.stderr}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )

--- a/integration/tests/posit/connect/oauth/conftest.py
+++ b/integration/tests/posit/connect/oauth/conftest.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+
+from posit import connect
+
+
+@pytest.fixture(scope="class", autouse=True)
+def clear_default_integration():
+    """Delete Connect's auto-created default integration before each class.
+
+    Automatic since Connect 2025.05.0:
+    https://docs.posit.co/connect/news/#posit-connect-2025.05.0
+    """
+    client = connect.Client()
+    for integration in client.oauth.integrations.find():
+        integration.delete()

--- a/integration/tests/posit/connect/oauth/test_associations.py
+++ b/integration/tests/posit/connect/oauth/test_associations.py
@@ -17,13 +17,6 @@ class TestAssociations:
     def setup_class(cls):
         cls.client = connect.Client()
 
-        # Destroy existing integrations.
-        #
-        # Starting with Connect 2025.05.0, a default integration is created automatically.
-        # https://github.com/posit-dev/connect/issues/31570
-        for integration in cls.client.oauth.integrations.find():
-            integration.delete()
-
         # Assert that no integrations exist
         assert len(cls.client.oauth.integrations.find()) == 0
 

--- a/integration/tests/posit/connect/oauth/test_integrations.py
+++ b/integration/tests/posit/connect/oauth/test_integrations.py
@@ -14,6 +14,7 @@ class TestIntegrations:
     @classmethod
     def setup_class(cls):
         cls.client = connect.Client()
+
         cls.integration = cls.client.oauth.integrations.create(
             name="example integration",
             description="integration description",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ build = ["build"]
 coverage = ["coverage"]
 external = ["databricks-sdk"]
 git = ["pre-commit"]
-lint = ["ruff", "pyright"]
+lint = ["ruff<0.16", "pyright"]
 test = ["rsconnect-python", "responses", "pytest", "pyjson5"]
 # Default install group by `uv`: `dev`
 dev = [


### PR DESCRIPTION
Fixes #460

- Provisions a fresh, disposable Connect container per test class via a class-scoped autouse fixture wrapping `with-connect` so state can never leak between test classes
- Cleans up the default Connect OAuth integration so related tests have a deterministic baseline and to prevent cross-test pollution. This is done via a scoped `conftest.py` fixture under `oauth/`
- Container lifecycle is now owned by pytest instead of the Makefile
- Updates CI to write the license file directly and drop the composite `with-connect` action
- Documents the new integration test workflow in `integration/README.md`