### PR TITLE
fix: make Ruff lint rules explicit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ extend-ignore = [
     "ISC001", # single-line-implicit-string-concatenation
     "ISC002", # multi-line-implicit-string-concatenation
 ]
-extend-select = [
+select = [
     # "C90", # Many false positives # C90; mccabe: https://docs.astral.sh/ruff/rules/complex-structure/
     # "DTZ", # Dates with timezones are different from dates without timezones # DTZ; flake8-datetimez: https://docs.astral.sh/ruff/rules/#flake8-datetimez-dtz
 


### PR DESCRIPTION
## Summary

- replace Ruff `extend-select` with `select` so the configured lint rules remain explicit
- prevent future Ruff default-rule changes from silently expanding the lint scope

Closes #488

## Verification

- `uv run ruff check`
- `uv run ruff format --check`
- `PYRIGHT_PYTHON_FORCE_VERSION=latest uv run pyright`
- `uv build`
- `uv run python -m pytest -q` (463 passed)